### PR TITLE
Stronger test cases - when we test the results of calling a handler, check that the handler was actually called

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingFails.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingFails.cs
@@ -15,6 +15,14 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         }
 
         [Then]
+        public async Task MessageHandlerWasCalled()
+        {
+            await Patiently.VerifyExpectationAsync(
+                () => Handler.ReceivedWithAnyArgs().Handle(
+                        Arg.Any<GenericMessage>()));
+        }
+
+        [Then]
         public async Task FailedMessageIsNotRemovedFromQueue()
         {
             // The un-handled one is however.

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -19,6 +19,14 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         }
 
         [Then]
+        public async Task MessageHandlerWasCalled()
+        {
+            await Patiently.VerifyExpectationAsync(
+                () => Handler.ReceivedWithAnyArgs().Handle(
+                        Arg.Any<GenericMessage>()));
+        }
+
+        [Then]
         public async Task FailedMessageIsNotRemovedFromQueue()
         {
             await Patiently.VerifyExpectationAsync(

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
@@ -39,6 +39,14 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         }
 
         [Then]
+        public async Task MessageHandlerWasNotCalled()
+        {
+            await Patiently.VerifyExpectationAsync(
+                () => Handler.DidNotReceiveWithAnyArgs().Handle(
+                        Arg.Any<GenericMessage>()));
+        }
+
+        [Then]
         public async Task FailedMessageIsNotRemovedFromQueue()
         {
             await Patiently.VerifyExpectationAsync(


### PR DESCRIPTION
Making a PR to see if this passes in AppVeyor. 

These work locally, but might fail in appveyor, rendering other parts of the test invalid
i.e. if we're testing that no exception was logged, this is not a good test if the handler wasn't even called as expected.