### PR TITLE
Update nlog

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -44,9 +44,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\JustSaying.Models.2.0.0.43\lib\net40\JustSaying.Models.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>

--- a/JustSaying.AwsTools.IntegrationTests/app.config
+++ b/JustSaying.AwsTools.IntegrationTests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/JustSaying.AwsTools.IntegrationTests/packages.config
+++ b/JustSaying.AwsTools.IntegrationTests/packages.config
@@ -4,7 +4,7 @@
   <package id="AWSSDK" version="2.3.47.0" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
   <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />

--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -43,9 +43,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\JustSaying.Models.2.0.0.43\lib\net40\JustSaying.Models.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>

--- a/JustSaying.AwsTools.UnitTests/app.config
+++ b/JustSaying.AwsTools.UnitTests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/JustSaying.AwsTools.UnitTests/packages.config
+++ b/JustSaying.AwsTools.UnitTests/packages.config
@@ -4,7 +4,7 @@
   <package id="AWSSDK" version="2.3.47.0" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
   <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />

--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -44,9 +44,9 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -134,7 +134,7 @@ namespace JustSaying.AwsTools
             }
             catch (Exception ex)
             {
-                Log.ErrorException(string.Format("Issue in message handling loop for queue {0}", _queue.QueueName), ex);
+                Log.Error(ex, string.Format("Issue in message handling loop for queue {0}", _queue.QueueName));
             }
         }
 
@@ -204,7 +204,7 @@ namespace JustSaying.AwsTools
             }
             catch (Exception ex)
             {
-                Log.ErrorException(string.Format("Issue handling message... {0}. StackTrace: {1}", message, ex.StackTrace), ex);
+                Log.Error(ex, string.Format("Issue handling message... {0}. StackTrace: {1}", message, ex.StackTrace));
                 if (typedMessage != null)
                 {
                     _messagingMonitor.HandleException(typedMessage.GetType().Name);

--- a/JustSaying.AwsTools/SqsQueueByNameBase.cs
+++ b/JustSaying.AwsTools/SqsQueueByNameBase.cs
@@ -69,14 +69,14 @@ namespace JustSaying.AwsTools
                 else
                 {
                     // Throw all errors which are not delete timeout related.
-                    Log.ErrorException(string.Format("Create Queue error: {0}", QueueName), ex);
+                    Log.Error(ex, string.Format("Create Queue error: {0}", QueueName));
                     throw;
                 }
 
                 // If we're on a delete timeout, throw after 2 attempts.
                 if (attempt >= 2)
                 {
-                    Log.ErrorException(string.Format("Create Queue error, max retries exceeded for delay - Queue: {0}", QueueName), ex);
+                    Log.Error(ex, string.Format("Create Queue error, max retries exceeded for delay - Queue: {0}", QueueName));
                     throw;
                 }
             }

--- a/JustSaying.AwsTools/packages.config
+++ b/JustSaying.AwsTools/packages.config
@@ -3,5 +3,5 @@
   <package id="AWSSDK" version="2.3.47.0" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
 </packages>

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -43,9 +43,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\JustSaying.Models.2.0.0.43\lib\net40\JustSaying.Models.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>

--- a/JustSaying.IntegrationTests/app.config
+++ b/JustSaying.IntegrationTests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -4,7 +4,7 @@
   <package id="AWSSDK" version="2.3.47.0" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
   <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />

--- a/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
+++ b/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
@@ -43,9 +43,9 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>

--- a/JustSaying.Messaging.UnitTests/app.config
+++ b/JustSaying.Messaging.UnitTests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/JustSaying.Messaging.UnitTests/packages.config
+++ b/JustSaying.Messaging.UnitTests/packages.config
@@ -4,7 +4,7 @@
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
   <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -39,8 +39,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\JustSaying.Models.2.0.0.43\lib\net40\JustSaying.Models.dll</HintPath>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute">

--- a/JustSaying.UnitTests/app.config
+++ b/JustSaying.UnitTests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/JustSaying.UnitTests/packages.config
+++ b/JustSaying.UnitTests/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoFixture" version="3.16.5" targetFramework="net40" />
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
   <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -44,9 +44,9 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.0.1\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/JustSaying/packages.config
+++ b/JustSaying/packages.config
@@ -3,5 +3,5 @@
   <package id="AWSSDK" version="2.3.47.0" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
-  <package id="NLog" version="4.0.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
update nLog nuget package from version 4.0.1. to version 4.1.0
Remove compiler warnings related to use of deprecated nLog method "ErrorException"