### PR TITLE
Remove the assemblyBinding redirects in the integration tests

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/app.config
+++ b/JustSaying.AwsTools.IntegrationTests/app.config
@@ -1,24 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Shouldly" publicKeyToken="6042cbcb05cbc941" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.36.9.0" newVersion="3.36.9.0" />
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />

--- a/JustSaying.IntegrationTests/app.config
+++ b/JustSaying.IntegrationTests/app.config
@@ -1,24 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Shouldly" publicKeyToken="6042cbcb05cbc941" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.36.9.0" newVersion="3.36.9.0" />
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />


### PR DESCRIPTION
Remove the assemblyBinding redirects in the integration tests
same reasons as in the unit tests: they don't do anything, and the nunit one is wrong.