### PR TITLE
Failover tests

### DIFF
--- a/JustSaying.IntegrationTests/JustSayingFluently/Future.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/Future.cs
@@ -21,6 +21,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         public Future(Action action)
         {
             _action = action;
+            ExpectedMessageCount = 1;
         }
 
         public void Complete(TMessage message)
@@ -36,7 +37,10 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             }
             finally
             {
-                Tasks.DelaySendDone(_doneSignal);
+                if (ReceivedMessageCount >= ExpectedMessageCount)
+                {
+                    Tasks.DelaySendDone(_doneSignal);
+                }
             }
         }
 
@@ -45,7 +49,9 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             get { return _doneSignal.Task; }
         }
 
-        public int MessageCount
+        public int ExpectedMessageCount { get; set; }
+
+        public int ReceivedMessageCount
         {
             get { return _messages.Count; }
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/Future.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/Future.cs
@@ -28,8 +28,8 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         {
             try
             {
-                Value = message;
                 _messages.Add(message);
+
                 if (_action != null)
                 {
                     _action();
@@ -57,8 +57,6 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         }
 
         public Exception RecordedException { get; set; }
-
-        public TMessage Value { get; set; }
 
         public bool HasReceived(TMessage message)
         {

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenAFailoverRegionIsSetup.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenAFailoverRegionIsSetup.cs
@@ -102,6 +102,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
             var done = await Tasks.WaitWithTimeoutAsync(handler.DoneSignal);
             Assert.That(done, Is.True);
 
+            Assert.That(handler.ReceivedMessageCount, Is.GreaterThanOrEqualTo(1));
             Assert.That(handler.HasReceived(_message));
         }
     }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
@@ -81,6 +81,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
             var done = await Tasks.WaitWithTimeoutAsync(_handler.DoneSignal);
             Assert.That(done, Is.True);
 
+            Assert.That(_handler.ReceivedMessageCount, Is.GreaterThanOrEqualTo(2));
             Assert.That(_handler.HasReceived(_message1));
             Assert.That(_handler.HasReceived(_message2));
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
@@ -20,14 +20,8 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
         private GenericMessage _message1;
         private GenericMessage _message2;
 
-        [TearDown]
-        public void TearDown()
-        {
-            _subscriber.StopListening();
-        }
-
         [Test]
-        public async Task AMessagedPublishedToBothRegionsWillBeReceived()
+        public async Task MessagesPublishedToBothRegionsWillBeReceived()
         {
             GivenASubscriptionToAQueueInTwoRegions(RegionEndpoint.EUWest1.SystemName, RegionEndpoint.USEast1.SystemName);
             AndAPublisherToThePrimaryRegion(RegionEndpoint.EUWest1.SystemName);
@@ -36,10 +30,13 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
             WhenMessagesArePublishedToBothRegions();
 
             await ThenTheSubscriberReceivesBothMessages();
+
+            _subscriber.StopListening();
         }
 
         private void GivenASubscriptionToAQueueInTwoRegions(string primaryRegion, string secondaryRegion)
         {
+            _handler.ExpectedMessageCount = 2;
             var handler = Substitute.For<IHandler<GenericMessage>>();
             handler.Handle(Arg.Any<GenericMessage>()).Returns(true);
             handler
@@ -81,8 +78,11 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
 
         private async Task ThenTheSubscriberReceivesBothMessages()
         {
-            await Patiently.AssertThatAsync(() => _handler.HasReceived(_message1));
-            await Patiently.AssertThatAsync(() => _handler.HasReceived(_message2));
+            var done = await Tasks.WaitWithTimeoutAsync(_handler.DoneSignal);
+            Assert.That(done, Is.True);
+
+            Assert.That(_handler.HasReceived(_message1));
+            Assert.That(_handler.HasReceived(_message2));
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenAFailoverRegionIsSetup.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenAFailoverRegionIsSetup.cs
@@ -25,13 +25,6 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
         private IHaveFulfilledSubscriptionRequirements _primaryBus;
         private IHaveFulfilledSubscriptionRequirements _secondaryBus;
 
-        [TearDown]
-        public void TearDown()
-        {
-            _primaryBus.StopListening();
-            _secondaryBus.StopListening();
-        }
-
         [Test]
         public async Task MessagesArePublishedToTheActiveRegion()
         {
@@ -45,6 +38,9 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             WhenTheFailoverRegionIsActive();
             AndAMessageIsPublished();
             await ThenTheMessageIsReceivedInThatRegion(_secondaryHandler);
+
+            _primaryBus.StopListening();
+            _secondaryBus.StopListening();
         }
 
         private void GivenSubscriptionsToAQueueInTwoRegions()
@@ -106,6 +102,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             var done = await Tasks.WaitWithTimeoutAsync(handler.DoneSignal);
             Assert.That(done, Is.True);
 
+            Assert.That(handler.ReceivedMessageCount, Is.GreaterThanOrEqualTo(1));
             Assert.That(handler.HasReceived(_message));
         }
     }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenAFailoverRegionIsSetup.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenAFailoverRegionIsSetup.cs
@@ -103,7 +103,10 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
 
         private async Task ThenTheMessageIsReceivedInThatRegion(Future<GenericMessage> handler)
         {
-            await Patiently.AssertThatAsync(() => handler.HasReceived(_message));
+            var done = await Tasks.WaitWithTimeoutAsync(handler.DoneSignal);
+            Assert.That(done, Is.True);
+
+            Assert.That(handler.HasReceived(_message));
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
@@ -83,6 +83,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             var done = await Tasks.WaitWithTimeoutAsync(_handler.DoneSignal);
             Assert.That(done, Is.True);
 
+            Assert.That(_handler.ReceivedMessageCount, Is.GreaterThanOrEqualTo(2));
             Assert.That(_handler.HasReceived(_message1));
             Assert.That(_handler.HasReceived(_message2));
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
@@ -20,14 +20,8 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
         private GenericMessage _message1;
         private GenericMessage _message2;
 
-        [TearDown]
-        public void TearDown()
-        {
-            _subscriber.StopListening();
-        }
-
         [Test]
-        public async Task AMessagedPublishedToBothRegionsWillBeReceived()
+        public async Task MessagesPublishedToBothRegionsWillBeReceived()
         {
             GivenASubscriptionToAQueueInTwoRegions(RegionEndpoint.EUWest1.SystemName, RegionEndpoint.USEast1.SystemName);
             AndAPublisherToThePrimaryRegion(RegionEndpoint.EUWest1.SystemName);
@@ -36,10 +30,14 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             WhenMessagesArePublishedToBothRegions();
 
             await ThenTheSubscriberReceivesBothMessages();
+
+            _subscriber.StopListening();
         }
 
         private void GivenASubscriptionToAQueueInTwoRegions(string primaryRegion, string secondaryRegion)
         {
+            _handler.ExpectedMessageCount = 2;
+
             var handler = Substitute.For<IHandler<GenericMessage>>();
             handler.Handle(Arg.Any<GenericMessage>()).Returns(true);
             handler
@@ -76,16 +74,17 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             _message2 = new GenericMessage {Id = Guid.NewGuid()};
 
             _primaryPublisher.Publish(_message1);
+
             _secondaryPublisher.Publish(_message2);
         }
 
         private async Task ThenTheSubscriberReceivesBothMessages()
         {
-            await Patiently.AssertThatAsync(
-                () => _handler.HasReceived(_message1));
+            var done = await Tasks.WaitWithTimeoutAsync(_handler.DoneSignal);
+            Assert.That(done, Is.True);
 
-            await Patiently.AssertThatAsync(
-                () => _handler.HasReceived(_message2));
+            Assert.That(_handler.HasReceived(_message1));
+            Assert.That(_handler.HasReceived(_message2));
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSnsToSqsSubscriber.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSnsToSqsSubscriber.cs
@@ -26,7 +26,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         [Test]
         public void ThenItGetsHandled()
         {
-            _handler.MessageCount.ShouldBeGreaterThan(0);
+            _handler.ReceivedMessageCount.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSqsToSqsSubscriber.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSqsToSqsSubscriber.cs
@@ -25,7 +25,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         [Test]
         public void ThenItGetsHandled()
         {
-            _handler.MessageCount.ShouldBeGreaterThan(0);
+            _handler.ReceivedMessageCount.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
@@ -29,7 +29,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         [Test]
         public void ThenExceptionIsRecordedInMonitoring()
         {
-            _handler.MessageCount.ShouldBeGreaterThan(0);
+            _handler.ReceivedMessageCount.ShouldBeGreaterThan(0);
 
             Monitoring.Received().HandleException(Arg.Any<string>());
         }

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
@@ -29,7 +29,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         [Test]
         public void ThenHandlerWillReceiveTheMessage()
         {
-            _handlerFuture.MessageCount.ShouldBeGreaterThan(0);
+            _handlerFuture.ReceivedMessageCount.ShouldBeGreaterThan(0);
         }
     }
 }


### PR DESCRIPTION
Less use of "patiently" in integration tests, more awaiting for the message to be received

The "Future" handler needs an ExpectedMessageCount, rather than always signalling done after the first messag
Then it can be used to tests some failover scenarios