### PR TITLE
Assembly version no longer in topic name

### DIFF
--- a/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenPublishing.cs
@@ -3,6 +3,7 @@ using Amazon.SimpleNotificationService.Model;
 using JustSaying.AwsTools;
 using JustSaying.Messaging.MessageSerialisation;
 using JustBehave;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Models;
 using JustSaying.TestingFramework;
 using NSubstitute;
@@ -44,7 +45,7 @@ namespace AwsTools.UnitTests.Sns.TopicByName
         [Then]
         public void MessageSubjectIsObjectType()
         {
-            _sns.Received().Publish(Arg.Is<PublishRequest>(x => x.Subject == typeof(GenericMessage).Name));
+            _sns.Received().Publish(Arg.Is<PublishRequest>(x => x.Subject == typeof(GenericMessage).ToKey()));
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -9,6 +9,7 @@ using JustSaying.TestingFramework;
 using NSubstitute;
 using JustSaying.Messaging.MessageSerialisation;
 using System.Collections.Generic;
+using JustSaying.Messaging.Extensions;
 
 namespace AwsTools.UnitTests.SqsNotificationListener
 {
@@ -23,7 +24,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
         protected IMessageMonitor Monitor;
         protected IMessageSerialisationRegister SerialisationRegister;
         protected IMessageLock MessageLock;
-        private readonly string _messageTypeString = typeof(GenericMessage).ToString();
+        private readonly string _messageTypeString = typeof(GenericMessage).ToKey();
 
         protected override JustSaying.AwsTools.SqsNotificationListener CreateSystemUnderTest()
         {

--- a/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.AwsTools.UnitTests/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -5,6 +5,7 @@ using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
 using JustBehave;
+using JustSaying.Messaging.Extensions;
 using NSubstitute;
 using JustSaying.TestingFramework;
 
@@ -13,7 +14,7 @@ namespace AwsTools.UnitTests.SqsNotificationListener
     public class WhenThereAreExceptionsInSqsCalling : BaseQueuePollingTest
     {
         private int _sqsCallCounter;
-        private readonly string _messageTypeString = typeof(GenericMessage).ToString();
+        private readonly string _messageTypeString = typeof(GenericMessage).ToKey();
         protected override void Given()
         {
             Sqs = Substitute.For<IAmazonSQS>();

--- a/JustSaying.AwsTools/SnsTopicBase.cs
+++ b/JustSaying.AwsTools/SnsTopicBase.cs
@@ -3,6 +3,7 @@ using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
 using JustSaying.Messaging;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Messaging.MessageSerialisation;
 using NLog;
 using Message = JustSaying.Models.Message;
@@ -46,7 +47,7 @@ namespace JustSaying.AwsTools
         public void Publish(Message message)
         {
             var messageToSend = _serialisationRegister.GeTypeSerialiser(message.GetType()).Serialiser.Serialise(message);
-            var messageType = message.GetType().Name;
+            var messageType = message.GetType().ToKey();
 
             Client.Publish(new PublishRequest
                                {

--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -183,7 +183,7 @@ namespace JustSaying.AwsTools
                         var watch = new System.Diagnostics.Stopwatch();
                         watch.Start();
 
-                        handlingSucceeded = handle(typedMessage);
+                        handlingSucceeded &= handle(typedMessage);
 
                         watch.Stop();
                         Log.Trace("Handled message - MessageType: " + messageType);

--- a/JustSaying.AwsTools/SqsPublisher.cs
+++ b/JustSaying.AwsTools/SqsPublisher.cs
@@ -1,6 +1,7 @@
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.Messaging;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Messaging.MessageSerialisation;
 using Newtonsoft.Json;
 using Message = JustSaying.Models.Message;
@@ -31,7 +32,7 @@ namespace JustSaying.AwsTools
         private string GetMessageInContext(Message message)
         {
             var serializedMessage = _serialisationRegister.GeTypeSerialiser(message.GetType()).Serialiser.Serialise(message);
-            var context = new { Subject = message.GetType().Name, Message = serializedMessage };
+            var context = new { Subject = message.GetType().ToKey(), Message = serializedMessage };
             return JsonConvert.SerializeObject(context);
         }
     }

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
@@ -1,4 +1,5 @@
 using JustBehave;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.TestingFramework;
 using Newtonsoft.Json;
@@ -23,7 +24,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
 
         public string GetMessageInContext(MessageWithEnum message)
         {
-            var context = new { Subject = message.GetType().Name, Message = SystemUnderTest.Serialise(message) };
+            var context = new { Subject = message.GetType().ToKey(), Message = SystemUnderTest.Serialise(message) };
             return JsonConvert.SerializeObject(context);
         }
 

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingAGenericSerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingAGenericSerialiser.cs
@@ -1,4 +1,5 @@
 using JustBehave;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 using NUnit.Framework;
@@ -19,7 +20,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
         [Then]
         public void MappingsCanBeRetreivedByStringType()
         {
-            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).Name));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).ToKey()));
         }
 
         [Test]

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiser.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiser.cs
@@ -1,4 +1,5 @@
 using JustBehave;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 using NSubstitute;
@@ -18,7 +19,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
         [Then]
         public void MappingsCanBeRetreivedByStringType()
         {
-            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).Name));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).ToKey()));
         }
 
         [Test]

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
@@ -1,4 +1,5 @@
 using JustBehave;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 using NSubstitute;
