### PR TITLE
Integration tests for AppVeyor

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/GlobalSetup.cs
+++ b/JustSaying.AwsTools.IntegrationTests/GlobalSetup.cs
@@ -1,4 +1,3 @@
-using Amazon.Runtime;
 using JustSaying.TestingFramework;
 using NUnit.Framework;
 
@@ -10,7 +9,7 @@ namespace JustSaying.AwsTools.IntegrationTests
         [SetUp]
         public void SetUp()
         {
-            CreateMeABus.DefaultClientFactory = () => new DefaultAwsClientFactory(new StoredProfileAWSCredentials(IntegrationTestConfig.AwsProfileName));
+            CreateMeABus.DefaultClientFactory = () => new IntegrationAwsClientFactory();
         }
     }
 }

--- a/JustSaying.IntegrationTests/GlobalSetup.cs
+++ b/JustSaying.IntegrationTests/GlobalSetup.cs
@@ -1,5 +1,3 @@
-using Amazon.Runtime;
-using JustSaying.AwsTools;
 using JustSaying.TestingFramework;
 using NUnit.Framework;
 
@@ -11,7 +9,7 @@ namespace JustSaying.IntegrationTests
         [SetUp]
         public void SetUp()
         {
-            CreateMeABus.DefaultClientFactory = () => new DefaultAwsClientFactory(new StoredProfileAWSCredentials(IntegrationTestConfig.AwsProfileName));
+            CreateMeABus.DefaultClientFactory = () => new IntegrationAwsClientFactory();
         }
     }
 }

--- a/JustSaying.TestingFramework/IntegrationAwsClientFactory.cs
+++ b/JustSaying.TestingFramework/IntegrationAwsClientFactory.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+using JustSaying.AwsTools;
+
+namespace JustSaying.TestingFramework
+{
+    /// <summary>
+    /// AwsCustomClient factory for running integration tests in continuous integration mode.
+    /// 
+    /// If environment variable "ci" is not defined, use default AWS profile name as specified by <code>IntegrationTestConfig.AwsProfileName</code>
+    /// 
+    /// Otherwise, construct AWS Profile using access and secret key by looking at "ci-access_key" and "ci-secret_key" environment variables.
+    /// </summary>
+    public class IntegrationAwsClientFactory : IAwsClientFactory
+    {
+        private readonly AWSCredentials _credentials;
+        private readonly string _ci = "ci";
+        private readonly string _ciAccesskey = "AWS_ACCESS_KEY_ID";
+        private readonly string _ciSecretkey = "AWS_SECRET_KEY";
+
+        public IntegrationAwsClientFactory()
+        {
+            var ci = System.Environment.GetEnvironmentVariable(_ci);
+            if (string.IsNullOrWhiteSpace(ci))
+                this._credentials = new StoredProfileAWSCredentials(IntegrationTestConfig.AwsProfileName);
+            else
+                _credentials = CredentialsFromEnvironment();
+        }
+
+        private AWSCredentials CredentialsFromEnvironment()
+        {
+            var accessKey = System.Environment.GetEnvironmentVariable(_ciAccesskey);
+            var secretKey = System.Environment.GetEnvironmentVariable(_ciSecretkey);
+            return new BasicAWSCredentials(accessKey, secretKey);
+        }
+
+        public IAmazonSimpleNotificationService GetSnsClient(RegionEndpoint region)
+        {
+            return AWSClientFactory.CreateAmazonSimpleNotificationServiceClient(_credentials, region);
+        }
+
+        public IAmazonSQS GetSqsClient(RegionEndpoint region)
+        {
+            return AWSClientFactory.CreateAmazonSQSClient(_credentials, region);
+        }
+    }
+}

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -41,6 +41,10 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="JustSaying.Models, Version=2.0.0.269, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\JustSaying.Models.2.0.0.269\lib\net40\JustSaying.Models.dll</HintPath>
       <Private>True</Private>
@@ -55,12 +59,19 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IntegrationTestConfig.cs" />
+    <Compile Include="IntegrationAwsClientFactory.cs" />
     <Compile Include="MessageStubs.cs" />
     <Compile Include="Patiently.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JustSaying.AwsTools\JustSaying.AwsTools.csproj">
+      <Project>{cbf2110b-c3a4-45e8-bbd6-301d77567043}</Project>
+      <Name>JustSaying.AwsTools</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/JustSaying.TestingFramework/packages.config
+++ b/JustSaying.TestingFramework/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
   <package id="JustSaying.Models" version="2.0.0.269" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
@brainmurphy , as discussed, this PR changes integration tests to use the new `IntegrationAwsClientFactory` instead of default AWS profile. 

Basically, this will look at 'ci' environment variable. If it is set (i.e. not empty), it will then look for ci-access_key and ci-secret_key values and will create an AWS basic profile credentials from that. 

You can use this to set-up integration tests to be run on AppVeyor.