### PR TITLE
Ensuring that SQS publisher uses IMessageSerialiser to serialise messages

### DIFF
--- a/JustSaying.AwsTools/SqsPublisher.cs
+++ b/JustSaying.AwsTools/SqsPublisher.cs
@@ -28,10 +28,10 @@ namespace JustSaying.AwsTools
             });
         }
 
-        private static string GetMessageInContext(Message message)
+        private string GetMessageInContext(Message message)
         {
-            // ToDo: No no mr JsonConvert.
-            var context = new { Subject = message.GetType().Name, Message = message };
+            var serializedMessage = _serialisationRegister.GeTypeSerialiser(message.GetType()).Serialiser.Serialise(message);
+            var context = new { Subject = message.GetType().Name, Message = serializedMessage };
             return JsonConvert.SerializeObject(context);
         }
     }


### PR DESCRIPTION
Note that JsonConvert.SerializeObject is still left as is, the final message pushed onto SQS queue must contain a Subject and Message fields. For SNS publishing, this is done automatically by AWS.