### PR TITLE
Avoid the StructureMap warnings in integration tests

### DIFF
--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructureMapHandlerResolver.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructureMapHandlerResolver.cs
@@ -6,9 +6,16 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {
     public class StructureMapHandlerResolver : IHandlerResolver
     {
+        private readonly IContainer _container;
+
+        public StructureMapHandlerResolver(IContainer container)
+        {
+            _container = container;
+        }
+
         public IEnumerable<IHandler<T>> ResolveHandlers<T>()
         {
-            return ObjectFactory.GetAllInstances<IHandler<T>>();
+            return _container.GetAllInstances<IHandler<T>>();
         }
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringAHandlerViaContainerWithMissingRegistration.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringAHandlerViaContainerWithMissingRegistration.cs
@@ -1,5 +1,6 @@
 using JustBehave;
 using NUnit.Framework;
+using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {
@@ -13,14 +14,12 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         protected override void When()
         {
             base.When();
-            var handlerResolver = new StructureMapHandlerResolver();
+            var handlerResolver = new StructureMapHandlerResolver(new Container());
 
-            var subscriber = JustSaying.CreateMeABus.InRegion("eu-west-1")
+            CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
                 .IntoQueue("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);
-
-            subscriber.StartListening();
         }
 
         [Then]

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
@@ -12,13 +12,13 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 
         protected override void Given()
         {
-            ObjectFactory.Initialize(x => x.AddRegistry(new SingleHandlerRegistry()));
+           var container = new Container(x => x.AddRegistry(new SingleHandlerRegistry()));
 
-            var handlerResolver = new StructureMapHandlerResolver();
+           var handlerResolver = new StructureMapHandlerResolver(container);
 
             _handlerFuture = ((OrderProcessor)handlerResolver.ResolveHandlers<OrderPlaced>().Single()).Future;
 
-            var subscriber = JustSaying.CreateMeABus.InRegion("eu-west-1")
+            var subscriber = CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
                 .IntoQueue("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringMultipleHandlersViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringMultipleHandlersViaContainer.cs
@@ -6,23 +6,23 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {
     public class WhenRegisteringMultipleHandlersViaContainer : GivenAPublisher
     {
+        private IContainer _container;
+
         protected override void Given()
         {
             RecordAnyExceptionsThrown();
 
-            ObjectFactory.Initialize(x => x.AddRegistry(new MultipleHandlerRegistry()));
+            _container = new Container(x => x.AddRegistry(new MultipleHandlerRegistry()));
         }
 
         protected override void When()
         {
-            var handlerResolver = new StructureMapHandlerResolver();
+            var handlerResolver = new StructureMapHandlerResolver(_container);
 
-            var subscriber = JustSaying.CreateMeABus.InRegion("eu-west-1")
+            CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
                 .IntoQueue("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);
-
-            subscriber.StartListening();
         }
 
         [Test]
@@ -30,7 +30,5 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         {
             Assert.IsInstanceOf<NotSupportedException>(ThrownException);
         }
-
-        
     }
 }


### PR DESCRIPTION
Avoid the StructureMap warnings from using the obsolete global `ObjectFactory`
capture an `IContainer` instance instead