### PR TITLE
Removed redundant constructor and field member from CreateMeABus

### DIFF
--- a/JustSaying/CreateMeABus.cs
+++ b/JustSaying/CreateMeABus.cs
@@ -1,19 +1,11 @@
-using System;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
 
 namespace JustSaying
 {
-    public class CreateMeABus
+    public static class CreateMeABus
     {
-        private readonly MessagingConfig _config;
-
-        public CreateMeABus(MessagingConfig config)
-        {
-            _config = config;
-        }
-
         public static IMayWantOptionalSettings InRegion(string region)
         {
             var config = new MessagingConfig {Region = region};

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CreateMe.cs" />
+    <Compile Include="CreateMeABus.cs" />
     <Compile Include="JustSayingFluently.cs" />
     <Compile Include="IPublishConfiguration.cs" />
     <Compile Include="JustSayingBus.cs" />


### PR DESCRIPTION
CreateMeABus has a redundant constructor and field member; the class only contains one static method and there are no constructor references.

I've also renamed the file to match the class name.
