### PR TITLE
Allowing to override settings for NewtonsoftSerializer

### DIFF
--- a/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
+++ b/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Serialisation\Newtonsoft\DealingWithPotentiallyMissingConversation.cs" />
     <Compile Include="Serialisation\Newtonsoft\WhenAskingForAnewSerialiser.cs" />
     <Compile Include="Serialisation\Newtonsoft\WhenSerialisingAndDeserialising.cs" />
+    <Compile Include="Serialisation\Newtonsoft\WhenUsingCustomSettings.cs" />
     <Compile Include="Serialisation\SerialisationRegister\WhenAddingAGenericSerialiser.cs" />
     <Compile Include="Serialisation\SerialisationRegister\WhenAddingASerialiser.cs" />
     <Compile Include="Serialisation\SerialisationRegister\WhenAddingASerialiserTwice.cs" />

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
@@ -1,0 +1,48 @@
+using JustBehave;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.TestingFramework;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
+{
+    public class WhenUsingCustomSettings: BehaviourTest<NewtonsoftSerialiser>
+    {
+        private MessageWithEnum _messageOut;
+        private string _jsonMessage;
+
+        protected override NewtonsoftSerialiser CreateSystemUnderTest()
+        {
+            return new NewtonsoftSerialiser(new JsonSerializerSettings());
+        }
+
+        protected override void Given()
+        {
+            _messageOut = new MessageWithEnum(Values.Two);
+        }
+
+        public string GetMessageInContext(MessageWithEnum message)
+        {
+            var context = new { Subject = message.GetType().Name, Message = SystemUnderTest.Serialise(message) };
+            return JsonConvert.SerializeObject(context);
+        }
+
+        protected override void When()
+        {
+            _jsonMessage = GetMessageInContext(_messageOut);
+        }
+
+        [Then]
+        public void MessageHasBeenCreated()
+        {
+            Assert.NotNull(_messageOut);
+        }
+
+        [Then]
+        public void EnumsAreNotRepresentedAsStrings()
+        {
+            Assert.That(_jsonMessage, Is.StringContaining("EnumVal"));
+            Assert.That(_jsonMessage, Is.Not.StringContaining("Two"));
+        }
+    }
+}

--- a/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
+++ b/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
@@ -6,22 +6,40 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public class NewtonsoftSerialiser : IMessageSerialiser
     {
-        private readonly JsonConverter _enumConverter = new Newtonsoft.Json.Converters.StringEnumConverter();
+        private readonly JsonSerializerSettings _settings;
+
+        public NewtonsoftSerialiser()
+        {
+            _settings = null;
+        }
+
+        public NewtonsoftSerialiser(JsonSerializerSettings settings) : this()
+        {
+            this._settings = settings;
+        }
 
         public Message Deserialise(string message, Type type)
         {
-            return (Message)JsonConvert.DeserializeObject(message, type, _enumConverter);
+            return (Message)JsonConvert.DeserializeObject(message, type, GetJsonSettings());
         }
 
         public string Serialise(Message message)
         {
-            var settings = new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                Converters = new[] { _enumConverter }
-            };
+            var settings = GetJsonSettings();
 
             return JsonConvert.SerializeObject(message, settings);
+        }
+
+        private JsonSerializerSettings GetJsonSettings()
+        {
+            if (_settings != null)
+                return _settings;
+            return new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                Converters = new JsonConverter[] { new Newtonsoft.Json.Converters.StringEnumConverter() }
+            };
+
         }
     }
 }


### PR DESCRIPTION
Exposting `JsonSerializerSettings` as an optional constructor parameter, allows to pass in custom settings.