### PR TITLE
call Unwrap on Task of task

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -87,6 +87,7 @@ namespace JustSaying.AwsTools.MessageHandling
                         await ListenLoop(_cts.Token);
                     }
                 })
+                .Unwrap()
                 .ContinueWith(t => LogTaskEndState(t, queueInfo));
 
             Log.Info(


### PR DESCRIPTION
So `Task.Factory.StartNew(async () => await.... ` returns `Task<Task>` which is not what we want to inspect in the Task end state logging.

Unwrap as per  https://msdn.microsoft.com/en-us/library/dd780917.aspx