### PR TITLE
A bit more async

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrows.cs
@@ -10,7 +10,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
     public class BrokenMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public void BeforeGettingMoreMessages()
+        public Task BeforeGettingMoreMessages()
         {
             throw new Exception("Thrown by test BeforeGettingMoreMessages");
         }

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -155,7 +155,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             try
             {
-                _messageProcessingStrategy.BeforeGettingMoreMessages();
+                await _messageProcessingStrategy.BeforeGettingMoreMessages();
 
                 var watch = new System.Diagnostics.Stopwatch();
                 watch.Start();

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public interface IMessageProcessingStrategy
     {
-        void BeforeGettingMoreMessages();
+        Task BeforeGettingMoreMessages();
         void ProcessMessage(Action action);
     }
 }

--- a/JustSaying.Messaging/MessageProcessingStrategies/MaximumThroughput.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/MaximumThroughput.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public class MaximumThroughput : IMessageProcessingStrategy
     {
-        public void BeforeGettingMoreMessages()
+        public Task BeforeGettingMoreMessages()
         {
+            return Task.FromResult(true);
         }
 
         public void ProcessMessage(Action action)

--- a/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
@@ -42,7 +42,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             _messageMonitor = messageMonitor;
         }
 
-        public void BeforeGettingMoreMessages()
+        public async Task BeforeGettingMoreMessages()
         {
             var watch = new System.Diagnostics.Stopwatch();
             watch.Start();
@@ -61,7 +61,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
                 }
 
                 _messageMonitor.IncrementThrottlingStatistic();
-                Task.WaitAny(activeTasksToWaitOn);
+                await Task.WhenAny(activeTasksToWaitOn);
             }
 
             watch.Stop();


### PR DESCRIPTION
Evolutionary change to Throttled message processing strategy rather than a big change: We can make `IMessageProcessingStrategy.BeforeGettingMoreMessages` awaitable so less busy-waiting when all the available slots for handlers are occupied and we have to wait for one to complete.

Important lines are in `Throttled`: ` public void BeforeGettingMoreMessages()` becomes `public async Task BeforeGettingMoreMessages()` and the synchronous wait at ` Task.WaitAny(activeTasksToWaitOn);` becomes `await Task.WhenAny(activeTasksToWaitOn);`

This gets most of the benefit for very little code change
And won't have to be changed when we go full async