### PR TITLE
Listener per queue per region

### DIFF
--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -39,6 +39,10 @@ namespace JustSaying.AwsTools
             _messageLock = messageLock;
         }
 
+        public string Queue
+        {
+            get { return this._queue.QueueName; }
+        }
         // ToDo: This should not be here.
         public SqsNotificationListener WithMaximumConcurrentLimitOnMessagesInFlightOf(int maximumAllowedMesagesInFlight)
         {

--- a/JustSaying.Messaging/INotificationSubscriber.cs
+++ b/JustSaying.Messaging/INotificationSubscriber.cs
@@ -9,5 +9,6 @@ namespace JustSaying.Messaging
         void AddMessageHandler<T>(Func<IHandler<T>> handler) where T : Message;
         void Listen();
         void StopListening();
+        string Queue { get; }
     }
 }

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
@@ -36,10 +36,10 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationTopicSubscriber(_topic, _subscriber);
-            SystemUnderTest.AddNotificationTopicSubscriber(_topic2, _subscriber);
-            SystemUnderTest.AddMessageHandler(_futureHandler1);
-            SystemUnderTest.AddMessageHandler(_futureHandler2);
+            SystemUnderTest.AddNotificationSubscriber(_topic, _subscriber);
+            SystemUnderTest.AddNotificationSubscriber(_topic, _subscriber);
+            SystemUnderTest.AddMessageHandler(_topic, _subscriber.Queue, _futureHandler1);
+            SystemUnderTest.AddMessageHandler(_topic, _subscriber.Queue, _futureHandler2);
             SystemUnderTest.Start();
         }
 
@@ -58,7 +58,7 @@ namespace JustSaying.UnitTests.JustSayingBus
                                      _subscriber.AddMessageHandler(Arg.Any<Func<IHandler<Message>>>());
                                      _subscriber.AddMessageHandler(Arg.Any<Func<IHandler<Message2>>>());
                                      _subscriber.Listen();
-                                     _subscriber.Listen();
+                                     //_subscriber.Listen();
                                  });
         }
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
@@ -13,8 +13,7 @@ namespace JustSaying.UnitTests.JustSayingBus
         private INotificationSubscriber _subscriber;
         private IHandler<Message> _handler1;
         private IHandler<Message2> _handler2;
-        private string _topic;
-        private string _topic2;
+        private string _region;
         private Func<IHandler<Message>> _futureHandler1;
         private Func<IHandler<Message2>> _futureHandler2;
 
@@ -30,16 +29,15 @@ namespace JustSaying.UnitTests.JustSayingBus
             _subscriber = Substitute.For<INotificationSubscriber>();
             _handler1 = Substitute.For<IHandler<Message>>();
             _handler2 = Substitute.For<IHandler<Message2>>();
-            _topic = "message"; //same as message name
-            _topic2 = "message2"; //same as message name
+            _region = "west-1";
         }
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationSubscriber(_topic, _subscriber);
-            SystemUnderTest.AddNotificationSubscriber(_topic, _subscriber);
-            SystemUnderTest.AddMessageHandler(_topic, _subscriber.Queue, _futureHandler1);
-            SystemUnderTest.AddMessageHandler(_topic, _subscriber.Queue, _futureHandler2);
+            SystemUnderTest.AddNotificationSubscriber(_region, _subscriber);
+            SystemUnderTest.AddNotificationSubscriber(_region, _subscriber);
+            SystemUnderTest.AddMessageHandler(_region, _subscriber.Queue, _futureHandler1);
+            SystemUnderTest.AddMessageHandler(_region, _subscriber.Queue, _futureHandler2);
             SystemUnderTest.Start();
         }
 
@@ -58,7 +56,6 @@ namespace JustSaying.UnitTests.JustSayingBus
                                      _subscriber.AddMessageHandler(Arg.Any<Func<IHandler<Message>>>());
                                      _subscriber.AddMessageHandler(Arg.Any<Func<IHandler<Message2>>>());
                                      _subscriber.Listen();
-                                     //_subscriber.Listen();
                                  });
         }
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
@@ -19,8 +19,8 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationTopicSubscriber("OrderDispatch", _subscriber1);
-            SystemUnderTest.AddNotificationTopicSubscriber("CustomerCommunication", _subscriber2);
+            SystemUnderTest.AddNotificationSubscriber("OrderDispatch", _subscriber1);
+            SystemUnderTest.AddNotificationSubscriber("CustomerCommunication", _subscriber2);
             SystemUnderTest.Start();
         }
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
@@ -14,13 +14,15 @@ namespace JustSaying.UnitTests.JustSayingBus
         {
             base.Given();
             _subscriber1 = Substitute.For<INotificationSubscriber>();
+            _subscriber1.Queue.Returns("queue1");
             _subscriber2 = Substitute.For<INotificationSubscriber>();
+            _subscriber2.Queue.Returns("queue2");
         }
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationSubscriber("OrderDispatch", _subscriber1);
-            SystemUnderTest.AddNotificationSubscriber("CustomerCommunication", _subscriber2);
+            SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
+            SystemUnderTest.AddNotificationSubscriber("region1", _subscriber2);
             SystemUnderTest.Start();
         }
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
@@ -17,7 +17,7 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationTopicSubscriber("OrderDispatch", _subscriber1);
+            SystemUnderTest.AddNotificationSubscriber("OrderDispatch", _subscriber1);
             SystemUnderTest.Start();
             SystemUnderTest.Stop();
         }

