### PR TITLE
Throw fewer exceptions in tests

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -23,7 +23,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
                 _firstTime = false;
                 Fail();
             }
-            return null;
+            return Task.FromResult(true);
         }
 
         public void ProcessMessage(Action action)

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -9,6 +9,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
         public int MaxBatchSize { get { return int.MaxValue; } }
 
         private readonly TaskCompletionSource<object> _doneSignal;
+        private bool _firstTime = true;
 
         public ThrowingBeforeMessageProcessingStrategy(TaskCompletionSource<object> doneSignal)
         {
@@ -17,7 +18,11 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
 
         public Task BeforeGettingMoreMessages()
         {
-            Fail();
+            if (_firstTime)
+            {
+                _firstTime = false;
+                Fail();
+            }
             return null;
         }
 

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -9,6 +9,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
         public int MaxBatchSize { get { return int.MaxValue; } }
 
         private readonly TaskCompletionSource<object> _doneSignal;
+        private bool _firstTime = true;
 
         public ThrowingDuringMessageProcessingStrategy(TaskCompletionSource<object> doneSignal)
         {
@@ -22,7 +23,11 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
 
         public void ProcessMessage(Action action)
         {
-            Fail();
+            if (_firstTime)
+            {
+                _firstTime = false;
+                Fail();
+            }
         }
 
         private void Fail()

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -3,7 +3,6 @@ using Amazon.SQS.Model;
 using JustBehave;
 using JustSaying.TestingFramework;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
@@ -12,7 +11,9 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         protected override void Given()
         {
             base.Given();
-            Handler.Handle(Arg.Any<GenericMessage>()).ThrowsForAnyArgs(new Exception("Thrown by test handler"));
+            Handler.Handle(Arg.Any<GenericMessage>()).Returns(
+                x => { throw new Exception("Thrown by test handler"); },
+                x => false );
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -14,7 +14,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
         {
             base.Given();
             Handler.Handle(Arg.Any<GenericMessage>()).Returns(
-                x => ExceptionOnFirstCall());
+                _ => ExceptionOnFirstCall());
         }
 
         private bool ExceptionOnFirstCall()

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -8,12 +8,24 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
     public class WhenMessageHandlingThrows : BaseQueuePollingTest
     {
+        private bool _firstTime = true;
+
         protected override void Given()
         {
             base.Given();
             Handler.Handle(Arg.Any<GenericMessage>()).Returns(
-                x => { throw new Exception("Thrown by test handler"); },
-                x => false );
+                x => ExceptionOnFirstCall());
+        }
+
+        private bool ExceptionOnFirstCall()
+        {
+            if (_firstTime)
+            {
+                _firstTime = false;
+                throw new Exception("Thrown by test handler");
+            }
+
+            return false;
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -40,13 +40,14 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
             _sqsCallCounter++;
             if (_sqsCallCounter == 1)
             {
-                throw new TestException("testing the failure");
+                throw new TestException("testing the failure on first call");
+            }
+            if (_sqsCallCounter == 2)
+            {
+                Tasks.DelaySendDone(_tcs);
             }
 
-            Tasks.DelaySendDone(_tcs);
-
-            var response = new ReceiveMessageResponse();
-            return Task.FromResult(response);
+            return Task.FromResult(new ReceiveMessageResponse());
         }
 
         protected override async Task When()


### PR DESCRIPTION
We only need one exception thrown to do a test.
and the sqs message processing loop logs thousands of lines when these exceptions are thrown repeatedly.

This is either occasionally breaks appveyor builds and makes it very slow to load the output, or just obscures what's actually breaking it.

This PR reduces the length of output in Appveyor from 8-10 thousand lines down to under 700 lines.