### PR TITLE
ExactlyOnce should use the actual handler's name not the wrapping decora...

### DIFF
--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -60,7 +60,8 @@ namespace JustSaying.AwsTools
                 handlers = new List<Func<Message, bool>>();
                 _handlers.Add(typeof(T), handlers);
             }
-            var guaranteedDelivery = new GuaranteedOnceDelivery<T>(futureHandler());
+            var handlerInstance = futureHandler();
+            var guaranteedDelivery = new GuaranteedOnceDelivery<T>(handlerInstance);
             
             IHandler<T> handler = new FutureHandler<T>(futureHandler);
             if (guaranteedDelivery.Enabled)
@@ -68,7 +69,7 @@ namespace JustSaying.AwsTools
                 if(_messageLock == null)
                     throw new Exception("IMessageLock is null. You need to specify an implementation for IMessageLock.");
 
-                handler = new ExactlyOnceHandler<T>(handler, _messageLock, guaranteedDelivery.TimeOut);
+                handler = new ExactlyOnceHandler<T>(handler, _messageLock, guaranteedDelivery.TimeOut, handlerInstance.GetType().FullName.ToLower());
             }
             var executionTimeMonitoring = _messagingMonitor as IMeasureHandlerExecutionTime;
             if (executionTimeMonitoring != null)

--- a/JustSaying.Messaging.UnitTests/MessageHandling/WhenEnsuringMessageIsOnlyHandledExactlyOnce.cs
+++ b/JustSaying.Messaging.UnitTests/MessageHandling/WhenEnsuringMessageIsOnlyHandledExactlyOnce.cs
@@ -13,7 +13,7 @@ namespace JustSaying.Messaging.UnitTests.MessageHandling
         {
             var messageLock = Substitute.For<IMessageLock>();
             messageLock.TryAquireLock(Arg.Any<string>(), Arg.Any<TimeSpan>()).Returns(new MessageLockResponse(){DoIHaveExclusiveLock = false});
-            var sut = new ExactlyOnceHandler<OrderAccepted>(Substitute.For<IHandler<OrderAccepted>>(), messageLock, 1);
+            var sut = new ExactlyOnceHandler<OrderAccepted>(Substitute.For<IHandler<OrderAccepted>>(), messageLock, 1, "handlerName");
 
             var result = sut.Handle(new OrderAccepted());
 

--- a/JustSaying.Messaging/MessageHandling/ExactlyOnceHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/ExactlyOnceHandler.cs
@@ -8,12 +8,14 @@ namespace JustSaying.Messaging.MessageHandling
         private readonly IHandler<T> _inner;
         private readonly IMessageLock _messageLock;
         private readonly int _timeOut;
+        private readonly string _handlerName;
 
-        public ExactlyOnceHandler(IHandler<T> inner, IMessageLock messageLock, int timeOut)
+        public ExactlyOnceHandler(IHandler<T> inner, IMessageLock messageLock, int timeOut, string handlerName)
         {
             _inner = inner;
             _messageLock = messageLock;
             _timeOut = timeOut;
+            _handlerName = handlerName;
         }
 
         private const bool RemoveTheMessageFromTheQueue = true;
@@ -21,7 +23,7 @@ namespace JustSaying.Messaging.MessageHandling
         
         public bool Handle(T message)
         {
-            var lockKey = string.Format("{0}-{1}-{2}", _inner.GetType().FullName.ToLower(), typeof(T).Name.ToLower(), message.UniqueKey());
+            var lockKey = string.Format("{2}-{1}-{0}", _handlerName, typeof(T).Name.ToLower(), message.UniqueKey());
             var lockResponse = _messageLock.TryAquireLock(lockKey, TimeSpan.FromSeconds(_timeOut));
             if (!lockResponse.DoIHaveExclusiveLock)
             {


### PR DESCRIPTION
...tor to form the unique key for the message.