### PR TITLE
Allow message TimeStamp to be set when deserializing

### DIFF
--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -11,7 +11,7 @@ namespace JustSaying.Models
         }
 
         public Guid Id { get; set; }
-        public DateTime TimeStamp { get; private set; }
+        public DateTime TimeStamp { get; set; }
         public string RaisingComponent { get; set; }
         public string Version{ get; private set; }
         public string SourceIp { get; private set; }


### PR DESCRIPTION
Made TimeStamp property setter public so that Json.NET can restore it's state to whatever is in the json, rather than leaving it to the time of when it was deserialized.