### PR TITLE
Update Nunit to 3.0.1

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -40,20 +40,20 @@
       <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JustBehave, Version=1.1.76.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JustBehave.0.76\lib\net451\JustBehave.dll</HintPath>
+    <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JustBehave.1.0.0.12\lib\net452\JustBehave.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.9.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.9.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/JustSaying.AwsTools.IntegrationTests/packages.config
+++ b/JustSaying.AwsTools.IntegrationTests/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
-  <package id="JustBehave" version="0.76" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
 </packages>

--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -40,20 +40,20 @@
       <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JustBehave, Version=1.1.76.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JustBehave.0.76\lib\net451\JustBehave.dll</HintPath>
+    <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JustBehave.1.0.0.12\lib\net452\JustBehave.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.9.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.9.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -5,11 +5,9 @@ using JustBehave;
 using JustSaying.TestingFramework;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using NUnit.Framework;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
-    [Ignore("Breaks in appveyor due to known nunit integration issues http://help.appveyor.com/discussions/problems/1737-tests-fail-to-run-with-weird-error")]
     public class WhenMessageHandlingThrows : BaseQueuePollingTest
     {
         protected override void Given()

--- a/JustSaying.AwsTools.UnitTests/packages.config
+++ b/JustSaying.AwsTools.UnitTests/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
-  <package id="JustBehave" version="0.76" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
 </packages>

--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -45,7 +45,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/JustSaying.AwsTools/packages.config
+++ b/JustSaying.AwsTools/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
 </packages>

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -40,20 +40,20 @@
       <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JustBehave, Version=1.1.76.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JustBehave.0.76\lib\net451\JustBehave.dll</HintPath>
+    <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JustBehave.1.0.0.12\lib\net452\JustBehave.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.9.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.9.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
@@ -19,7 +19,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         private bool _handledException;
         private IMessageMonitor _monitoring;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Given()
         {
             _handler.Handle(Arg.Any<GenericMessage>()).Returns(true).AndDoes(ex => { throw new Exception("My Ex"); });
@@ -66,7 +66,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             await Patiently.AssertThatAsync(() => _handledException);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void ByeBye()
         {
             _bus.StopListening();

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
@@ -14,7 +14,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         private IAmJustSayingFluently _bus;
         private readonly IHandler<GenericMessage> _handler = Substitute.For<IHandler<GenericMessage>>();
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Given()
         {
             var bus = CreateMeABus.InRegion(RegionEndpoint.EUWest1.SystemName).ConfigurePublisherWith(c =>

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
@@ -56,7 +56,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             DeleteQueueIfItAlreadyExists(_regionEndpoint, _queueName);

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
-  <package id="JustBehave" version="0.76" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
   <package id="structuremap" version="3.1.6.186" targetFramework="net452" />
 </packages>

--- a/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
+++ b/JustSaying.Messaging.UnitTests/JustSaying.Messaging.UnitTests.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JustBehave, Version=1.1.76.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JustBehave.0.76\lib\net451\JustBehave.dll</HintPath>
+    <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JustBehave.1.0.0.12\lib\net452\JustBehave.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -45,15 +45,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.9.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.9.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
@@ -28,7 +28,7 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
         public void
             ItDoesNotHaveConversationPropertySerialisedBecauseItIsNotSet_ThisIsForBackwardsCompatibilityWhenWeDeploy()
         {
-            Assert.That(_jsonMessage, Is.Not.StringContaining("Conversation"));
+            Assert.That(_jsonMessage, Is.Not.Contain("Conversation"));
         }
 
         [Then]

--- a/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
+++ b/JustSaying.Messaging.UnitTests/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
@@ -41,8 +41,8 @@ namespace JustSaying.Messaging.UnitTests.Serialisation.Newtonsoft
         [Then]
         public void EnumsAreNotRepresentedAsStrings()
         {
-            Assert.That(_jsonMessage, Is.StringContaining("EnumVal"));
-            Assert.That(_jsonMessage, Is.Not.StringContaining("Two"));
+            Assert.That(_jsonMessage, Does.Contain("EnumVal"));
+            Assert.That(_jsonMessage, Does.Not.Contain("Two"));
         }
     }
 }

--- a/JustSaying.Messaging.UnitTests/packages.config
+++ b/JustSaying.Messaging.UnitTests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
-  <package id="JustBehave" version="0.76" targetFramework="net452" />
+  <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
 </packages>

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/JustSaying.TestingFramework/packages.config
+++ b/JustSaying.TestingFramework/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
 </packages>

--- a/JustSaying.UnitTests/CreateMe/WhenCreatingABus.cs
+++ b/JustSaying.UnitTests/CreateMe/WhenCreatingABus.cs
@@ -8,7 +8,7 @@ namespace JustSaying.UnitTests.CreateMe
         private Action<IPublishConfiguration> _config;
         private string _region;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Given()
         {
             _region = "region-1";

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -36,20 +36,20 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JustBehave, Version=1.1.76.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JustBehave.0.76\lib\net451\JustBehave.dll</HintPath>
+    <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JustBehave.1.0.0.12\lib\net452\JustBehave.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.9.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.9.1.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.36.9.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using JustBehave;
+﻿using JustBehave;
 using JustSaying.AwsTools;
 using JustSaying.TestingFramework;
 using NSubstitute;
@@ -36,14 +35,14 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
         }
 
         /// Note: Ignored tests are here for fluent api exploration & expecting compile time issues when working on the fluent interface stuff...
-        [Then, Ignore]
+        [Then, Ignore("Testing compile-time issues")]
         public void ASqsPublisherCanBeSetup()
         {
             SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50)
                 .WithSnsMessagePublisher<GenericMessage>();
         }
 
-        [Then, Ignore]
+        [Then, Ignore("Testing compile-time issues")]
         public void MultipleSqsPublishersCanBeSetup()
         {
             SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50)
@@ -51,7 +50,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
                 .WithSnsMessagePublisher<GenericMessage>();
         }
 
-        [Then, Ignore]
+        [Then, Ignore("Testing compile-time issues")]
         public void ASqsPublisherCanBeSetupWithConfiguration()
         {
             SystemUnderTest.WithSqsMessagePublisher<GenericMessage>(c =>

--- a/JustSaying.UnitTests/packages.config
+++ b/JustSaying.UnitTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
-  <package id="JustBehave" version="0.76" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.6.0" targetFramework="net452" />
 </packages>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -45,7 +45,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.1.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/JustSaying/packages.config
+++ b/JustSaying/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="NLog" version="4.1.2" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
And update JustBehave and Nlog along with it
and change tests that use nunit syntax that is now deprecated.

This seems to fix an issue in Appveryor: Nunit tests happen with "CLR Version: 4.0.30319.42000" instead of incorrect "CLR Version 3.5".
And 1 test that had to be ignored due to incorrect async handling can now be re-enabled.
