### PR TITLE
Update to latest nSubstitute v 1.6.1.0 -> v 1.8.2.0

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -48,8 +48,9 @@
       <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute">
-      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/JustSaying.AwsTools.IntegrationTests/packages.config
+++ b/JustSaying.AwsTools.IntegrationTests/packages.config
@@ -5,7 +5,7 @@
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="4.1.0" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
 </packages>

--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -47,8 +47,9 @@
       <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute">
-      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/JustSaying.AwsTools.UnitTests/packages.config
+++ b/JustSaying.AwsTools.UnitTests/packages.config
@@ -5,7 +5,7 @@
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="4.1.0" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
 </packages>

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -47,8 +47,9 @@
       <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute">
-      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -5,7 +5,7 @@
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="4.1.0" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
   <package id="structuremap" version="3.1.4.143" targetFramework="net40" />

--- a/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
+++ b/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
@@ -47,8 +47,9 @@
       <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute">
-      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/JustSaying.Messaging.UnitTests/packages.config
+++ b/JustSaying.Messaging.UnitTests/packages.config
@@ -5,7 +5,7 @@
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
   <package id="NLog" version="4.1.0" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
 </packages>

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -43,8 +43,9 @@
       <HintPath>..\packages\NLog.4.1.0\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute">
-      <HintPath>..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
@@ -4,7 +4,6 @@ using JustSaying.Messaging;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 using NSubstitute;
-using NSubstitute.Experimental;
 
 namespace JustSaying.UnitTests.JustSayingBus
 {

--- a/JustSaying.UnitTests/packages.config
+++ b/JustSaying.UnitTests/packages.config
@@ -4,7 +4,7 @@
   <package id="JustBehave" version="0.57" targetFramework="net40" />
   <package id="JustSaying.Models" version="2.0.0.43" targetFramework="net40" />
   <package id="NLog" version="4.1.0" targetFramework="net40" />
-  <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Update to latest nSubstitute v 1.6.1.0 -> v 1.8.2.0
`using NSubstitute.Experimental` is not needed any more in WhenRegisteringMessageHandlers.cs