### PR TITLE
Improve a noisy log statement

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -71,11 +71,8 @@ namespace JustSaying.AwsTools.MessageHandling
             }
             catch (Exception ex)
             {
-                var msg = string.Format(
-                    "Issue handling message... {0}. StackTrace: {1}",
-                    message,
-                    ex.StackTrace);
-                Log.Error(ex, msg);
+                var errorText = string.Format("Error handling message [{0}]", message.Body);
+                Log.Error(ex, errorText);
 
                 if (typedMessage != null)
                 {


### PR DESCRIPTION
The message on line 74 onwards of MessageDispatcher could be better.
 There is no point in logging stack trace in the message when you have the exception as well, you can extract stack trace in the log formatter if you want it
Also the message.ToString just gives the type name Amazon.SQS.Model.Message, the message body is more interesting.
You can see the resulting output in the appveyor log starting on line 600
Compare a build before ans after to see what this PR does