### PR TITLE
Not patiently

### DIFF
--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -10,7 +10,7 @@ using NSubstitute;
 
 namespace JustSaying.IntegrationTests.JustSayingFluently
 {
-    public abstract class GivenANotificationStack : BehaviourTest<IAmJustSayingFluently>
+    public abstract class GivenANotificationStack : AsyncBehaviourTest<IAmJustSayingFluently>
     {
         readonly Stopwatch _stopwatch = new Stopwatch();
         protected IAmJustSayingFluently ServiceBus;

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSnsToSqsSubscriber.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSnsToSqsSubscriber.cs
@@ -1,4 +1,5 @@
-﻿using JustSaying.TestingFramework;
+﻿using System.Threading.Tasks;
+using JustSaying.TestingFramework;
 using NUnit.Framework;
 using Shouldly;
 
@@ -15,15 +16,17 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             RegisterSnsHandler(_handler);
         }
 
-        protected override void When()
+        protected override async Task When()
         {
             ServiceBus.Publish(new GenericMessage());
+
+            await _handler.DoneSignal;
         }
 
         [Test]
         public void ThenItGetsHandled()
         {
-            _handler.WaitUntilCompletion(10.Seconds()).ShouldBe(true);
+            _handler.MessageCount.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSqsToSqsSubscriber.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSqsToSqsSubscriber.cs
@@ -1,4 +1,5 @@
-﻿using JustSaying.TestingFramework;
+﻿using System.Threading.Tasks;
+using JustSaying.TestingFramework;
 using NUnit.Framework;
 using Shouldly;
 
@@ -15,15 +16,16 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             RegisterSqsHandler(_handler);
         }
 
-        protected override void When()
+        protected override async Task When()
         {
             ServiceBus.Publish(new AnotherGenericMessage());
+            await _handler.DoneSignal;
         }
 
         [Test]
         public void ThenItGetsHandled()
         {
-            _handler.WaitUntilCompletion(15.Seconds()).ShouldBe(true);
+            _handler.MessageCount.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
@@ -20,18 +20,18 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             RegisterSnsHandler(_handler);
         }
 
-        protected override void When()
+        protected override async Task When()
         {
             ServiceBus.Publish(new GenericMessage());
+            await _handler.DoneSignal;
         }
 
         [Test]
-        public async Task ThenExceptionIsRecordedInMonitoring()
+        public void ThenExceptionIsRecordedInMonitoring()
         {
-            _handler.WaitUntilCompletion(15.Seconds()).ShouldBe(true);
+            _handler.MessageCount.ShouldBeGreaterThan(0);
 
-            await Patiently.VerifyExpectationAsync(
-                () => Monitoring.Received().HandleException(Arg.Any<string>()));
+            Monitoring.Received().HandleException(Arg.Any<string>());
         }
     }
 }

--- a/JustSaying.IntegrationTests/WhenOptingOutOfErrorQueue.cs
+++ b/JustSaying.IntegrationTests/WhenOptingOutOfErrorQueue.cs
@@ -14,7 +14,8 @@ namespace JustSaying.IntegrationTests
             return true;
         }
     }
-    class WhenOptingOutOfErrorQueue
+
+    public class WhenOptingOutOfErrorQueue
     {
         private IAmazonSQS _client;
 

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Linq;
 using JustSaying.IntegrationTests.JustSayingFluently;
 using NUnit.Framework;
+using Shouldly;
 using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
@@ -29,7 +29,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         [Test]
         public void ThenHandlerWillReceiveTheMessage()
         {
-            Assert.IsTrue(_handlerFuture.WaitUntilCompletion(TimeSpan.FromSeconds(20)));
+            _handlerFuture.MessageCount.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/JustSaying.TestingFramework/Patiently.cs
+++ b/JustSaying.TestingFramework/Patiently.cs
@@ -6,35 +6,6 @@ namespace JustSaying.TestingFramework
 {
     public static class Patiently
     {
-        public static async Task VerifyExpectationAsync(Action expression)
-        {
-            await VerifyExpectationAsync(expression, 5.Seconds());
-        }
-
-        public static async Task VerifyExpectationAsync(Action expression, TimeSpan timeout)
-        {
-            var started = DateTime.Now;
-            var timeoutAt = DateTime.Now + timeout;
-            do
-            {
-                try
-                {
-                    expression.Invoke();
-                    return;
-                }
-                catch
-                {
-                }
-
-                await Task.Delay(50.Milliseconds());
-                Console.WriteLine(
-                    "Waiting for {0} ms - Still Checking.",
-                    (DateTime.Now - started).TotalMilliseconds);
-            } while (DateTime.Now < timeoutAt);
-
-            expression.Invoke();
-        }
-
         public static async Task AssertThatAsync(Func<bool> func)
         {
             await AssertThatAsync(func, 5.Seconds());


### PR DESCRIPTION
More removal of `Patiently` in Integration Tests

- building on previous PR that moved `Tasks.cs` to the TestingFramework project
- use `TaskCompletionSource` to signal when the "When" part of a test is done
- The "Then" part is always sync, never awaits, it inspects the final state of a stopped system.
- Removed some of the `Patiently` class as it was unused. But not yet all of it.

For the reasons behind this design, see https://github.com/justeat/JustSaying/pull/173