### PR TITLE
Get rid of the generic serialiser 

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/BasicHandlingThrottlingTest.cs
+++ b/JustSaying.AwsTools.IntegrationTests/BasicHandlingThrottlingTest.cs
@@ -63,9 +63,9 @@ namespace JustSaying.AwsTools.IntegrationTests
             var handler = Substitute.For<IHandler<GenericMessage>>();
             handler.Handle(null).ReturnsForAnyArgs(true).AndDoes(x => {lock (locker) { Thread.Sleep(10);handleCount++; } });
             
-            var serialiser = Substitute.For<IMessageSerialiser<GenericMessage>>();
-            serialiser.Deserialise(string.Empty).ReturnsForAnyArgs(new GenericMessage());
-            serialisations.GetSerialiser(string.Empty).ReturnsForAnyArgs(serialiser);
+            var serialiser = Substitute.For<IMessageSerialiser>();
+            serialiser.Deserialise(string.Empty, typeof(GenericMessage)).ReturnsForAnyArgs(new GenericMessage());
+            serialisations.GeTypeSerialiser(string.Empty).ReturnsForAnyArgs(new TypeSerialiser(typeof(GenericMessage), serialiser));
             var listener = new SqsNotificationListener(q, serialisations, monitor);
 
             listener.AddMessageHandler(handler);

--- a/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenPublishing.cs
@@ -24,9 +24,9 @@ namespace AwsTools.UnitTests.Sns.TopicByName
 
         protected override void Given()
         {
-            var serialiser = Substitute.For<IMessageSerialiser<GenericMessage>>();
+            var serialiser = Substitute.For<IMessageSerialiser>();
             serialiser.Serialise(Arg.Any<Message>()).Returns(Message);
-            _serialisationRegister.GetSerialiser(typeof(GenericMessage)).Returns(serialiser);
+            _serialisationRegister.GeTypeSerialiser(typeof(GenericMessage)).Returns(new TypeSerialiser(typeof(GenericMessage), serialiser));
             _sns.FindTopic(TopicName).Returns(new Topic { TopicArn = TopicArn });
         }
 

--- a/JustSaying.AwsTools.UnitTests/Sqs/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sqs/WhenPublishing.cs
@@ -25,7 +25,7 @@ namespace JustSaying.AwsTools.UnitTests.Sqs
         {
             // ToDo: We need to clean up serialisation (away from Json.Net)
             //var serialiser = Substitute.For<IMessageSerialiser<GenericMessage>>();
-            //_serialisationRegister.GetSerialiser(typeof(GenericMessage)).Returns(serialiser);
+            //_serialisationRegister.GeTypeSerialiser(typeof(GenericMessage)).Returns(serialiser);
             _sqs.ListQueues(Arg.Any<ListQueuesRequest>()).Returns(new ListQueuesResponse{QueueUrls = new List<string>{Url}});
             _sqs.GetQueueAttributes(Arg.Any<GetQueueAttributesRequest>()).Returns(new GetQueueAttributesResponse());
         }

