### PR TITLE
Log more structured data in tests

### DIFF
--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -74,7 +74,6 @@
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ExplicitExactlyOnceSignallingHandler.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\SignallingHandler.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\Tasks.cs" />
-    <Compile Include="MessageHandling\SqsNotificationListener\Support\TestException.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ThrowingDuringMessageProcessingStrategy.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ThrowingBeforeMessageProcessingStrategy.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageProcessingThrowsDuring.cs" />

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -36,6 +36,8 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 
         protected override void Given()
         {
+            Logging.ToConsole();
+
             Sqs = Substitute.For<IAmazonSQS>();
             SerialisationRegister = Substitute.For<IMessageSerialisationRegister>();
             Monitor = Substitute.For<IMessageMonitor>();

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.TestingFramework;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support
 {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.TestingFramework;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support
 {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -1,6 +1,7 @@
 using System;
 using Amazon.SQS.Model;
 using JustBehave;
+using JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support;
 using JustSaying.TestingFramework;
 using NSubstitute;
 
@@ -22,7 +23,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
             if (_firstTime)
             {
                 _firstTime = false;
-                throw new Exception("Thrown by test handler");
+                throw new TestException("Thrown by test handler");
             }
 
             return false;

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +10,7 @@ using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
 using NSubstitute;
 using NUnit.Framework;
-using JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support;
+using JustSaying.TestingFramework;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -21,6 +21,8 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 
         protected override void Given()
         {
+            Logging.ToConsole();
+
             Sqs = Substitute.For<IAmazonSQS>();
             SerialisationRegister = Substitute.For<IMessageSerialisationRegister>();
             Monitor = Substitute.For<IMessageMonitor>();

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -45,6 +45,10 @@
       <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.2.0\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -56,6 +60,7 @@
   <ItemGroup>
     <Compile Include="IntegrationTestConfig.cs" />
     <Compile Include="IntegrationAwsClientFactory.cs" />
+    <Compile Include="Logging.cs" />
     <Compile Include="MessageStubs.cs" />
     <Compile Include="Patiently.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -64,6 +64,7 @@
     <Compile Include="MessageStubs.cs" />
     <Compile Include="Patiently.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/JustSaying.TestingFramework/Logging.cs
+++ b/JustSaying.TestingFramework/Logging.cs
@@ -1,0 +1,31 @@
+﻿using NLog;
+using NLog.Config;
+using NLog.Targets;
+
+namespace JustSaying.TestingFramework
+{
+    public static class Logging
+    {
+        public static void ToConsole()
+        {
+            const string layout = @"${time}|${message}${onexception:inner=|${exception:format=ShortType,Message}}";
+            ToConsole(layout);
+        }
+
+        public static void ToConsole(string layout)
+        {
+            var consoleTarget = new ConsoleTarget
+            {
+                Layout = layout
+            };
+
+            var config = new LoggingConfiguration();
+
+            config.AddTarget("console", consoleTarget);
+            config.LoggingRules.Add(new LoggingRule("*", LogLevel.Info, consoleTarget));
+
+            LogManager.Configuration = config;
+
+        }
+    }
+}

--- a/JustSaying.TestingFramework/Logging.cs
+++ b/JustSaying.TestingFramework/Logging.cs
@@ -8,7 +8,7 @@ namespace JustSaying.TestingFramework
     {
         public static void ToConsole()
         {
-            const string layout = @"${time}|${message}${onexception:inner=|${exception:format=ShortType,Message}}";
+            const string layout = @"${time}|${level}|${message}${onexception:inner=|${exception:format=ShortType,Message}}";
             ToConsole(layout);
         }
 

--- a/JustSaying.TestingFramework/TestException.cs
+++ b/JustSaying.TestingFramework/TestException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support
+namespace JustSaying.TestingFramework
 {
     [Serializable]
     public class TestException : Exception

--- a/JustSaying.TestingFramework/packages.config
+++ b/JustSaying.TestingFramework/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="NLog" version="4.2.0" targetFramework="net452" />
   <package id="NUnit" version="3.0.1" targetFramework="net452" />
 </packages>

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
@@ -15,11 +15,15 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void Given()
         {
+            Logging.ToConsole();
             base.Given();
+
             Config.PublishFailureReAttempts.Returns(PublishAttempts);
             Config.PublishFailureBackoffMilliseconds.Returns(0);
             RecordAnyExceptionsThrown();
-            _publisher.When(x => x.Publish(Arg.Any<Message>())).Do(x => { throw new Exception(); });
+
+            _publisher.When(x => x.Publish(Arg.Any<Message>()))
+                .Do(x => { throw new TestException("Thrown by test WhenPublishingFails"); });
         }
 
         protected override void When()


### PR DESCRIPTION
Log more structured data in tests by configuring NLog in code
we use the `Logging` helper class to programmatically set the log format as suggested by GraemeF.
fields include: timestamp, log message, exception type and message

The `TestException` class is moved into `TestingFramework` so it can be used elsewhere.

You can see what this PR does by looking at the output of test in Appveyor:

The line logged changes from e.g. 
`Issue in message handling loop for queue , region eu-west-1`
to
`12:57:21.8846|Error|Issue in message handling loop for queue , region eu-west-1|TestException testing the failure on first call`