### PR TITLE
Moved the Tasks helper into TestingFramework

### DIFF
--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -73,7 +73,6 @@
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ExactlyOnceSignallingHandler.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ExplicitExactlyOnceSignallingHandler.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\SignallingHandler.cs" />
-    <Compile Include="MessageHandling\SqsNotificationListener\Support\Tasks.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ThrowingDuringMessageProcessingStrategy.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\Support\ThrowingBeforeMessageProcessingStrategy.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageProcessingThrowsDuring.cs" />

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/SignallingHandler.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/SignallingHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support
 {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support;
 using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support;
 using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -64,6 +64,7 @@
     <Compile Include="MessageStubs.cs" />
     <Compile Include="Patiently.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tasks.cs" />
     <Compile Include="TestException.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/JustSaying.TestingFramework/Tasks.cs
+++ b/JustSaying.TestingFramework/Tasks.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using NLog;
 
-namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.Support
+namespace JustSaying.TestingFramework
 {
     public static class Tasks
     {


### PR DESCRIPTION
Moved the `Tasks` helper into TestingFramework as we will want to use it in the integration tests too