--- a/JustSaying.AwsTools.UnitTests/Sqs/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sqs/WhenPublishing.cs
@@ -23,9 +23,6 @@ namespace JustSaying.AwsTools.UnitTests.Sqs
 
         protected override void Given()
         {
-            // ToDo: We need to clean up serialisation (away from Json.Net)
-            //var serialiser = Substitute.For<IMessageSerialiser<GenericMessage>>();
-            //_serialisationRegister.GeTypeSerialiser(typeof(GenericMessage)).Returns(serialiser);
             _sqs.ListQueues(Arg.Any<ListQueuesRequest>()).Returns(new ListQueuesResponse{QueueUrls = new List<string>{Url}});
             _sqs.GetQueueAttributes(Arg.Any<GetQueueAttributesRequest>()).Returns(new GetQueueAttributesResponse());
         }

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -16,7 +16,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
     {
         protected const string QueueUrl = "url";
         protected IAmazonSQS Sqs;
-        protected IMessageSerialiser<GenericMessage> Serialiser;
+        protected IMessageSerialiser Serialiser;
         protected GenericMessage DeserialisedMessage;
         protected const string MessageBody = "object";
         protected IHandler<GenericMessage> Handler;
@@ -34,16 +34,16 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         protected override void Given()
         {
             Sqs = Substitute.For<IAmazonSQS>();
-            Serialiser = Substitute.For<IMessageSerialiser<GenericMessage>>();
+            Serialiser = Substitute.For<IMessageSerialiser>();
             SerialisationRegister = Substitute.For<IMessageSerialisationRegister>();
             Monitor = Substitute.For<IMessageMonitor>();
             Handler = Substitute.For<IHandler<GenericMessage>>();
             var response = GenerateResponseMessage(_messageTypeString, Guid.NewGuid());
             Sqs.ReceiveMessage(Arg.Any<ReceiveMessageRequest>()).Returns(x => response, x => new ReceiveMessageResponse());
 
-            SerialisationRegister.GetSerialiser(_messageTypeString).Returns(Serialiser);
+            SerialisationRegister.GeTypeSerialiser(_messageTypeString).Returns(new TypeSerialiser(typeof(GenericMessage), Serialiser));
             DeserialisedMessage = new GenericMessage {RaisingComponent = "Component"};
-            Serialiser.Deserialise(Arg.Any<string>()).Returns(x => DeserialisedMessage);
+            Serialiser.Deserialise(Arg.Any<string>(), typeof(GenericMessage)).Returns(x => DeserialisedMessage);
         }
 
         protected override void When()

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenListeningStartsAndStops.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenListeningStartsAndStops.cs
@@ -41,7 +41,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         [Then]
         public void MessageIsProcessed()
         {
-            Patiently.VerifyExpectation(() => SerialisationRegister.Received().GetSerialiser(SubjectOfMessageAfterStop));
+            Patiently.VerifyExpectation(() => SerialisationRegister.Received().GeTypeSerialiser(SubjectOfMessageAfterStop));
         }
 
         public override void PostAssertTeardown()

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
@@ -16,7 +16,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         [Then]
         public void MessagesGetDeserialisedByCorrectHandler()
         {
-            Patiently.VerifyExpectation(() => Serialiser.Received().Deserialise(MessageBody));
+            Patiently.VerifyExpectation(() => Serialiser.Received().Deserialise(MessageBody, typeof(GenericMessage)));
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
@@ -17,7 +17,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         [Then]
         public void MessagesGetDeserialisedByCorrectHandler()
         {
-            Patiently.VerifyExpectation(() =>Serialiser.Received().Deserialise(MessageBody));
+            Patiently.VerifyExpectation(() =>Serialiser.Received().Deserialise(MessageBody, typeof(GenericMessage)));
         }
 
         [Then]
@@ -35,7 +35,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         [Then]
         public void AllMessagesAreClearedFromQueue()
         {
-            Patiently.VerifyExpectation(() =>Serialiser.Received(1).Deserialise(Arg.Any<string>()));
+            Patiently.VerifyExpectation(() => Serialiser.Received(1).Deserialise(Arg.Any<string>(), typeof(GenericMessage)));
             Patiently.VerifyExpectation(() =>Sqs.Received(2).DeleteMessage(Arg.Any<DeleteMessageRequest>()));
         }
     }

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -24,7 +24,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
 
         protected override void Given()
         {
-            _serialisationRegister.GetSerialiser(Arg.Any<string>()).Returns(x => { throw new Exception(); });
+            _serialisationRegister.GeTypeSerialiser(Arg.Any<string>()).Returns(x => { throw new Exception(); });
             _sqs.ReceiveMessage(Arg.Any<ReceiveMessageRequest>()).Returns(x => GenerateEmptyMessage());
             _sqs.When(x => x.ReceiveMessage(Arg.Any<ReceiveMessageRequest>())).Do(x => _callCount++);
         }

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -17,15 +17,15 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         protected override void Given()
         {
             Sqs = Substitute.For<IAmazonSQS>();
-            Serialiser = Substitute.For<IMessageSerialiser<GenericMessage>>();
+            Serialiser = Substitute.For<IMessageSerialiser>();
             SerialisationRegister = Substitute.For<IMessageSerialisationRegister>();
             Monitor = Substitute.For<IMessageMonitor>();
             Handler = Substitute.For<IHandler<GenericMessage>>();
             GenerateResponseMessage(_messageTypeString, Guid.NewGuid());
 
-            SerialisationRegister.GetSerialiser(_messageTypeString).Returns(Serialiser);
+            SerialisationRegister.GeTypeSerialiser(_messageTypeString).Returns(new TypeSerialiser(typeof(GenericMessage), Serialiser));
             DeserialisedMessage = new GenericMessage { RaisingComponent = "Component" };
-            Serialiser.Deserialise(Arg.Any<string>()).Returns(x => DeserialisedMessage);
+            Serialiser.Deserialise(Arg.Any<string>(), typeof(GenericMessage)).Returns(x => DeserialisedMessage);
             Sqs.When(x => x.ReceiveMessage(Arg.Any<ReceiveMessageRequest>()))
                 .Do(_ =>
                 {

--- a/JustSaying.AwsTools/SnsTopicBase.cs
+++ b/JustSaying.AwsTools/SnsTopicBase.cs
@@ -45,7 +45,7 @@ namespace JustSaying.AwsTools
 
         public void Publish(Message message)
         {
-            var messageToSend = _serialisationRegister.GetSerialiser(message.GetType()).Serialise(message);
+            var messageToSend = _serialisationRegister.GeTypeSerialiser(message.GetType()).Serialiser.Serialise(message);
             var messageType = message.GetType().Name;
 
             Client.Publish(new PublishRequest

--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -147,9 +147,8 @@ namespace JustSaying.AwsTools
                 string messageType = body["Subject"].ToString();
 
                 rawMessage = body["Message"].ToString();
-                typedMessage = _serialisationRegister
-                    .GetSerialiser(messageType)
-                    .Deserialise(rawMessage);
+                var typeSerialiser = _serialisationRegister.GeTypeSerialiser(messageType);
+                typedMessage = typeSerialiser.Serialiser.Deserialise(rawMessage, typeSerialiser.Type);
 
                 var handlingSucceeded = true;
 

--- a/JustSaying.AwsTools/SqsPublisher.cs
+++ b/JustSaying.AwsTools/SqsPublisher.cs
@@ -24,7 +24,6 @@ namespace JustSaying.AwsTools
             _client.SendMessage(new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                //MessageBody = _serialisationRegister.GeTypeSerialiser(message.GetType()).Serialise(message),
                 QueueUrl = Url
             });
         }

--- a/JustSaying.AwsTools/SqsPublisher.cs
+++ b/JustSaying.AwsTools/SqsPublisher.cs
@@ -24,7 +24,7 @@ namespace JustSaying.AwsTools
             _client.SendMessage(new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                //MessageBody = _serialisationRegister.GetSerialiser(message.GetType()).Serialise(message),
+                //MessageBody = _serialisationRegister.GeTypeSerialiser(message.GetType()).Serialise(message),
                 QueueUrl = Url
             });
         }

--- a/JustSaying.AwsTools/SqsQueueBase.cs
+++ b/JustSaying.AwsTools/SqsQueueBase.cs
@@ -35,8 +35,8 @@ namespace JustSaying.AwsTools
             if (!Exists())
                 return;
 
-            var result = Client.DeleteQueue(new DeleteQueueRequest { QueueUrl = Url });
-            //return result.IsSetResponseMetadata();
+            Client.DeleteQueue(new DeleteQueueRequest { QueueUrl = Url });
+            
             Arn = null;
             Url = null;
         }

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherAPublisherIsAddedToTheNotificationStack.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherAPublisherIsAddedToTheNotificationStack.cs
@@ -37,7 +37,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringAPublisher
         public void SerialisationIsRegisteredForMessage()
         {
             NotificationStack.SerialisationRegister.Received()
-                .AddSerialiser<Message>(Arg.Any<IMessageSerialiser<Message>>());
+                .AddSerialiser<Message>(Arg.Any<IMessageSerialiser>());
         }
 
         [TearDown]

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
@@ -43,7 +43,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         [Then]
         public void SerialisationIsRegisteredForMessage()
         {
-            NotificationStack.SerialisationRegister.Received().AddSerialiser<Message>(Arg.Any<IMessageSerialiser<Message>>());
+            NotificationStack.SerialisationRegister.Received().AddSerialiser<Message>(Arg.Any<IMessageSerialiser>());
         }
 
         [Then, Timeout(70000)] // ToDo: Sorry about this, but SQS is a little slow to verify againse. Can be better I'm sure? ;)

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
 {
-    public class DealingWithPotentiallyMissingConversation : BehaviourTest<NewtonsoftSerialiser<MessageWithEnum>>
+    public class DealingWithPotentiallyMissingConversation : BehaviourTest<NewtonsoftSerialiser>
     {
         private MessageWithEnum _messageOut;
         private MessageWithEnum _messageIn;
@@ -21,7 +21,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
 
             //add extra property to see what happens:
             _jsonMessage = _jsonMessage.Replace("{__", "{\"New\":\"Property\",__");
-            _messageIn = SystemUnderTest.Deserialise(_jsonMessage) as MessageWithEnum;
+            _messageIn = SystemUnderTest.Deserialise(_jsonMessage, typeof(MessageWithEnum)) as MessageWithEnum;
         }
 
         [Then]

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenAskingForAnewSerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenAskingForAnewSerialiser.cs
@@ -8,7 +8,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
 {
     public class WhenAskingForANewSerialiser : BehaviourTest<NewtonsoftSerialisationFactory>
     {
-        private IMessageSerialiser<Message> _result;
+        private IMessageSerialiser _result;
 
         protected override void Given()
         {

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenSerialisingAndDeserialising.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenSerialisingAndDeserialising.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
 {
-    public class WhenSerialisingAndDeserialising : BehaviourTest<NewtonsoftSerialiser<MessageWithEnum>>
+    public class WhenSerialisingAndDeserialising : BehaviourTest<NewtonsoftSerialiser>
     {
         private MessageWithEnum _messageOut;
         private MessageWithEnum _messageIn;
@@ -18,7 +18,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
         protected override void When()
         {
             _jsonMessage = SystemUnderTest.Serialise(_messageOut);
-            _messageIn = SystemUnderTest.Deserialise(_jsonMessage) as MessageWithEnum;
+            _messageIn = SystemUnderTest.Deserialise(_jsonMessage, typeof(MessageWithEnum)) as MessageWithEnum;
         }
 
         [Then]

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingAGenericSerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingAGenericSerialiser.cs
@@ -7,7 +7,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
 {
     public class WhenAddingAGenericSerialiser : BehaviourTest<MessageSerialisationRegister>
     {
-        private readonly NewtonsoftSerialiser<Message> _serialiser = new NewtonsoftSerialiser<Message>();
+        private readonly NewtonsoftSerialiser _serialiser = new NewtonsoftSerialiser();
 
         protected override void Given() { }
 
@@ -19,13 +19,13 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
         [Then]
         public void MappingsCanBeRetreivedByStringType()
         {
-            Assert.NotNull(SystemUnderTest.GetSerialiser(typeof(Message).Name));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).Name));
         }
 
         [Test]
         public void MappingsCanBeRetreivedStronglyTyped()
         {
-            Assert.NotNull(SystemUnderTest.GetSerialiser(typeof(Message)));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message)));
         }
     }
 }

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiser.cs
@@ -12,19 +12,19 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
 
         protected override void When()
         {
-            SystemUnderTest.AddSerialiser<Message>(Substitute.For<IMessageSerialiser<Message>>());
+            SystemUnderTest.AddSerialiser<Message>(Substitute.For<IMessageSerialiser>());
         }
 
         [Then]
         public void MappingsCanBeRetreivedByStringType()
         {
-            Assert.NotNull(SystemUnderTest.GetSerialiser(typeof(Message).Name));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).Name));
         }
 
         [Test]
         public void MappingsCanBeRetreivedStronglyTyped()
         {
-            Assert.NotNull(SystemUnderTest.GetSerialiser(typeof(Message)));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message)));
         }
     }
 }

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
@@ -15,8 +15,8 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
 
         protected override void When()
         {
-            SystemUnderTest.AddSerialiser<Message>(Substitute.For<IMessageSerialiser<Message>>());
-            SystemUnderTest.AddSerialiser<Message>(Substitute.For<IMessageSerialiser<Message>>());
+            SystemUnderTest.AddSerialiser<Message>(Substitute.For<IMessageSerialiser>());
+            SystemUnderTest.AddSerialiser<Message>(Substitute.For<IMessageSerialiser>());
         }
 
         [Then]
