### PR TITLE
Review SQS queue stopping

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenAttemptingToInterrogateASubscriber.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenAttemptingToInterrogateASubscriber.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.TestingFramework;
 using Shouldly;
@@ -8,15 +7,6 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
     public class WhenAttemptingToInterrogateASubscriber : BaseQueuePollingTest
     {
-        protected override async Task When()
-        {
-            await base.When();
-
-            SystemUnderTest.StopListening();
-
-            SystemUnderTest.Listen();
-        }
-
         [Then]
         public void SubscriptedMessagesAreAddedToTheInterrogationDetails()
         {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
@@ -27,6 +27,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
             SystemUnderTest.Listen();
 
             await doneSignal.Task;
+            SystemUnderTest.StopListening();
         }
 
         [Then]


### PR DESCRIPTION
A small PR which only affects only tests.

When sqs polling tests override "then", they should stop the listener at end of Then
And the stopping & starting doesn't appear to affect the subscriber test at all.
If it's necessary then should it be a different test?