### PR TITLE
Update AWSSDK to tried & battle tested v2.3.5.0

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.0.3.1, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+    <Reference Include="AWSSDK, Version=2.3.5.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.2.3.5.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="JustBehave">
       <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>

--- a/JustSaying.AwsTools.IntegrationTests/packages.config
+++ b/JustSaying.AwsTools.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
-  <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="AWSSDK" version="2.3.5.0" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -32,9 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.0.3.1, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+    <Reference Include="AWSSDK, Version=2.3.5.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.2.3.5.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="JustBehave">
       <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>

--- a/JustSaying.AwsTools.UnitTests/app.config
+++ b/JustSaying.AwsTools.UnitTests/app.config
@@ -8,4 +8,18 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <appSettings>
+    <!--AWSProfileName is used to reference an account that has been registered with the SDK.
+If using AWS Toolkit for Visual Studio then this value is the same value shown in the AWS Explorer.
+It is also possible to register an account using the <solution-dir>/packages/AWSSDK-X.X.X.X/tools/account-management.ps1 PowerShell script
+that is bundled with the nuget package under the tools folder.
+
+		<add key="AWSProfileName" value="" />
+-->
+    <!--AWSProfileName is used to reference an account that has been registered with the SDK.
+If using AWS Toolkit for Visual Studio then this value is the same value shown in the AWS Explorer.
+It is also possible to registered an accounts using the <solution-dir>/packages/AWSSDK-X.X.X.X/tools/account-management.ps1 PowerShell script
+that is bundled with the nuget package under the tools folder.-->
+    <add key="AWSProfileName" value="" />
+  </appSettings>
 </configuration>

--- a/JustSaying.AwsTools.UnitTests/packages.config
+++ b/JustSaying.AwsTools.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
-  <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="AWSSDK" version="2.3.5.0" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.0.3.1, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.5.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AWSSDK.2.3.5.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying.AwsTools/packages.config
+++ b/JustSaying.AwsTools/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="AWSSDK" version="2.3.5.0" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -32,9 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.0.3.1, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+    <Reference Include="AWSSDK, Version=2.3.5.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.2.3.5.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="JustBehave">
       <HintPath>..\packages\JustBehave.0.57\lib\net40\JustBehave.dll</HintPath>

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
-  <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="AWSSDK" version="2.3.5.0" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/JustSaying.Tools/JustSaying.Tools.csproj
@@ -34,8 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK">
-      <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.5.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AWSSDK.2.3.5.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="Magnum">
       <HintPath>..\packages\Magnum.2.1.2\lib\NET40\Magnum.dll</HintPath>

--- a/JustSaying.Tools/packages.config
+++ b/JustSaying.Tools/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="AWSSDK" version="2.3.5.0" targetFramework="net40" />
   <package id="Magnum" version="2.1.2" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
 </packages>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK">
-      <HintPath>..\packages\AWSSDK.2.0.3.1\lib\net35\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.5.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AWSSDK.2.3.5.0\lib\net35\AWSSDK.dll</HintPath>
     </Reference>
     <Reference Include="JustSaying.Models, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JustSaying/packages.config
+++ b/JustSaying/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.0.3.1" targetFramework="net40" />
+  <package id="AWSSDK" version="2.3.5.0" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />


### PR DESCRIPTION
I've updated the package to the last version which we battle tested last week.
We needed to break-free of the version fixed at 2.0.3.1 in order to update Dynamo calls in a shared project.
Please shout if any issues.