@@ -28,7 +28,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
         [Then]
         public void TheMappingContainsTheSerialiser()
         {
-            Assert.NotNull(SystemUnderTest.GetSerialiser(typeof(Message).Name));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).Name));
         }
     }
 }

--- a/JustSaying.Messaging/JustSaying.Messaging.csproj
+++ b/JustSaying.Messaging/JustSaying.Messaging.csproj
@@ -56,6 +56,7 @@
     <Compile Include="MessageProcessingStrategies\Throttled.cs" />
     <Compile Include="MessageSerialisation\IMessageSerialisationFactory.cs" />
     <Compile Include="MessageSerialisation\NewtonsoftSerialisationFactory.cs" />
+    <Compile Include="MessageSerialisation\TypeSerialiser.cs" />
     <Compile Include="Monitoring\IMeasureHandlerExecutionTime.cs" />
     <Compile Include="Monitoring\IMessageMonitor.cs" />
     <Compile Include="IMessagePublisher.cs" />

--- a/JustSaying.Messaging/MessageSerialisation/IMessageSerialisationFactory.cs
+++ b/JustSaying.Messaging/MessageSerialisation/IMessageSerialisationFactory.cs
@@ -4,6 +4,6 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public interface IMessageSerialisationFactory
     {
-        IMessageSerialiser<Message> GetSerialiser<T>() where T : Message;
+        IMessageSerialiser GetSerialiser<T>() where T : Message;
     }
 }

