### PR TITLE
Added queue name to exception logging

### DIFF
--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -123,11 +123,11 @@ namespace JustSaying.AwsTools
             }
             catch (InvalidOperationException ex)
             {
-                Log.Trace("Suspected no messaged in queue. Ex: {0}", ex);
+                Log.Trace("Suspected no messaged in queue {0}. Ex: {1}", _queue.QueueName, ex);
             }
             catch (Exception ex)
             {
-                Log.ErrorException("Issue in message handling loop", ex);
+                Log.ErrorException(string.Format("Issue in message handling loop for queue {0}", _queue.QueueName), ex);
             }
         }
 

--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -123,7 +123,7 @@ namespace JustSaying.AwsTools
             }
             catch (InvalidOperationException ex)
             {
-                Log.Trace("Suspected no messaged in queue {0}. Ex: {1}", _queue.QueueName, ex);
+                Log.Trace("Suspected no message in queue {0}. Ex: {1}", _queue.QueueName, ex);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Recently we had an issue inside the message read loop but it was not easy to ascertain whether one queue or all queues were affected as the queue name was not part of the log entry. This change adds the queue name to the log entries.