### PR TITLE
Remove the Assembly Binding redirects on some unit tests

### DIFF
--- a/JustSaying.Messaging.UnitTests/app.config
+++ b/JustSaying.Messaging.UnitTests/app.config
@@ -1,25 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Shouldly" publicKeyToken="6042cbcb05cbc941" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.36.9.0" newVersion="3.36.9.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+ </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>


### PR DESCRIPTION
Remove the Assembly Biding redirects on some unit tests
These should not be needed, and for nunit.framework are actually wrong - we use NUnit 3 now