### PR TITLE
Fix - Interrogation result was returning duplicate registrations

### DIFF
--- a/JustSaying.AwsTools/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/SqsNotificationListener.cs
@@ -83,7 +83,7 @@ namespace JustSaying.AwsTools
                 handler = new StopwatchHandler<T>(handler, executionTimeMonitoring);
             }
 
-            Subscribers.Add(new Subsriber(typeof(T)));
+            Subscribers.Add(new Subscriber(typeof(T)));
             handlers.Add(message => handler.Handle((T)message));
         }
 

--- a/JustSaying.Messaging/Interrogation/IInterrogationResponse.cs
+++ b/JustSaying.Messaging/Interrogation/IInterrogationResponse.cs
@@ -4,6 +4,7 @@ namespace JustSaying.Messaging.Interrogation
 {
     public interface IInterrogationResponse
     {
+        IEnumerable<string> Regions { get; set; } 
         IEnumerable<ISubscriber> Subscribers { get; set; }
         IEnumerable<IPublisher> Publishers { get; set; }
     }

--- a/JustSaying.Messaging/Interrogation/InterrogationResponse.cs
+++ b/JustSaying.Messaging/Interrogation/InterrogationResponse.cs
@@ -4,12 +4,14 @@ namespace JustSaying.Messaging.Interrogation
 {
     public class InterrogationResponse : IInterrogationResponse
     {
-        public InterrogationResponse(IEnumerable<ISubscriber> subscribers, IEnumerable<IPublisher> publishers)
+        public InterrogationResponse(IEnumerable<string> regions, IEnumerable<ISubscriber> subscribers, IEnumerable<IPublisher> publishers)
         {
+            Regions = regions;
             Subscribers = subscribers;
             Publishers = publishers;
         }
 
+        public IEnumerable<string> Regions { get; set; } 
         public IEnumerable<ISubscriber> Subscribers { get; set; }
         public IEnumerable<IPublisher> Publishers { get; set; }
     }

--- a/JustSaying.Messaging/Interrogation/Publisher.cs
+++ b/JustSaying.Messaging/Interrogation/Publisher.cs
@@ -10,5 +10,15 @@ namespace JustSaying.Messaging.Interrogation
         }
 
         public Type MessageType { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return MessageType == ((Publisher)obj).MessageType;
+        }
+
+        public override int GetHashCode()
+        {
+            return (MessageType != null ? MessageType.GetHashCode() : 0);
+        }
     }
 }

--- a/JustSaying.Messaging/Interrogation/Subscriber.cs
+++ b/JustSaying.Messaging/Interrogation/Subscriber.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace JustSaying.Messaging.Interrogation
 {
-    public class Subsriber : ISubscriber
+    public class Subscriber : ISubscriber
     {
-        public Subsriber(Type messageType)
+        public Subscriber(Type messageType)
         {
             MessageType = messageType;
         }
@@ -13,7 +13,7 @@ namespace JustSaying.Messaging.Interrogation
 
         public override bool Equals(object obj)
         {
-            return MessageType == ((Subsriber)obj).MessageType;
+            return MessageType == ((Subscriber)obj).MessageType;
         }
 
         public override int GetHashCode()

--- a/JustSaying.Messaging/Interrogation/Subsriber.cs
+++ b/JustSaying.Messaging/Interrogation/Subsriber.cs
@@ -10,5 +10,15 @@ namespace JustSaying.Messaging.Interrogation
         }
 
         public Type MessageType { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return MessageType == ((Subsriber)obj).MessageType;
+        }
+
+        public override int GetHashCode()
+        {
+            return (MessageType != null ? MessageType.GetHashCode() : 0);
+        }
     }
 }

--- a/JustSaying.Messaging/JustSaying.Messaging.csproj
+++ b/JustSaying.Messaging/JustSaying.Messaging.csproj
@@ -52,7 +52,7 @@
     <Compile Include="Interrogation\IPublisher.cs" />
     <Compile Include="Interrogation\ISubscriber.cs" />
     <Compile Include="Interrogation\Publisher.cs" />
-    <Compile Include="Interrogation\Subsriber.cs" />
+    <Compile Include="Interrogation\Subscriber.cs" />
     <Compile Include="MessageHandling\ExactlyOnceAttribute.cs" />
     <Compile Include="MessageHandling\ExactlyOnceHandler.cs" />
     <Compile Include="MessageHandling\FutureHandler.cs" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="JustSayingBus\CustomMonitor.cs" />
     <Compile Include="JustSayingBus\GivenAServiceBusWithoutMonitoring.cs" />
     <Compile Include="JustSayingBus\WhenPublishingMessageWithoutMonitor.cs" />
