### PR TITLE
NewtonsoftSerialiser will use JsonSerializerSettings for deserialisation as well as for serialisation

### DIFF
--- a/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
+++ b/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Serialisation\Newtonsoft\WhenSerialisingAndDeserialising.cs" />
     <Compile Include="Serialisation\Newtonsoft\WhenUsingCustomSettings.cs" />
     <Compile Include="Serialisation\SerialisationRegister\WhenAddingASerialiserTwice.cs" />
+    <Compile Include="Serialisation\SerialisationRegister\WhenDeserializingMessage.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JustSaying.Messaging\JustSaying.Messaging.csproj">

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
@@ -24,11 +24,5 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
         {
             Assert.IsNull(ThrownException);
         }
-
-        [Then]
-        public void ExceptionThrownIfFormatNotSupported()
-        {
-            Assert.Throws<MessageFormatNotSupportedException>(() => SystemUnderTest.DeserializeMessage(string.Empty));
-        }
     }
 }

--- a/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenDeserializingMessage.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/SerialisationRegister/WhenDeserializingMessage.cs
@@ -1,0 +1,42 @@
+using JustBehave;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.Models;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace JustSaying.Messaging.UnitTests.Serialisation.SerialisationRegister
+{
+    public class WhenDeserializingMessage : BehaviourTest<MessageSerialisationRegister>
+    {
+        private class CustomMessage : Message
+        {
+        }
+
+        private string messageBody = "msgBody";
+        protected override void Given()
+        {
+            RecordAnyExceptionsThrown();
+        }
+
+        protected override void When()
+        {
+            var messageSerialiser = Substitute.For<IMessageSerialiser>();
+            messageSerialiser.GetMessageType(messageBody).Returns(typeof(CustomMessage).Name);
+            messageSerialiser.Deserialise(messageBody, typeof (CustomMessage)).Returns(new CustomMessage());
+            SystemUnderTest.AddSerialiser<CustomMessage>(messageSerialiser);
+        }
+
+        [Then]
+        public void ThrowsMessageFormatNotSupportedWhenMessabeBodyIsUnserializable()
+        {
+            Assert.Throws<MessageFormatNotSupportedException>(() => SystemUnderTest.DeserializeMessage(string.Empty));
+        }
+
+        [Then]
+        public void TheMappingContainsTheSerialiser()
+        {
+            Assert.NotNull(SystemUnderTest.DeserializeMessage(messageBody));
+        }
+
+    }
+}

--- a/JustSaying.Messaging/MessageSerialisation/IMessageSerialiser.cs
+++ b/JustSaying.Messaging/MessageSerialisation/IMessageSerialiser.cs
@@ -9,20 +9,13 @@ namespace JustSaying.Messaging.MessageSerialisation
         Message Deserialise(string message, Type type);
 
         /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="serializeForSnsPublishing">
-        /// <summary>
-        /// Serializes a message for publishing
+        /// Serialises a message for publishing
         /// </summary>
         /// <param name="message"></param>
         /// <param name="serializeForSnsPublishing">If set to false, then message will be wrapped in extra object with Subject and Message fields, e.g.:
         /// new { Subject = message.GetType().Name, Message = serializedMessage };
         /// 
         /// AWS SNS service adds these automatically, so for publishing to topics don't add these properties
-        /// </param>
-        /// <returns></returns>
         /// </param>
         /// <returns></returns>
         string Serialise(Message message, bool serializeForSnsPublishing);

--- a/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
+++ b/JustSaying.Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
@@ -7,7 +7,6 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public class NewtonsoftSerialiser : IMessageSerialiser
     {
-        private readonly JsonConverter _enumConverter = new Newtonsoft.Json.Converters.StringEnumConverter();
         private readonly JsonSerializerSettings _settings;
 
         public NewtonsoftSerialiser()
@@ -24,7 +23,7 @@ namespace JustSaying.Messaging.MessageSerialisation
         {
             var jsqsMessage = JObject.Parse(message);
             var messageBody = jsqsMessage["Message"].ToString();
-            return (Message)JsonConvert.DeserializeObject(messageBody, type, _enumConverter);
+            return (Message)JsonConvert.DeserializeObject(messageBody, type, GetJsonSettings());
         }
 
         public string Serialise(Message message, bool serializeForSnsPublishing)


### PR DESCRIPTION
Some minor fixes:

* `ExceptionThrownIfFormatNotSupported` was moved to another file
* `IMessageSerialiser` - fixes to documentation
* `NewtonsoftSerialiser` - same settings should be used for deserialisation + serialistion

These are the last changes as of now from IntelliFlo, we'll be on par with your branch from this point.