### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can opt out during subscription configuration.
 ## Power tool
 
 JustSaying comes with a power tool console app that helps you mange your SQS queues from the command line.
-At this point, the power tool is only able to move arbitary number of messages from one queue to another.
+At this point, the power tool is only able to move arbitrary number of messages from one queue to another.
 ````
 JustSaying.Tools.exe move -from "source_queue_name" -to "destination_queue_name" -count "1"
 ````


### PR DESCRIPTION
@justeat, I've corrected a typographical error in the documentation of the [JustSaying](https://github.com/justeat/JustSaying) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.