### PR TITLE
Extract the messageDispatcher class from SQSMessageListener 

### DIFF
--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -60,6 +60,7 @@
     <Compile Include="MessageHandling\HandlerMap.cs" />
     <Compile Include="IAwsClientFactoryProxy.cs" />
     <Compile Include="IAwsClientFactory.cs" />
+    <Compile Include="MessageHandling\MessageDispatcher.cs" />
     <Compile Include="MessageHandling\MessageHandlerWrapper.cs" />
     <Compile Include="QueueCreation\AmazonQueueCreator.cs" />
     <Compile Include="QueueCreation\IRegionResourceCache.cs" />

--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -4,6 +4,7 @@ using Amazon.SQS.Model;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
 using Message = JustSaying.Models.Message;
+using SQSMessage = Amazon.SQS.Model.Message;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
@@ -12,15 +13,16 @@ namespace JustSaying.AwsTools.MessageHandling
         private readonly SqsQueueBase _queue;
         private readonly IMessageSerialisationRegister _serialisationRegister;
         private readonly IMessageMonitor _messagingMonitor;
-        private readonly Action<Exception, Amazon.SQS.Model.Message> _onError;
-        private readonly HandlerMap _handlerMap = new HandlerMap();
+        private readonly Action<Exception, SQSMessage> _onError;
+        private readonly HandlerMap _handlerMap;
 
         private static readonly Logger Log = LogManager.GetLogger("JustSaying");
 
-        public MessageDispatcher(SqsQueueBase queue, 
+        public MessageDispatcher(
+            SqsQueueBase queue, 
             IMessageSerialisationRegister serialisationRegister,
             IMessageMonitor messagingMonitor,
-            Action<Exception, Amazon.SQS.Model.Message> onError,
+            Action<Exception, SQSMessage> onError,
             HandlerMap handlerMap)
         {
             _queue = queue;
@@ -30,7 +32,7 @@ namespace JustSaying.AwsTools.MessageHandling
             _handlerMap = handlerMap;
         }
 
-        public void ProcessMessage(Amazon.SQS.Model.Message message)
+        public void ProcessMessage(SQSMessage message)
         {
             Message typedMessage;
             try
@@ -119,6 +121,5 @@ namespace JustSaying.AwsTools.MessageHandling
             };
             _queue.Client.DeleteMessage(deleteRequest);
         }
-
     }
 }

