### PR TITLE
Task end state

### DIFF
--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -70,6 +70,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageProcessingThrows.cs" />
+    <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageHandlingThrows.cs" />
     <Compile Include="QueueCreation\WhenSerializingRedrivePolicy.cs" />
     <Compile Include="MessageHandling\Sns\TopicByName\WhenPublishing.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\WhenAttemptingToInterrogateASubscriber.cs" />

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -29,7 +29,8 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 
         protected override JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
         {
-            return new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(new SqsQueueByUrl(RegionEndpoint.EUWest1, QueueUrl, Sqs), SerialisationRegister, Monitor, null, MessageLock);
+            var queue = new SqsQueueByUrl(RegionEndpoint.EUWest1, QueueUrl, Sqs);
+            return new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(queue, SerialisationRegister, Monitor, null, MessageLock);
         }
 
         protected override void Given()
@@ -62,7 +63,8 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         {
             return new ReceiveMessageResponse
             {
-                Messages = new List<Message> {       
+                Messages = new List<Message>
+                {
                     new Message
                     {   
                         MessageId = messageId.ToString(),
@@ -72,7 +74,8 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
                     {
                         MessageId = messageId.ToString(),
                         Body = "{\"Subject\":\"SOME_UNKNOWN_MESSAGE\"," + "\"Message\":\"SOME_RANDOM_MESSAGE\"}"
-                    }}
+                    }
+                }
             };
         }
 

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
@@ -44,5 +44,13 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
                 () => Monitor.Received().ReceiveMessageTime(
                     Arg.Any<long>()));
         }
+
+        [Then]
+        public async Task ExceptionIsNotLoggedToMonitor()
+        {
+            await Patiently.VerifyExpectationAsync(
+                () => Monitor.DidNotReceiveWithAnyArgs().HandleException(
+                        Arg.Any<string>()));
+        }
     }
 }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -5,9 +5,11 @@ using JustBehave;
 using JustSaying.TestingFramework;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
+    [Ignore("Breaks in appveyor due to known nunit integration issues http://help.appveyor.com/discussions/problems/1737-tests-fail-to-run-with-weird-error")]
     public class WhenMessageHandlingThrows : BaseQueuePollingTest
     {
         protected override void Given()
@@ -25,13 +27,11 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         }
 
         [Then]
-        public void ExceptionIsLoggedToMonitor()
+        public async Task ExceptionIsLoggedToMonitor()
         {
-            var verifyTask =  Patiently.VerifyExpectationAsync(
+            await Patiently.VerifyExpectationAsync(
                 () => Monitor.ReceivedWithAnyArgs().HandleException(
                         Arg.Any<string>()));
-
-            verifyTask.Wait();
         }
     }
 }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -13,7 +13,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         protected override void Given()
         {
             base.Given();
-            Handler.Handle(Arg.Any<GenericMessage>()).ThrowsForAnyArgs(new Exception("handler went rong"));
+            Handler.Handle(Arg.Any<GenericMessage>()).ThrowsForAnyArgs(new Exception("Thrown by test handler"));
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -25,11 +25,13 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         }
 
         [Then]
-        public async Task ExceptionIsLoggedToMonitor()
+        public void ExceptionIsLoggedToMonitor()
         {
-            await Patiently.VerifyExpectationAsync(
+            var verifyTask =  Patiently.VerifyExpectationAsync(
                 () => Monitor.ReceivedWithAnyArgs().HandleException(
                         Arg.Any<string>()));
+
+            verifyTask.Wait();
         }
     }
 }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
@@ -13,17 +13,17 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
     {
         public void BeforeGettingMoreMessages()
         {
-            throw new Exception("Lol no");
+            throw new Exception("Thrown by test BeforeGettingMoreMessages");
         }
 
         public void ProcessMessage(Action action)
         {
-            throw new Exception("Lol no");
+            throw new Exception("Thrown by test ProcessMessage");
         }
     }
 
     /// <summary>
-    /// this test exercises different exception ahndlers to the "handler throws an exception" path in WhenMessageHandlingThrows
+    /// this test exercises different exception handlers to the "handler throws an exception" path in WhenMessageHandlingThrows
     /// </summary>
     public class WhenMessageProcessingThrows : BaseQueuePollingTest
     {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
@@ -1,0 +1,58 @@
+
+using System;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+using JustBehave;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.TestingFramework;
+using NSubstitute;
+
+namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
+{
+    public class BrokenMessageProcessingStrategy : IMessageProcessingStrategy
+    {
+        public void BeforeGettingMoreMessages()
+        {
+            throw new Exception("Lol no");
+        }
+
+        public void ProcessMessage(Action action)
+        {
+            throw new Exception("Lol no");
+        }
+    }
+
+    /// <summary>
+    /// this test exercises different exception ahndlers to the "handler throws an exception" path in WhenMessageHandlingThrows
+    /// </summary>
+    public class WhenMessageProcessingThrows : BaseQueuePollingTest
+    {
+        protected override void Given()
+        {
+            base.Given();
+            Handler.Handle(null).ReturnsForAnyArgs(true);
+        }
+
+        protected override void When()
+        {
+            SystemUnderTest.WithMessageProcessingStrategy(new BrokenMessageProcessingStrategy());
+            base.When();
+        }
+
+        [Then]
+        public async Task FailedMessageIsNotRemovedFromQueue()
+        {
+            await Patiently.VerifyExpectationAsync(
+                () => Sqs.DidNotReceiveWithAnyArgs().DeleteMessage(
+                        Arg.Any<DeleteMessageRequest>()));
+        }
+
+        [Then]
+        public async Task ExceptionIsLoggedToMonitor()
+        {
+            await Patiently.VerifyExpectationAsync(
+                () => Monitor.DidNotReceiveWithAnyArgs().HandleException(
+                        Arg.Any<string>()));
+        }
+    }
+}

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -101,19 +101,15 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 Log.Info(
                     "[Failed] Stopped Listening - {0}\n{1}",
-                    queueInfo,
-                    task.Exception);
-            }
-            else if (task.IsCompleted)
-            {
-                Log.Info(
-                    "[Completed] Stopped Listening - {0}",
-                    queueInfo);
+                     queueInfo,
+                     task.Exception);
             }
             else
             {
+                var endState = task.Status.ToString();
                 Log.Info(
-                    "[Canceled] Stopped Listening - {0}",
+                    "[{0}] Stopped Listening - {1}",
+                    endState,
                     queueInfo);
             }
         }

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -88,32 +88,34 @@ namespace JustSaying.AwsTools.MessageHandling
                         await ListenLoop(_cts.Token);
                     }
                 })