@@ -28,7 +29,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
         [Then]
         public void TheMappingContainsTheSerialiser()
         {
-            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).Name));
+            Assert.NotNull(SystemUnderTest.GeTypeSerialiser(typeof(Message).ToKey()));
         }
     }
 }

--- a/JustSaying.Messaging/Extensions/TypeExtensions.cs
+++ b/JustSaying.Messaging/Extensions/TypeExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace JustSaying.Messaging.Extensions
+{
+    public static class TypeExtensions
+    {
+        public static string ToKey(this Type type)
+        {
+            return string.Join("_", type.Flatten().Select(t => Regex.Replace(t.Name + "_" + t.Namespace, "\\W", "_"))).TruncateTo(100);
+        }
+
+        private static IEnumerable<Type> Flatten(this Type type)
+        {
+            yield return type;
+            foreach (var inner in type.GetGenericArguments().SelectMany(t => t.Flatten()))
+            {
+                yield return inner;
+            }
+        }
+
+        private static string TruncateTo(this string name, int maxLength)
+        {
+            if (name.Length <= maxLength) return name;
+
+            var suffix = name.GetInvariantHashCode().ToString();
+            name = name.Substring(0, maxLength - suffix.Length) + suffix;
+
+            return name;
+        }
+
+        private static int GetInvariantHashCode(this string value)
+        {
+            return value.Aggregate(5381, (current, character) => (current * 397) ^ character);
+        }
+
+    }
+}

--- a/JustSaying.Messaging/JustSaying.Messaging.csproj
+++ b/JustSaying.Messaging/JustSaying.Messaging.csproj
@@ -45,6 +45,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="Interrogation\IAmJustInterrogating.cs" />
     <Compile Include="Interrogation\IInterrogationResponse.cs" />
     <Compile Include="Interrogation\INotificationSubscriberInterrogation.cs" />

--- a/JustSaying.Messaging/MessageHandling/ExactlyOnceHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/ExactlyOnceHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Models;
 
 namespace JustSaying.Messaging.MessageHandling
