### PR TITLE
Simple fix to a simple compiler warning!

### DIFF
--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -205,7 +205,8 @@ namespace JustSaying
                 {
                     Monitor.IssuePublishingMessage();
 
-                    Log.ErrorException(string.Format("Unable to publish message {0}", message.GetType().Name), ex);
+                    var errorMessage = "Unable to publish message " + message.GetType().Name;
+                    Log.Error(ex, errorMessage);
                     throw;
                 }
 


### PR DESCRIPTION
in nlog, ` Log.ErrorException(errorMessage, ex)` is deprecated in favour of `Log.Error(ex, errorMessage)`