--- a/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
@@ -17,7 +17,7 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationSubscriber("OrderDispatch", _subscriber1);
+            SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
             SystemUnderTest.Start();
             SystemUnderTest.Stop();
         }

--- a/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
@@ -18,8 +18,8 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationTopicSubscriber("OrderDispatch", _subscriber1);
-            SystemUnderTest.AddNotificationTopicSubscriber("CustomerCommunication", _subscriber2);
+            SystemUnderTest.AddNotificationSubscriber("OrderDispatch", _subscriber1);
+            SystemUnderTest.AddNotificationSubscriber("CustomerCommunication", _subscriber2);
             SystemUnderTest.Start();
             SystemUnderTest.Stop();
         }

--- a/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
@@ -13,13 +13,15 @@ namespace JustSaying.UnitTests.JustSayingBus
         {
             base.Given();
             _subscriber1 = Substitute.For<INotificationSubscriber>();
+            _subscriber1.Queue.Returns("queue1");
             _subscriber2 = Substitute.For<INotificationSubscriber>();
+            _subscriber2.Queue.Returns("queue2");
         }
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationSubscriber("OrderDispatch", _subscriber1);
-            SystemUnderTest.AddNotificationSubscriber("CustomerCommunication", _subscriber2);
+            SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
+            SystemUnderTest.AddNotificationSubscriber("region1", _subscriber2);
             SystemUnderTest.Start();
             SystemUnderTest.Stop();
         }

--- a/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
@@ -14,13 +14,13 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void When()
         {
-            SystemUnderTest.AddNotificationTopicSubscriber(" ", null);
+            SystemUnderTest.AddNotificationSubscriber(" ", null);
         }
 
         [Then]
         public void ArgExceptionThrown()
         {
-            Assert.AreEqual(((ArgumentException)ThrownException).ParamName, "topic");
+            Assert.AreEqual(((ArgumentException)ThrownException).ParamName, "region");
         }
     }
 }

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -38,13 +38,13 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Then]
         public void TheSubscriptionIsCreatedInEachRegion()
         {
-            Bus.Received(2).AddNotificationTopicSubscriber(Arg.Any<string>(), Arg.Any<INotificationSubscriber>());
+            Bus.Received(2).AddNotificationSubscriber(Arg.Any<string>(), Arg.Any<INotificationSubscriber>());
         }
 
         [Then]
         public void HandlerIsAddedToBus()
         {
-            Bus.Received().AddMessageHandler(Arg.Any<Func<IHandler<Message>>>());
+            Bus.Received().AddMessageHandler(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<IHandler<Message>>>());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -38,13 +38,13 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Then]
         public void TheSubscriptionIsCreatedInEachRegion()
         {
-            Bus.Received(2).AddNotificationTopicSubscriber(Arg.Any<string>(), Arg.Any<INotificationSubscriber>());
+            Bus.Received(2).AddNotificationSubscriber(Arg.Any<string>(), Arg.Any<INotificationSubscriber>());
         }
 
         [Then]
         public void HandlerIsAddedToBus()
         {
-            Bus.Received().AddMessageHandler(Arg.Any<Func<IHandler<Message>>>());
+            Bus.Received().AddMessageHandler(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<IHandler<Message>>>());
         }
         
         [Then]