@@ -23,7 +24,7 @@ namespace JustSaying.Messaging.MessageHandling
         
         public bool Handle(T message)
         {
-            var lockKey = string.Format("{2}-{1}-{0}", _handlerName, typeof(T).Name.ToLower(), message.UniqueKey());
+            var lockKey = string.Format("{2}-{1}-{0}", _handlerName, typeof(T).ToKey().ToLower(), message.UniqueKey());
             var lockResponse = _messageLock.TryAquireLock(lockKey, TimeSpan.FromSeconds(_timeOut));
             if (!lockResponse.DoIHaveExclusiveLock)
             {

--- a/JustSaying.Messaging/MessageSerialisation/MessageSerialisationRegister.cs
+++ b/JustSaying.Messaging/MessageSerialisation/MessageSerialisationRegister.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using JustSaying.Messaging.Extensions;
 using JustSaying.Models;
 
 namespace JustSaying.Messaging.MessageSerialisation
@@ -20,12 +21,12 @@ namespace JustSaying.Messaging.MessageSerialisation
 
         public TypeSerialiser GeTypeSerialiser(Type objectType)
         {
-            return _map[objectType.Name];
+            return _map[objectType.ToKey()];
         }
 
         public void AddSerialiser<T>(IMessageSerialiser serialiser) where T : Message
         {
-            var keyname = typeof (T).Name;
+            var keyname = typeof(T).ToKey();
             if (! _map.ContainsKey(keyname))
                 _map.Add(keyname, new TypeSerialiser(typeof(T), serialiser));
         }

--- a/JustSaying/Extensions/TypeExtensions.cs
+++ b/JustSaying/Extensions/TypeExtensions.cs
@@ -1,31 +1,49 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace JustSaying.Extensions
 {
-    internal static class TypeExtensions
+    public static class TypeExtensions
     {
         private const int MAX_TOPIC_NAME_LENGTH = 256;
 
         public static string ToTopicName(this Type type)
         {
-            var name = type.IsGenericType
-                ? Regex.Replace(type.FullName, "\\W", "_").ToLower()
-                : type.Name.ToLower();
-
-            if (name.Length > MAX_TOPIC_NAME_LENGTH)
-            {
-                var suffix = name.GetInvariantHashCode().ToString();
-                name = name.Substring(0, MAX_TOPIC_NAME_LENGTH - suffix.Length) + suffix;
-            }
-
+            var name = type.GetTopicName().TruncateTo(MAX_TOPIC_NAME_LENGTH);
             return name;
         }
 
         private static int GetInvariantHashCode(this string value)
         {
-            return value.Aggregate(5381, (current, character) => (current*397) ^ character);
+            return value.Aggregate(5381, (current, character) => (current * 397) ^ character);
+        }
+
+        private static string GetTopicName(this Type type)
+        {
+            var list = new List<string>();
+            RecursiveGetTopicName(type, list);
+            return string.Join("-", list);
+        }
+
+        private static string TruncateTo(this string name, int maxLength)
+        {
+            if (name.Length <= maxLength) return name;
+
+            var suffix = name.GetInvariantHashCode().ToString();
+            name = name.Substring(0, maxLength - suffix.Length) + suffix;
+
+            return name;
+        }
+
+        private static void RecursiveGetTopicName(Type type, ICollection<string> types)
+        {
+            types.Add(Regex.Replace(type.Name, "\\W", "_").ToLower());
+            foreach (var innerType in type.GetGenericArguments())
+            {
+                RecursiveGetTopicName(innerType, types);
+            }
         }
     }
 }

--- a/JustSaying/Extensions/TypeExtensions.cs
+++ b/JustSaying/Extensions/TypeExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
+using JustSaying.Messaging.Extensions;
 
 namespace JustSaying.Extensions
 {
@@ -11,20 +10,8 @@ namespace JustSaying.Extensions
 
         public static string ToTopicName(this Type type)
         {
-            var name = type.GetTopicName().TruncateTo(MAX_TOPIC_NAME_LENGTH);
+            var name = type.ToKey().TruncateTo(MAX_TOPIC_NAME_LENGTH);
             return name;
-        }
-
-        private static int GetInvariantHashCode(this string value)
-        {
-            return value.Aggregate(5381, (current, character) => (current * 397) ^ character);
-        }
-
-        private static string GetTopicName(this Type type)
-        {
-            var list = new List<string>();
-            RecursiveGetTopicName(type, list);
-            return string.Join("-", list);
         }
 
         private static string TruncateTo(this string name, int maxLength)
@@ -37,13 +24,10 @@ namespace JustSaying.Extensions
             return name;
         }
 
-        private static void RecursiveGetTopicName(Type type, ICollection<string> types)
+
+        private static int GetInvariantHashCode(this string value)
         {
-            types.Add(Regex.Replace(type.Name, "\\W", "_").ToLower());
-            foreach (var innerType in type.GetGenericArguments())
-            {
-                RecursiveGetTopicName(innerType, types);
-            }
+            return value.Aggregate(5381, (current, character) => (current*397) ^ character);
         }
     }
 }


### PR DESCRIPTION
The topic name extension used type.FullName. This caused an issue in an Amazon policy as we increment our assembly versions.