### PR TITLE
Add the .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_size = 2
+
+[*.cs]
+indent_size = 4
+
+[*.lock]
+end_of_line = lf
+
+[*.sln]
+indent_style = tab


### PR DESCRIPTION
We use editorconfig and get value from it.
This file configures the visual studio plugin (or plugin for your favourite editor) to do some simple whitespace consistency-keeping automatically. It helps cut down on noise in git diffs.

http://editorconfig.org/