### PR TITLE
Turn on structured console logging for remaining unit tests

### DIFF
--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
@@ -1,5 +1,6 @@
 using JustBehave;
 using JustSaying.Messaging.Monitoring;
+using JustSaying.TestingFramework;
 using NSubstitute;
 
 namespace JustSaying.UnitTests.JustSayingBus
@@ -13,6 +14,8 @@ namespace JustSaying.UnitTests.JustSayingBus
         {
             Config = Substitute.For<IMessagingConfig>();
             Monitor = Substitute.For<IMessageMonitor>();
+
+            Logging.ToConsole();
         }
 
         protected override JustSaying.JustSayingBus CreateSystemUnderTest()

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
@@ -15,7 +14,6 @@ namespace JustSaying.UnitTests.JustSayingBus
 
         protected override void Given()
         {
-            Logging.ToConsole();
             base.Given();
 
             Config.PublishFailureReAttempts.Returns(PublishAttempts);


### PR DESCRIPTION
A small PR which only affects only tests.

Turn on structured console logging for remaining unit tests
in base class "GivenAServiceBus"