--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using NLog;
+using Amazon.SQS.Model;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.Messaging.Monitoring;
+using Message = JustSaying.Models.Message;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    public class MessageDispatcher
+    {
+        private readonly SqsQueueBase _queue;
+        private readonly IMessageSerialisationRegister _serialisationRegister;
+        private readonly IMessageMonitor _messagingMonitor;
+        private readonly Action<Exception, Amazon.SQS.Model.Message> _onError;
+        private readonly HandlerMap _handlerMap = new HandlerMap();
+
+        private static readonly Logger Log = LogManager.GetLogger("JustSaying");
+
+        public MessageDispatcher(SqsQueueBase queue, 
+            IMessageSerialisationRegister serialisationRegister,
+            IMessageMonitor messagingMonitor,
+            Action<Exception, Amazon.SQS.Model.Message> onError,
+            HandlerMap handlerMap)
+        {
+            _queue = queue;
+            _serialisationRegister = serialisationRegister;
+            _messagingMonitor = messagingMonitor;
+            _onError = onError;
+            _handlerMap = handlerMap;
+        }
+
+        public void ProcessMessage(Amazon.SQS.Model.Message message)
+        {
+            Message typedMessage;
+            try
+            {
+                typedMessage = _serialisationRegister.DeserializeMessage(message.Body);
+            }
+            catch (MessageFormatNotSupportedException ex)
+            {
+                Log.Trace(
+                    "Didn't handle message [{0}]. No serialiser setup",
+                    message.Body ?? string.Empty);
+                DeleteMessageFromQueue(message.ReceiptHandle);
+                _onError(ex, message);
+                return;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error deserialising message");
+                _onError(ex, message);
+                return;
+            }
+
+            try
+            {
+                var handlingSucceeded = true;
+
+                if (typedMessage != null)
+                {
+                    handlingSucceeded = CallMessageHandlers(typedMessage);
+                }
+
+                if (handlingSucceeded)
+                {
+                    DeleteMessageFromQueue(message.ReceiptHandle);
+                }
+            }
+            catch (Exception ex)
+            {
+                var msg = string.Format(
+                    "Issue handling message... {0}. StackTrace: {1}",
+                    message,
+                    ex.StackTrace);
+                Log.Error(ex, msg);
+
+                if (typedMessage != null)
+                {
+                    _messagingMonitor.HandleException(typedMessage.GetType().Name);
+                }
+
+                _onError(ex, message);
+            }
+        }
+
+        private bool CallMessageHandlers(Message message)
+        {
+            var handlerFuncs = _handlerMap.Get(message.GetType());
+
+            if (handlerFuncs == null)
+            {
+                return true;
+            }
+
+            var allHandlersSucceeded = true;
+            foreach (var handlerFunc in handlerFuncs)
+            {
+                var watch = new System.Diagnostics.Stopwatch();
+                watch.Start();
+
+                var thisHandlerSucceeded = handlerFunc(message);
+                allHandlersSucceeded = allHandlersSucceeded && thisHandlerSucceeded;
+
+                watch.Stop();
+                Log.Trace("Handled message - MessageType: {0}", message.GetType().Name);
+                _messagingMonitor.HandleTime(watch.ElapsedMilliseconds);
+            }
+
+            return allHandlersSucceeded;
+        }
+
+        private void DeleteMessageFromQueue(string receiptHandle)
+        {
+            var deleteRequest = new DeleteMessageRequest
+            {
+                QueueUrl = _queue.Url,
+                ReceiptHandle = receiptHandle
+            };
+            _queue.Client.DeleteMessage(deleteRequest);
+        }
+
+    }
+}

--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -32,7 +32,7 @@ namespace JustSaying.AwsTools.MessageHandling
             _handlerMap = handlerMap;
         }
 