--- a/JustSaying.Messaging/MessageSerialisation/IMessageSerialisationRegister.cs
+++ b/JustSaying.Messaging/MessageSerialisation/IMessageSerialisationRegister.cs
@@ -5,8 +5,8 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public interface IMessageSerialisationRegister
     {
-        IMessageSerialiser<Message> GetSerialiser(string objectType);
-        IMessageSerialiser<Message> GetSerialiser(Type objectType);
-        void AddSerialiser<T>(IMessageSerialiser<Message> serialiser) where T : Message;
+        TypeSerialiser GeTypeSerialiser(string objectType);
+        TypeSerialiser GeTypeSerialiser(Type objectType);
+        void AddSerialiser<T>(IMessageSerialiser serialiser) where T : Message;
     }
 }

--- a/JustSaying.Messaging/MessageSerialisation/IMessageSerialiser.cs
+++ b/JustSaying.Messaging/MessageSerialisation/IMessageSerialiser.cs
@@ -1,10 +1,11 @@
+using System;
 using JustSaying.Models;
 
 namespace JustSaying.Messaging.MessageSerialisation
 {
-    public interface IMessageSerialiser<out T> where T : Message
+    public interface IMessageSerialiser
     {
-        T Deserialise(string message);
+        Message Deserialise(string message, Type type);
         string Serialise(Message message);
     }
 }