--- a/JustSaying/IAmJustSaying.cs
+++ b/JustSaying/IAmJustSaying.cs
@@ -10,8 +10,10 @@ namespace JustSaying
     public interface IAmJustSaying : IMessagePublisher
     {
         bool Listening { get; }
-        void AddNotificationTopicSubscriber(string topic, INotificationSubscriber subscriber);
-        void AddMessageHandler<T>(Func<IHandler<T>> handler) where T : Message;
+        void AddNotificationSubscriber(string region, INotificationSubscriber subscriber);
+        void AddMessageHandler<T>(string region, string queueName, Func<IHandler<T>> handler) where T : Message;
+
+        // TODO - swap params
         void AddMessagePublisher<T>(IMessagePublisher messagePublisher, string region) where T : Message;
         void Start();
         void Stop();

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -14,19 +14,6 @@ using JustSaying.Lookups;
 
 namespace JustSaying
 {
-    public static class LinqExtensions
-    {
-        public static IEnumerable<T> ForEach<T>(this IEnumerable<T> enumeration, Action<T> action)
-        {
-            foreach (T item in enumeration)
-            {
-                action(item);
-                yield return item;
-            }
-        }
-    }
-
-
     /// <summary>
     /// Fluently configure a JustSaying message bus.
     /// Intended usage:

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -14,6 +14,19 @@ using JustSaying.Lookups;
 
 namespace JustSaying
 {
+    public static class LinqExtensions
+    {
+        public static IEnumerable<T> ForEach<T>(this IEnumerable<T> enumeration, Action<T> action)
+        {
+            foreach (T item in enumeration)
+            {
+                action(item);
+                yield return item;
+            }
+        }
+    }
+
+
     /// <summary>
     /// Fluently configure a JustSaying message bus.
     /// Intended usage:
@@ -212,12 +225,17 @@ namespace JustSaying
         /// <returns></returns>
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandler<T> handler) where T : Message
         {
+            // TODO - Subscription listeners should be just added once per queue,
+            // and not for each message handler
             var thing =  _subscriptionConfig.SubscriptionType == SubscriptionType.PointToPoint
                 ? PointToPointHandler<T>()
                 : TopicHandler<T>();
-
+            
             Bus.SerialisationRegister.AddSerialiser<T>(_serialisationFactory.GetSerialiser<T>());
-            Bus.AddMessageHandler(() => handler);
+            foreach (var region in Bus.Config.Regions)
+            {
+                Bus.AddMessageHandler(region, _subscriptionConfig.QueueName, () => handler);
+            }
             var messageTypeName = typeof(T).Name.ToLower();
             Log.Info(string.Format("Added a message handler - MessageName: {0}, QueueName: {1}, HandlerName: {2}", messageTypeName, _subscriptionConfig.QueueName, handler.GetType().Name));
 
@@ -239,8 +257,14 @@ namespace JustSaying
             {
                 throw new NotSupportedException(string.Format("There are more than one registration for IHandler<{0}>. JustSaying currently does not support multiple registration for IHandler<T>.", typeof(T).Name));
             }
+
+            foreach (var region in Bus.Config.Regions)
+            {
+                Bus.AddMessageHandler(region, 
+                    _subscriptionConfig.QueueName, 
+                    () => handlerResolver.ResolveHandlers<T>().Single());
+            }
             
-            Bus.AddMessageHandler(() => handlerResolver.ResolveHandlers<T>().Single());
 
             Log.Info(string.Format("Added a message handler - Topic: {0}, QueueName: {1}, HandlerName: IHandler<{2}>", _subscriptionConfig.Topic, _subscriptionConfig.QueueName, typeof(T)));
 
@@ -255,7 +279,7 @@ namespace JustSaying
             foreach (var region in Bus.Config.Regions)
             {
                 var queue = _amazonQueueCreator.EnsureTopicExistsWithQueueSubscribed(region, Bus.SerialisationRegister, _subscriptionConfig);
-                CreateSubscriptionListener(queue, _subscriptionConfig.Topic);
+                CreateSubscriptionListener(region, queue, _subscriptionConfig.Topic);
                 Log.Info(string.Format("Created SQS topic subscription - Topic: {0}, QueueName: {1}", _subscriptionConfig.Topic, _subscriptionConfig.QueueName));
             }
           
@@ -270,17 +294,17 @@ namespace JustSaying
             foreach (var region in Bus.Config.Regions)
             {
                 var queue = _amazonQueueCreator.EnsureQueueExists(region, _subscriptionConfig);
-                CreateSubscriptionListener(queue, messageTypeName);
+                CreateSubscriptionListener(region, queue, messageTypeName);
                 Log.Info(string.Format("Created SQS subscriber - MessageName: {0}, QueueName: {1}", messageTypeName, _subscriptionConfig.QueueName));
             }
            
             return this;
         }
 
-        private void CreateSubscriptionListener(SqsQueueBase queue, string messageTypeName)
+        private void CreateSubscriptionListener(string region, SqsQueueBase queue, string messageTypeName)
         {
             var sqsSubscriptionListener = new SqsNotificationListener(queue, Bus.SerialisationRegister, Bus.Monitor, _subscriptionConfig.OnError, Bus.MessageLock);
-            Bus.AddNotificationTopicSubscriber(messageTypeName, sqsSubscriptionListener);
+            Bus.AddNotificationSubscriber(region, sqsSubscriptionListener);
 
             if (_subscriptionConfig.MaxAllowedMessagesInFlight.HasValue)
             {


### PR DESCRIPTION
Updating JustSaying so that only one listener would be created per queue, instead of listener per topic.

As discussed in [issue77](https://github.com/justeat/JustSaying/issues/77).