### PR TITLE
Multiple queue creation (issue #86)

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicHandlingThrottlingTest.cs" />
+    <Compile Include="ProxyAwsClientFactory.cs" />
     <Compile Include="DynamoDbStoreIntregrationTests.cs" />
     <Compile Include="DynamoTableTests.cs" />
     <Compile Include="GlobalSetup.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="WhenIAccessAnExistingQueueWithoutAnErrorQueue.cs" />
     <Compile Include="WhenICreateAQueueByName.cs" />
     <Compile Include="WhenQueueIsDeleted.cs" />
+    <Compile Include="WhenSettingUpMultipleHandlers.cs" />
     <Compile Include="WhenUpdatingDeliveryDelay.cs" />
     <Compile Include="WhenUpdatingRedrivePolicy.cs" />
     <Compile Include="WhenUpdatingRetentionPeriod.cs" />

--- a/JustSaying.AwsTools.IntegrationTests/ProxyAwsClientFactory.cs
+++ b/JustSaying.AwsTools.IntegrationTests/ProxyAwsClientFactory.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using Amazon;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using NSubstitute;
+
+namespace JustSaying.AwsTools.IntegrationTests
+{
+    /// <summary>
+    /// An AWS Client Factory which forwards all AWS calls to SNS/SQS clients
+    /// and stores all calls in a dictionary.
+    /// 
+    /// Use to inspect what operations and which arguments have been passed
+    /// </summary>
+    public class ProxyAwsClientFactory : IAwsClientFactory
+    {
+        /// <summary>
+        /// Root dictionary key is aws operation, such as ListTopics, GetQueue, etc.
+        /// 
+        /// Each inner dictionary contains a grouped collection of calls to that operator. Key for the grouping 
+        /// is chosen on a per operation basis, but in many cases this is the queue or topic name.
+        /// 
+        /// List of objects is the full list of arguments when that call was made.
+        /// </summary>
+        private Dictionary<string, Dictionary<string, List<object>>> counters;
+
+        public ProxyAwsClientFactory()
+        {
+            this.counters = new Dictionary<string, Dictionary<string, List<object>>>();
+        }
+
+
+        public Dictionary<string, Dictionary<string, List<object>>> Counters
+        {
+            get { return counters; }
+        }
+
+        public IAmazonSimpleNotificationService GetSnsClient(RegionEndpoint region)
+        {
+            var innerClient = CreateMeABus.DefaultClientFactory().GetSnsClient(region);
+            var client = Substitute.For<IAmazonSimpleNotificationService>();
+
+            client.CreateTopic(Arg.Any<CreateTopicRequest>())
+                .ReturnsForAnyArgs(r => innerClient.CreateTopic(r.Arg<CreateTopicRequest>()))
+                .AndDoes(r => Increment("CreateTopic", r.Arg<CreateTopicRequest>().Name, r.Arg<CreateTopicRequest>()));
+
+            client.FindTopic(Arg.Any<string>())
+                .ReturnsForAnyArgs(r => innerClient.FindTopic(r.Arg<string>()))
+                .AndDoes(r => Increment("FindTopic", r.Arg<string>(), r.Arg<string>()));
+
+            return client;
+        }
+
+        private void Increment(string operationName, string paramKey, params object[] extraParams)
+        {
+            if (counters.ContainsKey(operationName) == false)
+                counters[operationName] = new Dictionary<string, List<object>>();
+
+            var operation = counters[operationName];
+            if (operation.ContainsKey(paramKey) == false)
+                operation.Add(paramKey, new List<object>());
+
+            var paramOperation = operation[paramKey];
+            paramOperation.Add(extraParams);
+        }
+
+        public IAmazonSQS GetSqsClient(RegionEndpoint region)
+        {
+            var innerClient = CreateMeABus.DefaultClientFactory().GetSqsClient(region);
+            var client = Substitute.For<IAmazonSQS>();
+
+            client.ListQueues(Arg.Any<ListQueuesRequest>())
+                .ReturnsForAnyArgs(r => innerClient.ListQueues(r.Arg<ListQueuesRequest>()))
+                .AndDoes(r => Increment("ListQueues", r.Arg<ListQueuesRequest>().QueueNamePrefix, r.Arg<ListQueuesRequest>()));
+
+            client.CreateQueue(Arg.Any<CreateQueueRequest>())
+                .ReturnsForAnyArgs(r => innerClient.CreateQueue(r.Arg<CreateQueueRequest>()))
+                .AndDoes(r => Increment("CreateQueue", r.Arg<CreateQueueRequest>().QueueName, r.Arg<CreateQueueRequest>()));
+
+            client.GetQueueAttributes(Arg.Any<GetQueueAttributesRequest>())
+                .ReturnsForAnyArgs(r => innerClient.GetQueueAttributes(r.Arg<GetQueueAttributesRequest>()))
+                .AndDoes(r => Increment("GetQueueAttributes", r.Arg<GetQueueAttributesRequest>().QueueUrl, r.Arg<GetQueueAttributesRequest>()));
+
+            client.ReceiveMessageAsync(Arg.Any<ReceiveMessageRequest>())
+                .ReturnsForAnyArgs(r => innerClient.ReceiveMessageAsync(r.Arg<ReceiveMessageRequest>()))
+                .AndDoes(r => Increment("ReceiveMessageAsync", r.Arg<ReceiveMessageRequest>().QueueUrl, r.Arg<ReceiveMessageRequest>()));
+
+            return client;
+        }
+    }
+}

--- a/JustSaying.AwsTools.IntegrationTests/SqsQueueIntegrationTests.cs
+++ b/JustSaying.AwsTools.IntegrationTests/SqsQueueIntegrationTests.cs
@@ -15,7 +15,9 @@ namespace JustSaying.AwsTools.IntegrationTests
         protected override SqsQueueByName CreateSystemUnderTest()
         {
             QueueUniqueKey = "test" + DateTime.Now.Ticks;
-            return new SqsQueueByName(RegionEndpoint.EUWest1, QueueUniqueKey, CreateMeABus.DefaultClientFactory().GetSqsClient(RegionEndpoint.EUWest1), 1);
+            var queue = new SqsQueueByName(RegionEndpoint.EUWest1, QueueUniqueKey, CreateMeABus.DefaultClientFactory().GetSqsClient(RegionEndpoint.EUWest1), 1);
+            queue.Exists();
+            return queue;
         }
         public override void PostAssertTeardown()
         {

--- a/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlers.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlers.cs
@@ -1,0 +1,106 @@
+using System;
+using Amazon;
+using JustBehave;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Messaging.MessageHandling;
+using NUnit.Framework;
+
+namespace JustSaying.AwsTools.IntegrationTests
+{
+    [TestFixture]
+    public class WhenSettingUpMultipleHandlers : BehaviourTest<IHaveFulfilledSubscriptionRequirements>
+    {
+        public class Order : JustSaying.Models.Message
+        {
+        }
+
+        public class OrderHandler : IHandler<Order>
+        {
+            public bool Handle(Order message)
+            {
+                return true;
+            }
+        }
+
+        public class UniqueTopicAndQueueNames : INamingStrategy
+        {
+            private readonly long ticks = DateTime.UtcNow.Ticks;
+
+            public string GetTopicName(string topicName, string messageType)
+            {
+                return (messageType + ticks).ToLower();
+            }
+
+            public string GetQueueName(SqsReadConfiguration sqsConfig, string messageType)
+            {
+                return (sqsConfig.BaseQueueName + ticks).ToLower();
+            }
+        }
+
+        protected string QueueUniqueKey;
+        private UniqueTopicAndQueueNames uniqueTopicAndQueueNames;
+        private ProxyAwsClientFactory proxyAwsClientFactory;
+        IHaveFulfilledSubscriptionRequirements bus;
+        private string topicName;
+        private string queueName;
+
+        protected override void Given()
+        { }
+
+        protected override IHaveFulfilledSubscriptionRequirements CreateSystemUnderTest()
+        {
+            // Given 2 handlers
+            uniqueTopicAndQueueNames = new UniqueTopicAndQueueNames();
+            proxyAwsClientFactory = new ProxyAwsClientFactory();
+
+            var baseQueueName = "CustomerOrders_";
+            topicName = uniqueTopicAndQueueNames.GetTopicName(string.Empty, typeof(Order).Name);
+            queueName = uniqueTopicAndQueueNames.GetQueueName(new SqsReadConfiguration(SubscriptionType.ToTopic) {BaseQueueName = baseQueueName }, typeof(Order).Name);
+
+            bus = CreateMeABus.InRegion(RegionEndpoint.EUWest1.SystemName)
+                .WithAwsClientFactory(() => proxyAwsClientFactory)
+                .WithNamingStrategy(() => uniqueTopicAndQueueNames)
+                .WithSqsTopicSubscriber()
+                .IntoQueue(baseQueueName) // generate unique queue name
+                .WithMessageHandler<Order>(new OrderHandler())
+                .WithMessageHandler<Order>(new OrderHandler());
+
+            bus
+                .StartListening();
+            return bus;
+        }
+        public override void PostAssertTeardown()
+        {
+            SystemUnderTest.StopListening();
+            base.PostAssertTeardown();
+        }
+
+        protected override void When()
+        {
+        }
+
+        [Test]
+        public void CreateTopicCalledOnce()
+        {
+            Assert.That(proxyAwsClientFactory.Counters["CreateTopic"][topicName].Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void FindTopicCalledOnce()
+        {
+            Assert.That(proxyAwsClientFactory.Counters["FindTopic"][topicName].Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ListQueuesCalledOnce()
+        {
+            Assert.That(proxyAwsClientFactory.Counters["ListQueues"][queueName].Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CreateQueueCalledOnce()
+        {
+            Assert.That(proxyAwsClientFactory.Counters["CreateQueue"][queueName].Count, Is.EqualTo(1));
+        }
+    }
+}

--- a/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sns/TopicByName/WhenPublishing.cs
@@ -19,7 +19,9 @@ namespace AwsTools.UnitTests.Sns.TopicByName
 
         protected override SnsTopicByName CreateSystemUnderTest()
         {
-            return new SnsTopicByName(TopicName, _sns, _serialisationRegister);
+            var topic = new SnsTopicByName(TopicName, _sns, _serialisationRegister);
+            topic.Exists();
+            return topic;
         }
 
         protected override void Given()

--- a/JustSaying.AwsTools.UnitTests/Sqs/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/Sqs/WhenPublishing.cs
@@ -19,7 +19,9 @@ namespace JustSaying.AwsTools.UnitTests.Sqs
 
         protected override SqsPublisher CreateSystemUnderTest()
         {
-            return new SqsPublisher(RegionEndpoint.EUWest1, QueueName, _sqs, 0, _serialisationRegister);
+            var sqs = new SqsPublisher(RegionEndpoint.EUWest1, QueueName, _sqs, 0, _serialisationRegister);
+            sqs.Exists();
+            return sqs;
         }
 
         protected override void Given()

--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -64,8 +64,10 @@
     <Compile Include="IAwsClientFactoryProxy.cs" />
     <Compile Include="IAwsClientFactory.cs" />
     <Compile Include="QueueCreation\AmazonQueueCreator.cs" />
+    <Compile Include="QueueCreation\IRegionResourceCache.cs" />
     <Compile Include="QueueCreation\IVerifyAmazonQueues.cs" />
     <Compile Include="QueueCreation\RedrivePolicy.cs" />
+    <Compile Include="QueueCreation\RegionResourceCache.cs" />
     <Compile Include="QueueCreation\SqsBasicConfiguration.cs" />
     <Compile Include="QueueCreation\SqsReadConfiguration.cs" />
     <Compile Include="DynamoTable.cs" />

--- a/JustSaying.AwsTools/QueueCreation/IRegionResourceCache.cs
+++ b/JustSaying.AwsTools/QueueCreation/IRegionResourceCache.cs
@@ -1,0 +1,8 @@
+namespace JustSaying.AwsTools.QueueCreation
+{
+    public interface IRegionResourceCache<T>
+    {
+        T TryGetFromCache(string region, string key);
+        void AddToCache(string region, string key, T value);
+    }
+}

--- a/JustSaying.AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying.AwsTools/QueueCreation/RegionResourceCache.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace JustSaying.AwsTools.QueueCreation
+{
+    public class RegionResourceCache<T> : Dictionary<string, Dictionary<string, T>>, IRegionResourceCache<T>
+    {
+        public T TryGetFromCache(string region, string key)
+        {
+            if (this.ContainsKey(region) == false)
+                return default(T);
+            var regionDict = this[region];
+
+            if (regionDict.ContainsKey(key) == false)
+                return default(T);
+            return regionDict[key];
+        }
+
+        public void AddToCache(string region, string key, T value)
+        {
+            if (this.ContainsKey(region) == false)
+                this[region] = new Dictionary<string, T>();
+            var regionDict = this[region];
+            regionDict[key] = value;
+        }
+    }
+}

--- a/JustSaying.AwsTools/SnsTopicByName.cs
+++ b/JustSaying.AwsTools/SnsTopicByName.cs
@@ -15,11 +15,13 @@ namespace JustSaying.AwsTools
         {
             TopicName = topicName;
             Client = client;
-            Exists();
         }
 
         public override bool Exists()
         {
+            if (string.IsNullOrWhiteSpace(Arn) == false)
+                return true;
+
             Log.Info("Checking if topic '{0}' exists", TopicName);
             var topic = Client.FindTopic(TopicName);
 

--- a/JustSaying.AwsTools/SqsQueueByNameBase.cs
+++ b/JustSaying.AwsTools/SqsQueueByNameBase.cs
@@ -18,7 +18,6 @@ namespace JustSaying.AwsTools
             : base(region, client)
         {
             QueueName = queueName;
-            Exists();
         }
 
         public override bool Exists()

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -31,7 +31,7 @@ namespace JustSaying
         protected readonly IAmJustSaying Bus;
         private SqsReadConfiguration _subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic);
         private IMessageSerialisationFactory _serialisationFactory;
-        private Func<INamingStrategy> busNamingStrategyFunc;
+        private Func<INamingStrategy> _busNamingStrategyFunc;
 
         internal protected JustSayingFluently(IAmJustSaying bus, IVerifyAmazonQueues queueCreator, IAwsClientFactoryProxy awsClientFactoryProxy)
         {
@@ -47,8 +47,8 @@ namespace JustSaying
 
         public virtual INamingStrategy GetNamingStrategy()
         {
-            if (busNamingStrategyFunc != null)
-                return busNamingStrategyFunc();
+            if (_busNamingStrategyFunc != null)
+                return _busNamingStrategyFunc();
             return new DefaultNamingStrategy();
         }
 
@@ -369,7 +369,7 @@ namespace JustSaying
 
         public IMayWantOptionalSettings WithNamingStrategy(Func<INamingStrategy> busNamingStrategy)
         {
-            this.busNamingStrategyFunc = busNamingStrategy;
+            this._busNamingStrategyFunc = busNamingStrategy;
             return this;
         }
 


### PR DESCRIPTION
This PR addresses issue #86. Queue and topic list and create operations are ran more often than needed. If a queue has been created, it is unnecessary to run another `ListQueue` request to check the existence of the queue.

The bulk of the changes relate to making the tests pass in fixture `WhenSettingUpMultipleHandlers`. 

This PR depends on #133, and will need to be rebased before merging.