--- a/JustSaying.Messaging/MessageSerialisation/MessageSerialisationRegister.cs
+++ b/JustSaying.Messaging/MessageSerialisation/MessageSerialisationRegister.cs
@@ -6,28 +6,28 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public class MessageSerialisationRegister : IMessageSerialisationRegister
     {
-        private readonly Dictionary<string, IMessageSerialiser<Message>> _map;
+        private readonly Dictionary<string, TypeSerialiser> _map;
 
         public MessageSerialisationRegister()
         {
-            _map = new Dictionary<string, IMessageSerialiser<Message>>();
+            _map = new Dictionary<string, TypeSerialiser>();
         }
 
-        public IMessageSerialiser<Message> GetSerialiser(string objectType)
+        public TypeSerialiser GeTypeSerialiser(string objectType)
         {
             return _map[objectType];
         }
 
-        public IMessageSerialiser<Message> GetSerialiser(Type objectType)
+        public TypeSerialiser GeTypeSerialiser(Type objectType)
         {
             return _map[objectType.Name];
         }
 
-        public void AddSerialiser<T>(IMessageSerialiser<Message> serialiser) where T : Message
+        public void AddSerialiser<T>(IMessageSerialiser serialiser) where T : Message
         {
             var keyname = typeof (T).Name;
             if (! _map.ContainsKey(keyname))
-                _map.Add(keyname, serialiser);
+                _map.Add(keyname, new TypeSerialiser(typeof(T), serialiser));
         }
     }
 }

