### PR TITLE
Ditch all internal JustEat framework references / nuget packeges

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -37,9 +37,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
-    <Reference Include="JustEat.Testing, Version=6.4.0.83, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.Testing.6.4.0.83\lib\net40\JustEat.Testing.dll</HintPath>
+    <Reference Include="JustBehave">
+      <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying.AwsTools.IntegrationTests/SqsQueueIntegrationTests.cs
+++ b/JustSaying.AwsTools.IntegrationTests/SqsQueueIntegrationTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Amazon;
 using JustSaying.AwsTools;
-using JustEat.Testing;
+using JustBehave;
 
 namespace JustSaying.AwsTools.IntegrationTests
 {

--- a/JustSaying.AwsTools.IntegrationTests/WhenIAccessAnExistingQueueWithoutAnErrorQueue.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenIAccessAnExistingQueueWithoutAnErrorQueue.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.TestingFramework;
 
 namespace JustSaying.AwsTools.IntegrationTests

--- a/JustSaying.AwsTools.IntegrationTests/WhenICreateAQueueByName.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenICreateAQueueByName.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using NUnit.Framework;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.IntegrationTests/packages.config
+++ b/JustSaying.AwsTools.IntegrationTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
   <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustEat.Testing" version="6.4.0.83" targetFramework="net40" />
   <package id="JustSaying.Models" version="1.2.0" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -36,9 +36,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
-    <Reference Include="JustEat.Testing, Version=6.4.0.83, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.Testing.6.4.0.83\lib\net40\JustEat.Testing.dll</HintPath>
+    <Reference Include="JustBehave">
+      <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying.AwsTools.UnitTests/QueueCreation/WhenSerializingRedrivePolicy.cs
+++ b/JustSaying.AwsTools.UnitTests/QueueCreation/WhenSerializingRedrivePolicy.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.AwsTools.QueueCreation;
 using NUnit.Framework;
 

--- a/JustSaying.AwsTools.UnitTests/Sns/TopicByArn/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sns/TopicByArn/WhenPublishing.cs
@@ -2,7 +2,7 @@
 using Amazon.SimpleNotificationService.Model;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.MessageSerialisation;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Models;
 using JustSaying.TestingFramework;
 using NSubstitute;

--- a/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenCheckingForTopicName.cs
+++ b/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenCheckingForTopicName.cs
@@ -1,5 +1,5 @@
 ﻿using Amazon.SimpleNotificationService;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using NSubstitute;
 using NUnit.Framework;

--- a/JustSaying.AwsTools.UnitTests/Sqs/WhenFetchingQueueByName.cs
+++ b/JustSaying.AwsTools.UnitTests/Sqs/WhenFetchingQueueByName.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Amazon.SQS;
 using Amazon.SQS.Model;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -4,7 +4,7 @@ using Amazon.SQS.Model;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.Monitoring;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.TestingFramework;
 using NSubstitute;
 using JustSaying.Messaging.MessageSerialisation;

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/HandlingExceptions/WhenErrorHandlingActionIsNotProvided.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/HandlingExceptions/WhenErrorHandlingActionIsNotProvided.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 
 namespace AwsTools.UnitTests.SqsNotificationListener.HandlingExceptions

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/HandlingExceptions/WhenErrorHandlingActionIsProvided.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/HandlingExceptions/WhenErrorHandlingActionIsProvided.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenListeningStartsAndStops.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenListeningStartsAndStops.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Amazon.SQS.Model;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenMessageHandlingFails.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenMessageHandlingFails.cs
@@ -1,5 +1,5 @@
 using Amazon.SQS.Model;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
@@ -1,5 +1,5 @@
 using Amazon.SQS.Model;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 using Amazon.SQS.Model;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -4,7 +4,7 @@ using Amazon.SQS.Model;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -4,7 +4,7 @@ using Amazon.SQS.Model;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
@@ -3,7 +3,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.Monitoring;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 using JustSaying.TestingFramework;
 

--- a/JustSaying.AwsTools.UnitTests/SqsQueueConfiguration/Validation/WhenPublishEndpointIsNotProvided.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsQueueConfiguration/Validation/WhenPublishEndpointIsNotProvided.cs
@@ -1,6 +1,6 @@
 ﻿using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 
 namespace AwsTools.UnitTests.SqsQueueConfiguration.Validation

--- a/JustSaying.AwsTools.UnitTests/packages.config
+++ b/JustSaying.AwsTools.UnitTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
   <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustEat.Testing" version="6.4.0.83" targetFramework="net40" />
   <package id="JustSaying.Models" version="1.2.0" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
+++ b/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using Amazon;
 using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS.Model;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 
 namespace JustSaying.IntegrationTests

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -36,13 +36,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
-    <Reference Include="JustEat.StatsD, Version=1.0.0.96, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.StatsD.1.0.0.96\lib\JustEat.StatsD.dll</HintPath>
-    </Reference>
-    <Reference Include="JustEat.Testing, Version=6.4.0.83, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.Testing.6.4.0.83\lib\net40\JustEat.Testing.dll</HintPath>
+    <Reference Include="JustBehave">
+      <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 using Amazon;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.Monitoring;

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Amazon;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.Monitoring;
 using JustSaying.TestingFramework;

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
@@ -1,5 +1,5 @@
 using System;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.TestingFramework;
 using NSubstitute;
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
@@ -1,5 +1,5 @@
 ﻿using Amazon;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
 using NSubstitute;

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenPublishingAndNotInstantiated.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenPublishingAndNotInstantiated.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.TestingFramework;
 using NUnit.Framework;
 

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherAPublisherIsAddedToTheNotificationStack.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherAPublisherIsAddedToTheNotificationStack.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherInANonDefaultRegion.cs
@@ -1,5 +1,5 @@
 using Amazon.SimpleNotificationService.Model;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Models;
 using NUnit.Framework;
 

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Amazon;
 using Amazon.SQS;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Amazon;
 using Amazon.SimpleNotificationService.Model;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 using NSubstitute;

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
   <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustEat.StatsD" version="1.0.0.96" targetFramework="net40" />
   <package id="JustEat.Testing" version="6.4.0.83" targetFramework="net40" />
   <package id="JustSaying.Models" version="1.2.0" targetFramework="net40" />

--- a/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
+++ b/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JustEat.Testing, Version=6.4.0.83, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.Testing.6.4.0.83\lib\net40\JustEat.Testing.dll</HintPath>
+    <Reference Include="JustBehave">
+      <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying.Messaging.UnitTests/MessageHandling/DelegateAdjusters/WhenSerialisingAndDeserialising.cs
+++ b/JustSaying.Messaging.UnitTests/MessageHandling/DelegateAdjusters/WhenSerialisingAndDeserialising.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 using JustSaying.TestingFramework;

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.TestingFramework;
 using NUnit.Framework;

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenSerialisingAndDeserialising.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenSerialisingAndDeserialising.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.TestingFramework;
 using NUnit.Framework;

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingAGenericSerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingAGenericSerialiser.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 using NUnit.Framework;

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiser.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 using NSubstitute;

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 using NSubstitute;

--- a/JustSaying.Messaging.UnitTests/Serialisation/ServiceStack/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/ServiceStack/DealingWithPotentiallyMissingConversation.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.TestingFramework;
 using NUnit.Framework;

--- a/JustSaying.Messaging.UnitTests/Serialisation/ServiceStack/WhenSerialisingAndDeserialising.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/ServiceStack/WhenSerialisingAndDeserialising.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.TestingFramework;
 using NUnit.Framework;

--- a/JustSaying.Messaging.UnitTests/packages.config
+++ b/JustSaying.Messaging.UnitTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
+  <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustEat.Testing" version="6.4.0.83" targetFramework="net40" />
   <package id="JustSaying.Models" version="1.2.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -32,13 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JustEat.StatsD, Version=1.0.0.96, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.StatsD.1.0.0.96\lib\JustEat.StatsD.dll</HintPath>
-    </Reference>
-    <Reference Include="JustEat.Testing, Version=6.4.0.83, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JustEat.Testing.6.4.0.83\lib\net40\JustEat.Testing.dll</HintPath>
+    <Reference Include="JustBehave">
+      <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.Monitoring;
 using NSubstitute;
 

--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBusWithoutMonitoring.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBusWithoutMonitoring.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.Monitoring;
 using NSubstitute;
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenAddingAPublisherWithNoTopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenAddingAPublisherWithNoTopic.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
 using NSubstitute;

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
@@ -1,5 +1,5 @@
 using System;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
 using JustSaying.Models;

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessageWithoutMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessageWithoutMonitor.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Messaging.Monitoring;
 using JustSaying.TestingFramework;

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
 using NSubstitute;

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingWithoutRegistering.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingWithoutRegistering.cs
@@ -1,5 +1,5 @@
 using System;
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Models;
 using NSubstitute;
 using NUnit.Framework;

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
 using NSubstitute;

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging;
 using NSubstitute;
 using NUnit.Framework;

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Models;
 using NUnit.Framework;
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using NSubstitute;
 using NUnit.Framework;

--- a/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging;
 using NSubstitute;
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
@@ -1,5 +1,5 @@
 using System;
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 
 namespace JustSaying.UnitTests.JustSayingBus

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 using NSubstitute;

--- a/JustSaying.UnitTests/JustSayingFluently/AddingMonitoring/WhenAddingACustomMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingMonitoring/WhenAddingACustomMonitor.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Messaging.Monitoring;
 using NSubstitute;
 using NUnit.Framework;

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
@@ -1,5 +1,5 @@
 using System;
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 
 namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation

--- a/JustSaying.UnitTests/JustSayingFluently/Publishing/WhenPublishing.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/Publishing/WhenPublishing.cs
@@ -1,4 +1,4 @@
-using JustEat.Testing;
+using JustBehave;
 using JustSaying.Models;
 using JustSaying.TestingFramework;
 using NSubstitute;

--- a/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingASubscriptionHandler.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.TestingFramework;

--- a/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
+++ b/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using JustSaying.AwsTools.QueueCreation;
-using JustEat.Testing;
+using JustBehave;
 using NSubstitute;
 
 namespace JustSaying.UnitTests

--- a/JustSaying.UnitTests/Lookups/SnsEndpointNames/WhenRequestingAnEndpointName.cs
+++ b/JustSaying.UnitTests/Lookups/SnsEndpointNames/WhenRequestingAnEndpointName.cs
@@ -1,4 +1,4 @@
-﻿using JustEat.Testing;
+﻿using JustBehave;
 using NUnit.Framework;
 using JustSaying.Lookups;
 

--- a/JustSaying.UnitTests/Lookups/SqsEndpointNames/WhenRequestingAnEndpointName.cs
+++ b/JustSaying.UnitTests/Lookups/SqsEndpointNames/WhenRequestingAnEndpointName.cs
@@ -1,5 +1,5 @@
 ﻿using JustSaying.AwsTools.QueueCreation;
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 using JustSaying.Lookups;
 

--- a/JustSaying.UnitTests/WhenPublishEndpointIsNotProvided.cs
+++ b/JustSaying.UnitTests/WhenPublishEndpointIsNotProvided.cs
@@ -1,6 +1,6 @@
 ﻿using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
-using JustEat.Testing;
+using JustBehave;
 using NUnit.Framework;
 
 namespace JustSaying.UnitTests

--- a/JustSaying.UnitTests/packages.config
+++ b/JustSaying.UnitTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
+  <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustEat.StatsD" version="1.0.0.96" targetFramework="net40" />
   <package id="JustEat.Testing" version="6.4.0.83" targetFramework="net40" />
   <package id="JustSaying.Models" version="1.2.0" targetFramework="net40" />


### PR DESCRIPTION
Remove internal reference to testing Framework. This is OpenSource now.
StatsD Library reference is irrelevant as used only internally by JustEat extension package.
