### PR TITLE
Global SQS constants changed to static from const

### DIFF
--- a/JustSaying.AwsTools/JustSayingConstants.cs
+++ b/JustSaying.AwsTools/JustSayingConstants.cs
@@ -8,15 +8,52 @@ namespace JustSaying.AwsTools
         public const string ATTRIBUTE_VISIBILITY_TIMEOUT = "VisibilityTimeout";
         public const string ATTRIBUTE_DELIVERY_DELAY = "DelaySeconds";
         public const string ATTRIBUTE_POLICY = "Policy";
-        public const int DEFAULT_CREATE_REATTEMPT = 0;
-        public const int DEFAULT_VISIBILITY_TIMEOUT = 30;
-        public const int DEFAULT_HANDLER_RETRY_COUNT = 5;
-        public const int DEFAULT_PUBLISHER_RETRY_COUNT = 3;
-        public const int DEFAULT_PUBLISHER_RETRY_INTERVAL = 100;//100 milliseconds
-        public const int MINIMUM_RETENTION_PERIOD = 60;         //1 minute
-        public const int DEFAULT_RETENTION_PERIOD = 60 * 10;    //10 minutes
-        public const int MAXIMUM_RETENTION_PERIOD = 1209600;    //14 days
-        public const int MINIMUM_DELIVERY_DELAY = 0;
-        public const int MAXIMUM_DELIVERY_DELAY = 900;          //15 minutes
+
+        /// <summary>
+        /// Default visibility timeout for message in seconds
+        /// </summary>
+        public static int DEFAULT_VISIBILITY_TIMEOUT = 30;
+        
+        /// <summary>
+        /// Number of times a handler will retry a message until a message 
+        /// is sent to error queue
+        /// </summary>
+        public static int DEFAULT_HANDLER_RETRY_COUNT = 5;
+
+        /// <summary>
+        /// Number of times publisher will retry to publish a message if destination is down.
+        /// </summary>
+        public static int DEFAULT_PUBLISHER_RETRY_COUNT = 3;
+
+        /// <summary>
+        /// Every time a publisher is not able to deliver a message, it will 
+        /// wait {interval}*{attemptCount} miliseconds before retrying,
+        /// </summary>
+        public static int DEFAULT_PUBLISHER_RETRY_INTERVAL = 100;//100 milliseconds
+        
+        /// <summary>
+        /// Minimum message retention period on a queue.
+        /// </summary>
+        public static int MINIMUM_RETENTION_PERIOD = 60;         //1 minute
+
+        /// <summary>
+        /// Default message retention period on a queue in seconds
+        /// </summary>
+        public static int DEFAULT_RETENTION_PERIOD = 60 * 10;    //10 minutes
+
+        /// <summary>
+        /// Maximum message retention period on a queue in seconds
+        /// </summary>
+        public static int MAXIMUM_RETENTION_PERIOD = 1209600;    //14 days
+        
+        /// <summary>
+        /// Minimum delay in message delivery for SQS i nseconds. This is also the default.
+        /// </summary>
+        public static int MINIMUM_DELIVERY_DELAY = 0;
+
+        /// <summary>
+        /// Maximum message delivery delay for SQS in seconds
+        /// </summary>
+        public static int MAXIMUM_DELIVERY_DELAY = 900;          //15 minutes
     }
 }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -191,7 +191,7 @@ namespace JustSaying
                     throw;
                 }
 
-                Thread.Sleep(Config.PublishFailureBackoffMilliseconds * attemptCount); // ToDo: Increase back off each time (exponential)
+                Thread.Sleep(Config.PublishFailureBackoffMilliseconds * attemptCount); // ToDo: Increase back off each time (linear)
                 Publish(publisher, message, attemptCount);
             }
         }


### PR DESCRIPTION
Global SQS constants changed to static from const, allows to update configuration globally.
Describing what each configuration variable does.
Fixing comment in JustSayingBus - publish back off is linear, not exponential.