-        public void ProcessMessage(SQSMessage message)
+        public void DispatchMessage(SQSMessage message)
         {
             Message typedMessage;
             try

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -195,7 +195,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public void HandleMessage(Amazon.SQS.Model.Message message)
         {
-            var action = new Action(() => _messageDispatcher.ProcessMessage(message));
+            var action = new Action(() => _messageDispatcher.DispatchMessage(message));
             _messageProcessingStrategy.ProcessMessage(action);
         }
 

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -18,17 +18,17 @@ namespace JustSaying.AwsTools.MessageHandling
     public class SqsNotificationListener : INotificationSubscriber
     {
         private readonly SqsQueueBase _queue;
-        private readonly IMessageSerialisationRegister _serialisationRegister;
         private readonly IMessageMonitor _messagingMonitor;
-        private readonly Action<Exception, Amazon.SQS.Model.Message> _onError;
-        private readonly HandlerMap _handlerMap = new HandlerMap();
+
+        private readonly MessageDispatcher _messageDispatcher;
         private readonly MessageHandlerWrapper _messageHandlerWrapper;
+        private IMessageProcessingStrategy _messageProcessingStrategy;
+        private readonly HandlerMap _handlerMap = new HandlerMap();
 
         private CancellationTokenSource _cts = new CancellationTokenSource();
         private static readonly Logger Log = LogManager.GetLogger("JustSaying");
 
         private const int MaxAmazonMessageCap = 10;
-        private IMessageProcessingStrategy _messageProcessingStrategy;
 
         public SqsNotificationListener(
             SqsQueueBase queue,
@@ -38,11 +38,12 @@ namespace JustSaying.AwsTools.MessageHandling
             IMessageLock messageLock = null)
         {
             _queue = queue;
-            _serialisationRegister = serialisationRegister;
             _messagingMonitor = messagingMonitor;
-            _onError = onError ?? ((ex,message) => { });
+            onError = onError ?? ((ex,message) => { });
+            
             _messageProcessingStrategy = new MaximumThroughput();
             _messageHandlerWrapper = new MessageHandlerWrapper(messageLock, _messagingMonitor);
+            _messageDispatcher = new MessageDispatcher(queue, serialisationRegister, messagingMonitor, onError, _handlerMap);
 
             Subscribers = new Collection<ISubscriber>();
         }
@@ -194,98 +195,8 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public void HandleMessage(Amazon.SQS.Model.Message message)
         {
-            var action = new Action(() => ProcessMessageAction(message));
+            var action = new Action(() => _messageDispatcher.ProcessMessage(message));
             _messageProcessingStrategy.ProcessMessage(action);
-        }
-
-        public void ProcessMessageAction(Amazon.SQS.Model.Message message)
-        {
-            Message typedMessage;
-            try
-            {
-                typedMessage = _serialisationRegister.DeserializeMessage(message.Body);
-            }
-            catch (MessageFormatNotSupportedException ex)
-            {
-                Log.Trace(
-                    "Didn't handle message [{0}]. No serialiser setup",
-                    message.Body ?? string.Empty);
-                DeleteMessageFromQueue(message.ReceiptHandle);
-                _onError(ex, message);
-                return;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error deserialising message");
-                _onError(ex, message);
-                return;
-            }
-
-            try
-            {
-                var handlingSucceeded = true;
-
-                if (typedMessage != null)
-                {
-                    handlingSucceeded = CallMessageHandlers(typedMessage);
-                }
-
-                if (handlingSucceeded)
-                {
-                    DeleteMessageFromQueue(message.ReceiptHandle);
-                }
-            }
-            catch (Exception ex)
-            {
-                var msg = string.Format(
-                    "Issue handling message... {0}. StackTrace: {1}",
-                    message,
-                    ex.StackTrace);
-                Log.Error(ex, msg);
-
-                if (typedMessage != null)
-                {
-                    _messagingMonitor.HandleException(typedMessage.GetType().Name);
-                }
-
-                _onError(ex, message);
-            }
-        }
-
-        private bool CallMessageHandlers(Message message)
-        {
-            var handlerFuncs = _handlerMap.Get(message.GetType());
-
-            if (handlerFuncs == null)
-            {
-                return true;
-            }
-
-            var allHandlersSucceeded = true;
-            foreach (var handlerFunc in handlerFuncs)
-            {
-                var watch = new System.Diagnostics.Stopwatch();
-                watch.Start();
-
-                var thisHandlerSucceeded = handlerFunc(message);
-                allHandlersSucceeded = allHandlersSucceeded && thisHandlerSucceeded;
-
-                watch.Stop();
-                Log.Trace("Handled message - MessageType: {0}", message.GetType().Name);
-                _messagingMonitor.HandleTime(watch.ElapsedMilliseconds);
-            }
-
-            return allHandlersSucceeded;
-        }
-
-        private void DeleteMessageFromQueue(string receiptHandle)
-        {
-            var deleteRequest = new DeleteMessageRequest
-            {
-                QueueUrl = _queue.Url,
-                ReceiptHandle = receiptHandle
-            };
-            _queue.Client.DeleteMessage(deleteRequest);
         }
 
         public ICollection<ISubscriber> Subscribers { get; set; }


### PR DESCRIPTION
Extract the `MessageDispatcher` class from `SQSMessageListener` as discussed on Friday.

Any thoughts on naming?

I think that the right place to go to a new class is so that `messageProcessingStrategy` is between them. I find this neater than calling back to the same object. There is still an `Action` with no params or result needed for the threading model, but that may change later.

I would inline the method `SQSMessageListener.HandleMessage` but it is public and used in tests :/