### PR TITLE
Ensure that batch size is set when throttling is strategy is in place.

### DIFF
--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -104,7 +104,7 @@ namespace JustSaying.AwsTools
                 var sqsMessageResponse = _queue.Client.ReceiveMessage(new ReceiveMessageRequest
                 {
                     QueueUrl = _queue.Url,
-                    MaxNumberOfMessages = MaxAmazonMessageCap,
+                    MaxNumberOfMessages = GetMaxBatchSize(),
                     WaitTimeSeconds = 20
                 });
 
@@ -129,6 +129,12 @@ namespace JustSaying.AwsTools
             {
                 Log.ErrorException("Issue in message handling loop", ex);
             }
+        }
+
+        private int GetMaxBatchSize()
+        {
+            var maxMessageBatchSize = _messageProcessingStrategy as IMessageMaxBatchSizeProcessingStrategy;
+            return maxMessageBatchSize != null ? maxMessageBatchSize.MaxBatchSize : MaxAmazonMessageCap;
         }
 
         public void HandleMessage(Amazon.SQS.Model.Message message)

--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -138,7 +138,6 @@ namespace JustSaying.AwsTools
             if (maxMessageBatchSize == null || (maxMessageBatchSize.MaxBatchSize <= 0 || maxMessageBatchSize.MaxBatchSize > MaxAmazonMessageCap))
             {
                 return MaxAmazonMessageCap;
-     
             }
             return maxMessageBatchSize.MaxBatchSize;
         }

--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -134,7 +134,13 @@ namespace JustSaying.AwsTools
         private int GetMaxBatchSize()
         {
             var maxMessageBatchSize = _messageProcessingStrategy as IMessageMaxBatchSizeProcessingStrategy;
-            return maxMessageBatchSize != null ? maxMessageBatchSize.MaxBatchSize : MaxAmazonMessageCap;
+
+            if (maxMessageBatchSize == null || (maxMessageBatchSize.MaxBatchSize <= 0 || maxMessageBatchSize.MaxBatchSize > MaxAmazonMessageCap))
+            {
+                return MaxAmazonMessageCap;
+     
+            }
+            return maxMessageBatchSize.MaxBatchSize;
         }
 
         public void HandleMessage(Amazon.SQS.Model.Message message)

--- a/JustSaying.Messaging/JustSaying.Messaging.csproj
+++ b/JustSaying.Messaging/JustSaying.Messaging.csproj
@@ -52,6 +52,7 @@
     <Compile Include="MessageHandling\ExactlyOnceAttribute.cs" />
     <Compile Include="MessageHandling\ExactlyOnceHandler.cs" />
     <Compile Include="MessageHandling\IMessageLock.cs" />
+    <Compile Include="MessageProcessingStrategies\IMessageMaxBatchSizeProcessingStrategy.cs" />
     <Compile Include="MessageProcessingStrategies\IMessageProcessingStrategy.cs" />
     <Compile Include="MessageProcessingStrategies\MaximumThroughput.cs" />
     <Compile Include="MessageProcessingStrategies\Throttled.cs" />

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageMaxBatchSizeProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageMaxBatchSizeProcessingStrategy.cs
@@ -1,0 +1,7 @@
+namespace JustSaying.Messaging.MessageProcessingStrategies
+{
+    public interface IMessageMaxBatchSizeProcessingStrategy
+    {
+        int MaxBatchSize { get; }
+    }
+}

--- a/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
@@ -7,7 +7,7 @@ using JustSaying.Messaging.Monitoring;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
-    public class Throttled : IMessageProcessingStrategy
+    public class Throttled : IMessageProcessingStrategy, IMessageMaxBatchSizeProcessingStrategy
     {
         private readonly Func<int> _maximumAllowedMesagesInFlightProducer;
         private const int MinimumThreshold = 1;
@@ -89,6 +89,10 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             }
 
             Interlocked.Decrement(ref _activeTaskCount);
+        }
+
+        public int MaxBatchSize {
+            get { return _maximumBatchSize; }
         }
     }
 }


### PR DESCRIPTION
In the throttling strategy you can specify a "maximumBatchSize" however this doesn't seem to be warranted and batch size is always 10.

````c#
    public class SqsNotificationListener : INotificationSubscriber
    {
.....
        private const int MaxAmazonMessageCap = 10;
````