-                .ContinueWith(t =>
-                    {
-                        if (t.IsCompleted)
-                        {
-                            Log.Info(
-                                "[Completed] Stopped Listening - {0}", 
-                                queueInfo);
-                        }
-                        else if (t.IsFaulted)
-                        {
-                            Log.Info(
-                                "[Failed] Stopped Listening - {0}\n{1}", 
-                                queueInfo, 
-                                t.Exception);
-                        }
-                        else
-                        {
-                            Log.Info(
-                                "[Canceled] Stopped Listening - {0}", 
-                                queueInfo);
-                        }
-                    });
+                .ContinueWith(t => LogTaskEndState(t, queueInfo));
 
             Log.Info(
                 "Starting Listening - {0}", 
                 queueInfo);
+        }
+
+        private static void LogTaskEndState(Task task, string queueInfo)
+        {
+            if (task.IsCompleted)
+            {
+                Log.Info(
+                    "[Completed] Stopped Listening - {0}",
+                    queueInfo);
+            }
+            else if (task.IsFaulted)
+            {
+                Log.Info(
+                    "[Failed] Stopped Listening - {0}\n{1}",
+                    queueInfo,
+                    task.Exception);
+            }
+            else
+            {
+                Log.Info(
+                    "[Canceled] Stopped Listening - {0}",
+                    queueInfo);
+            }
         }
 
         public void StopListening()

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -99,7 +99,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             if (task.IsFaulted)
             {
-                Log.Info(
+                Log.Warn(
                     "[Faulted] Stopped Listening - {0}\n{1}",
                      queueInfo,
                      task.Exception);

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -100,7 +100,7 @@ namespace JustSaying.AwsTools.MessageHandling
             if (task.IsFaulted)
             {
                 Log.Info(
-                    "[Failed] Stopped Listening - {0}\n{1}",
+                    "[Faulted] Stopped Listening - {0}\n{1}",
                      queueInfo,
                      task.Exception);
             }

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -97,18 +97,18 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private static void LogTaskEndState(Task task, string queueInfo)
         {
-            if (task.IsCompleted)
-            {
-                Log.Info(
-                    "[Completed] Stopped Listening - {0}",
-                    queueInfo);
-            }
-            else if (task.IsFaulted)
+            if (task.IsFaulted)
             {
                 Log.Info(
                     "[Failed] Stopped Listening - {0}\n{1}",
                     queueInfo,
                     task.Exception);
+            }
+            else if (task.IsCompleted)
+            {
+                Log.Info(
+                    "[Completed] Stopped Listening - {0}",
+                    queueInfo);
             }
             else
             {

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
@@ -102,7 +103,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 Log.Warn(
                     "[Faulted] Stopped Listening - {0}\n{1}",
                      queueInfo,
-                     task.Exception);
+                     AggregateExceptionDetails(task.Exception));
             }
             else
             {
@@ -114,7 +115,31 @@ namespace JustSaying.AwsTools.MessageHandling
             }
         }
 
-        public void StopListening()
+        private static string AggregateExceptionDetails(AggregateException ex)
+        {
+            var flatEx = ex.Flatten();
+
+            if (flatEx.InnerExceptions.Count == 0)
+            {
+                return "AggregateException containing no inner exceptions\n" + ex;
+            }
+
+            if (flatEx.InnerExceptions.Count == 1)
+            {
+                return ex.InnerExceptions[0].ToString();
+            }
+
+            var innerExDetails = new StringBuilder();
+            innerExDetails.AppendFormat("AggregateException containing {0} inner exceptions", flatEx.InnerExceptions.Count);
+            foreach (var innerEx in flatEx.InnerExceptions)
+            {
+                innerExDetails.AppendLine(innerEx.ToString());
+            }
+
+            return innerExDetails.ToString();
+        }
+
+       public void StopListening()
         {
             _cts.Cancel();
             Log.Info(


### PR DESCRIPTION
Extract method to log task end state rather than use a big lambda. 

Previous ordering of cases was not correct: the faulted case would never be hit since IsFaulted is a *subset* of IsCompleted, it means "completed due to an unhandled exception" Check the docs: https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.iscompleted.aspx

We can log all "non-faulted" states the same way. The "faulted" state has it's own code - The "faulted" state is the same as IsFaulted  = true. Is the same as Exception != null
http://stackoverflow.com/a/32273273

I would like a unit test on these faulted tasks, as it's tricky! We're feeding async code into `Task.Run`, so the type is `Action<Task<Task>>`  - how would we know if we have the wrong task in the completion logging? 