--- a/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialisationFactory.cs
+++ b/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialisationFactory.cs
@@ -4,9 +4,9 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public class NewtonsoftSerialisationFactory : IMessageSerialisationFactory
     {
-        public IMessageSerialiser<Message> GetSerialiser<T>() where T : Message
+        public IMessageSerialiser GetSerialiser<T>() where T : Message
         {
-            return new NewtonsoftSerialiser<T>();
+            return new NewtonsoftSerialiser();
         }
     }
 }

--- a/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
+++ b/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
@@ -1,15 +1,16 @@
+using System;
 using JustSaying.Models;
 using Newtonsoft.Json;
 
 namespace JustSaying.Messaging.MessageSerialisation
 {
-    public class NewtonsoftSerialiser<T> : IMessageSerialiser<Message> where T : Message
+    public class NewtonsoftSerialiser : IMessageSerialiser
     {
         private readonly JsonConverter _enumConverter = new Newtonsoft.Json.Converters.StringEnumConverter();
 
-        public Message Deserialise(string message)
+        public Message Deserialise(string message, Type type)
         {
-            return JsonConvert.DeserializeObject<T>(message, _enumConverter);
+            return (Message)JsonConvert.DeserializeObject(message, type, _enumConverter);
         }
 
         public string Serialise(Message message)

--- a/JustSaying.Messaging/MessageSerialisation/TypeSerialiser.cs
+++ b/JustSaying.Messaging/MessageSerialisation/TypeSerialiser.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace JustSaying.Messaging.MessageSerialisation
+{
+    public class TypeSerialiser
+    {
+        public Type Type { get; private set; }
+        public IMessageSerialiser Serialiser { get; private set; }
+
+        public TypeSerialiser(Type type, IMessageSerialiser serialiser)
+        {
+            Type = type;
+            Serialiser = serialiser;
+        }
+    }
+}

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -49,7 +49,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Then]
         public void SerialisationIsRegisteredForMessage()
         {
-            Bus.SerialisationRegister.Received().AddSerialiser<Message>(Arg.Any<IMessageSerialiser<Message>>());
+            Bus.SerialisationRegister.Received().AddSerialiser<Message>(Arg.Any<IMessageSerialiser>());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -49,7 +49,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Then]
         public void SerialisationIsRegisteredForMessage()
         {
-            Bus.SerialisationRegister.Received().AddSerialiser<Message>(Arg.Any<IMessageSerialiser<Message>>());
+            Bus.SerialisationRegister.Received().AddSerialiser<Message>(Arg.Any<IMessageSerialiser>());
         }
 
         [Then]


### PR DESCRIPTION
Generic interfaces are an anti-pattern IMO, but anyway, the generic on the serialiser is one of the root causes of a lot of forced implementation in JustSaying. 

When you have a generic class, anything that consumes that class and cares about the type will generally be forced into being generic itself, making code quite rigid as things that don't care will end up passing around Types via generics just for the sake of it.

This change is a start on breaking that dependency by wrapping the Type of class itself, allow dependant classes to lookup by the Type object rather than having to be generic themselves. 

It's a small prices to pay for the amount of refactoring that will be possible in coming PRs