+    <Compile Include="JustSayingBus\WhenUsingMultipleRegions.cs" />
     <Compile Include="JustSayingFluentlyTestBase.cs" />
     <Compile Include="JustSayingFluently\AddingHandlers\WhenAddingASubscriptionHandlerForAGenericMessage.cs" />
     <Compile Include="JustSayingFluently\AddingHandlers\WhenSubscribingPointToPoint.cs" />

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
@@ -23,12 +23,12 @@ namespace JustSaying.UnitTests.JustSayingBus
             _subscriber1.Queue.Returns("queue1");
             _subscriber1.Subscribers.Returns(new Collection<ISubscriber>
             {
-                new Subsriber(typeof (OrderAccepted)),
-                new Subsriber(typeof (OrderRejected))
+                new Subscriber(typeof (OrderAccepted)),
+                new Subscriber(typeof (OrderRejected))
             });
             _subscriber2 = Substitute.For<INotificationSubscriber>();
             _subscriber2.Queue.Returns("queue2");
-            _subscriber2.Subscribers.Returns(new Collection<ISubscriber> {new Subsriber(typeof (GenericMessage))});
+            _subscriber2.Subscribers.Returns(new Collection<ISubscriber> {new Subscriber(typeof (GenericMessage))});
         }
 
         protected override void When()

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
@@ -1,26 +1,44 @@
+using System.Linq;
 using JustBehave;
+using JustSaying.Messaging;
 using JustSaying.Models;
+using NSubstitute;
 using NUnit.Framework;
+using Shouldly;
 
 namespace JustSaying.UnitTests.JustSayingBus
 {
     public class WhenRegisteringTheSamePublisherTwice : GivenAServiceBus
     {
+        private IMessagePublisher _publisher;
+
         protected override void Given()
         {
+            base.Given();
+            _publisher = Substitute.For<IMessagePublisher>();
             RecordAnyExceptionsThrown();
         }
 
         protected override void When()
         {
-            SystemUnderTest.AddMessagePublisher<Message>(null, string.Empty);
-            SystemUnderTest.AddMessagePublisher<Message>(null, string.Empty);
+            SystemUnderTest.AddMessagePublisher<Message>(_publisher, string.Empty);
+            SystemUnderTest.AddMessagePublisher<Message>(_publisher, string.Empty);
         }
 
         [Then]
-        public void AnExceptionIsThrown()
+        public void NoExceptionIsThrown()
         {
-            Assert.NotNull(ThrownException);
+            // Specifying failover regions mean that messages can be registered more than once.
+            Assert.Null(ThrownException);
         }
+
+        [Then]
+        public void AndInterrogationShowsNonDuplicatedPublishers()
+        {
+            var response = SystemUnderTest.WhatDoIHave();
+
+            response.Publishers.Count().ShouldBe(1);
+            response.Publishers.First(x => x.MessageType == typeof(Message)).ShouldNotBe(null);
+        } 
     }
 }

--- a/JustSaying.UnitTests/JustSayingBus/WhenUsingMultipleRegions.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenUsingMultipleRegions.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using JustBehave;
+using Shouldly;
+
+namespace JustSaying.UnitTests.JustSayingBus
+{
+    public class WhenUsingMultipleRegions : GivenAServiceBus
+    {
+        protected override void Given()
+        {
+            base.Given();
+            Config.Regions.Returns(new List<string>{"region1", "region2"});
+        }
+
+        protected override void When()
+        {
+        }
+
+        [Then]
+        public void RegionsAreReturnedInTheInterrogationResult()
+        {
+            var response = SystemUnderTest.WhatDoIHave();
+
+            response.Regions.Count().ShouldBe(2);
+            response.Regions.ShouldContain("region1");
+            response.Regions.ShouldContain("region2");
+        }
+    }
+}

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -216,7 +216,7 @@ namespace JustSaying
         }
         public IInterrogationResponse WhatDoIHave()
         {
-            return new InterrogationResponse(_subscribers, _publishers);
+            return new InterrogationResponse(Config.Regions, _subscribers, _publishers);
         }
     }
 }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -31,8 +31,8 @@ namespace JustSaying
         public IMessageLock MessageLock { get; set; }
         private static readonly Logger Log = LogManager.GetLogger("JustSaying"); //ToDo: danger!
         private readonly object _syncRoot = new object();
-        private readonly IList<IPublisher> _publishers;
-        private readonly IList<ISubscriber> _subscribers;
+        private readonly ICollection<IPublisher> _publishers;
+        private readonly ICollection<ISubscriber> _subscribers;
 
         public JustSayingBus(IMessagingConfig config, IMessageSerialisationRegister serialisationRegister)
         {
@@ -47,9 +47,8 @@ namespace JustSaying
             _subscribersByRegionAndQueue = new Dictionary<string, Dictionary<string, INotificationSubscriber>>();
             _publishersByRegionAndTopic = new Dictionary<string, Dictionary<string, IMessagePublisher>>();
             SerialisationRegister = serialisationRegister;
-            _publishers = new List<IPublisher>();
-            _subscribers = new List<ISubscriber>();
-            _subscribers = new List<ISubscriber>();
+            _publishers = new HashSet<IPublisher>();
+            _subscribers = new HashSet<ISubscriber>();
         }
 
         public void AddNotificationSubscriber(string region, INotificationSubscriber subscriber)


### PR DESCRIPTION
when failover region(s) were specified.  Existing unit test WhenRegisteringTheSamePublisherTwice was not functioning as intended.