### PR TITLE
rename "FreeTasks" to "AvailableWorkers"

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -7,12 +7,12 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingBeforeMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int MaxConcurrentMessageHandlers
+        public int MaxWorkers
         {
             get { return int.MaxValue; }
         }
 
-        public int AvailableMessageHandlers
+        public int AvailableWorkers
         {
             get
             {
@@ -33,7 +33,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public Task AwaitAtLeastOneTaskToComplete()
+        public Task AwaitAtLeastOneWorkerToComplete()
         {
             if (_firstTime)
             {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -43,7 +43,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
             return Task.FromResult(true);
         }
 
-        public void ProcessMessage(Func<Task> action)
+        public void StartWorker(Func<Task> action)
         {
         }
 

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -7,7 +7,12 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingBeforeMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int FreeTasks
+        public int MaxConcurrentMessageHandlers
+        {
+            get { return int.MaxValue; }
+        }
+
+        public int AvailableMessageHandlers
         {
             get
             {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -33,7 +33,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public Task AwaitAtLeastOneWorkerToComplete()
+        public Task WaitForAvailableWorkers()
         {
             if (_firstTime)
             {

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -19,7 +19,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public async Task AwaitAtLeastOneWorkerToComplete()
+        public async Task WaitForAvailableWorkers()
         {
             await Task.Yield();
         }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -7,9 +7,9 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingDuringMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int MaxConcurrentMessageHandlers { get { return int.MaxValue; } }
+        public int MaxWorkers { get { return int.MaxValue; } }
 
-        public int AvailableMessageHandlers { get { return int.MaxValue; } }
+        public int AvailableWorkers { get { return int.MaxValue; } }
 
         private readonly TaskCompletionSource<object> _doneSignal;
         private bool _firstTime = true;
@@ -19,7 +19,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public async Task AwaitAtLeastOneTaskToComplete()
+        public async Task AwaitAtLeastOneWorkerToComplete()
         {
             await Task.Yield();
         }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -7,7 +7,9 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingDuringMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int FreeTasks { get { return int.MaxValue; } }
+        public int MaxConcurrentMessageHandlers { get { return int.MaxValue; } }
+
+        public int AvailableMessageHandlers { get { return int.MaxValue; } }
 
         private readonly TaskCompletionSource<object> _doneSignal;
         private bool _firstTime = true;

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -24,7 +24,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener.
             await Task.Yield();
         }
 
-        public void ProcessMessage(Func<Task> action)
+        public void StartWorker(Func<Task> action)
         {
             if (_firstTime)
             {

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -204,13 +204,13 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private async Task<int> GetNumberOfMessagesToReadFromSqs()
         {
-            var numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableMessageHandlers, MessageConstants.MaxAmazonMessageCap);
+            var numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
 
             if (numberOfMessagesToreadFromSqs == 0)
             {
-                await _messageProcessingStrategy.AwaitAtLeastOneTaskToComplete();
+                await _messageProcessingStrategy.AwaitAtLeastOneWorkerToComplete();
 
-                numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableMessageHandlers, MessageConstants.MaxAmazonMessageCap);
+                numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
             }
 
             if (numberOfMessagesToreadFromSqs == 0)

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -204,21 +204,21 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private async Task<int> GetNumberOfMessagesToReadFromSqs()
         {
-            var numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
+            var numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
 
-            if (numberOfMessagesToreadFromSqs == 0)
+            if (numberOfMessagesToReadFromSqs == 0)
             {
-                await _messageProcessingStrategy.AwaitAtLeastOneWorkerToComplete();
+                await _messageProcessingStrategy.WaitForAvailableWorkers();
 
-                numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
+                numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
             }
 
-            if (numberOfMessagesToreadFromSqs == 0)
+            if (numberOfMessagesToReadFromSqs == 0)
             {
-                throw new InvalidOperationException("Cannot determine numberOfMessagesToreadFromSqs");
+                throw new InvalidOperationException("Cannot determine numberOfMessagesToReadFromSqs");
             }
 
-            return numberOfMessagesToreadFromSqs;
+            return numberOfMessagesToReadFromSqs;
         }
 
         private void HandleMessage(Amazon.SQS.Model.Message message)

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -224,7 +224,7 @@ namespace JustSaying.AwsTools.MessageHandling
         private void HandleMessage(Amazon.SQS.Model.Message message)
         {
             var action = new Func<Task>(() => _messageDispatcher.DispatchMessage(message));
-            _messageProcessingStrategy.ProcessMessage(action);
+            _messageProcessingStrategy.StartWorker(action);
         }
 
         public ICollection<ISubscriber> Subscribers { get; set; }

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -204,13 +204,13 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private async Task<int> GetNumberOfMessagesToReadFromSqs()
         {
-            var numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.FreeTasks, MessageConstants.MaxAmazonMessageCap);
+            var numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableMessageHandlers, MessageConstants.MaxAmazonMessageCap);
 
             if (numberOfMessagesToreadFromSqs == 0)
             {
                 await _messageProcessingStrategy.AwaitAtLeastOneTaskToComplete();
 
-                numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.FreeTasks, MessageConstants.MaxAmazonMessageCap);
+                numberOfMessagesToreadFromSqs = Math.Min(_messageProcessingStrategy.AvailableMessageHandlers, MessageConstants.MaxAmazonMessageCap);
             }
 
             if (numberOfMessagesToreadFromSqs == 0)

--- a/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
@@ -124,7 +124,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
                 }
 
                 Assert.That(messageProcessingStrategy.AvailableWorkers, Is.GreaterThanOrEqualTo(0));
-                await messageProcessingStrategy.AwaitAtLeastOneWorkerToComplete();
+                await messageProcessingStrategy.WaitForAvailableWorkers();
                 Assert.That(messageProcessingStrategy.AvailableWorkers, Is.GreaterThan(0));
 
                 if (stopwatch.Elapsed > timeout)

--- a/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
@@ -111,7 +111,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
 
             while (actions.Any())
             {
-                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.FreeTasks);
+                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.AvailableMessageHandlers);
 
                 foreach (var action in batch)
                 {
@@ -123,9 +123,9 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
                     break;
                 }
 
-                Assert.That(messageProcessingStrategy.FreeTasks, Is.GreaterThanOrEqualTo(0));
+                Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.GreaterThanOrEqualTo(0));
                 await messageProcessingStrategy.AwaitAtLeastOneTaskToComplete();
-                Assert.That(messageProcessingStrategy.FreeTasks, Is.GreaterThan(0));
+                Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.GreaterThan(0));
 
                 if (stopwatch.Elapsed > timeout)
                 {

--- a/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
@@ -115,7 +115,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
 
                 foreach (var action in batch)
                 {
-                    messageProcessingStrategy.ProcessMessage(action);
+                    messageProcessingStrategy.StartWorker(action);
                 }
 
                 if (!actions.Any())

--- a/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/MessageLoopTests.cs
@@ -111,7 +111,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
 
             while (actions.Any())
             {
-                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.AvailableMessageHandlers);
+                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.AvailableWorkers);
 
                 foreach (var action in batch)
                 {
@@ -123,9 +123,9 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
                     break;
                 }
 
-                Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.GreaterThanOrEqualTo(0));
-                await messageProcessingStrategy.AwaitAtLeastOneTaskToComplete();
-                Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.GreaterThan(0));
+                Assert.That(messageProcessingStrategy.AvailableWorkers, Is.GreaterThanOrEqualTo(0));
+                await messageProcessingStrategy.AwaitAtLeastOneWorkerToComplete();
+                Assert.That(messageProcessingStrategy.AvailableWorkers, Is.GreaterThan(0));
 
                 if (stopwatch.Elapsed > timeout)
                 {

--- a/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/ThrottledTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/ThrottledTests.cs
@@ -25,48 +25,48 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
             maxAllowedMessagesInFlight().Returns(100);
             var messageProcessingStrategy = new Throttled(maxAllowedMessagesInFlight, _fakeMonitor);
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(100));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(100));
 
             maxAllowedMessagesInFlight().Returns(90);
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(90));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(90));
         }
 
         [Test]
-        public void FreeTaskCountStartsAtCapacity()
+        public void AvailableMessageHandlersCount_StartsAtCapacity()
         {
             var messageProcessingStrategy = new Throttled(123, _fakeMonitor);
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(123));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(123));
         }
 
         [Test]
-        public void WhenATasksIsAddedTheFreeTaskCountIsDecremented()
+        public void WhenATasksIsAdded_TheAvailableMessageHandlersCountIsDecremented()
         {
             var messageProcessingStrategy = new Throttled(123, _fakeMonitor);
             var tcs = new TaskCompletionSource<bool>();
 
             messageProcessingStrategy.ProcessMessage(() => tcs.Task);
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(122));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(122));
         }
 
         [Test]
-        public async Task WhenATaskCompletesTheFreeTaskCountIsIncremented()
+        public async Task WhenATaskCompletes_TheAvailableMessageHandlersCountIsIncremented()
         {
             var messageProcessingStrategy = new Throttled(3, _fakeMonitor);
             var tcs = new TaskCompletionSource<object>();
 
             messageProcessingStrategy.ProcessMessage(() => tcs.Task);
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(2));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(2));
 
             await AllowTasksToComplete(tcs);
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(3));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(3));
         }
 
         [Test]
-        public async Task FreeTaskCountCanReachZero()
+        public async Task AvailableMessageHandlersCount_CanReachZero()
         {
             const int capacity = 10;
             var messageProcessingStrategy = new Throttled(capacity, _fakeMonitor);
@@ -77,12 +77,12 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
                 messageProcessingStrategy.ProcessMessage(() => tcs.Task);
             }
             
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(0));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(0));
             await AllowTasksToComplete(tcs);
         }
 
         [Test]
-        public async Task FreeTaskCountCanGoToZeroAndBackToFull()
+        public async Task AvailableMessageHandlersCount_CanGoToZeroAndBackToFull()
         {
             const int capacity = 10;
             var messageProcessingStrategy = new Throttled(capacity, _fakeMonitor);
@@ -93,15 +93,15 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
                 messageProcessingStrategy.ProcessMessage(() => tcs.Task);
             }
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(0));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(0));
 
             await AllowTasksToComplete(tcs);
 
-            Assert.That(messageProcessingStrategy.FreeTasks, Is.EqualTo(capacity));
+            Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.EqualTo(capacity));
         }
 
         [Test]
-        public async Task FreeTaskCountIsNeverNegative()
+        public async Task AvailableMessageHandlersCount_IsNeverNegative()
         {
             const int capacity = 10;
             var messageProcessingStrategy = new Throttled(capacity, _fakeMonitor);
@@ -111,7 +111,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
             for (int i = 0; i < capacity; i++)
             {
                 messageProcessingStrategy.ProcessMessage(() => tcs.Task);
-                Assert.That(messageProcessingStrategy.FreeTasks, Is.GreaterThanOrEqualTo(0));
+                Assert.That(messageProcessingStrategy.AvailableMessageHandlers, Is.GreaterThanOrEqualTo(0));
             }
 
             await AllowTasksToComplete(tcs);

--- a/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/ThrottledTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageProcessingStrategies/ThrottledTests.cs
@@ -56,7 +56,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
             var messageProcessingStrategy = new Throttled(123, _fakeMonitor);
             var tcs = new TaskCompletionSource<object>();
 
-            messageProcessingStrategy.ProcessMessage(() => tcs.Task);
+            messageProcessingStrategy.StartWorker(() => tcs.Task);
 
             Assert.That(messageProcessingStrategy.MaxWorkers, Is.EqualTo(123));
 
@@ -69,7 +69,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
             var messageProcessingStrategy = new Throttled(123, _fakeMonitor);
             var tcs = new TaskCompletionSource<object>();
 
-            messageProcessingStrategy.ProcessMessage(() => tcs.Task);
+            messageProcessingStrategy.StartWorker(() => tcs.Task);
 
             Assert.That(messageProcessingStrategy.AvailableWorkers, Is.EqualTo(122));
             await AllowTasksToComplete(tcs);
@@ -81,7 +81,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
             var messageProcessingStrategy = new Throttled(3, _fakeMonitor);
             var tcs = new TaskCompletionSource<object>();
 
-            messageProcessingStrategy.ProcessMessage(() => tcs.Task);
+            messageProcessingStrategy.StartWorker(() => tcs.Task);
 
             Assert.That(messageProcessingStrategy.AvailableWorkers, Is.EqualTo(2));
 
@@ -100,7 +100,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
 
             for (int i = 0; i < capacity; i++)
             {
-                messageProcessingStrategy.ProcessMessage(() => tcs.Task);
+                messageProcessingStrategy.StartWorker(() => tcs.Task);
             }
 
             Assert.That(messageProcessingStrategy.MaxWorkers, Is.EqualTo(capacity));
@@ -117,7 +117,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
 
             for (int i = 0; i < capacity; i++)
             {
-                messageProcessingStrategy.ProcessMessage(() => tcs.Task);
+                messageProcessingStrategy.StartWorker(() => tcs.Task);
             }
 
             Assert.That(messageProcessingStrategy.AvailableWorkers, Is.EqualTo(0));
@@ -137,7 +137,7 @@ namespace JustSaying.Messaging.UnitTests.MessageProcessingStrategies
 
             for (int i = 0; i < capacity; i++)
             {
-                messageProcessingStrategy.ProcessMessage(() => tcs.Task);
+                messageProcessingStrategy.StartWorker(() => tcs.Task);
                 Assert.That(messageProcessingStrategy.AvailableWorkers, Is.GreaterThanOrEqualTo(0));
             }
 

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -13,7 +13,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         /// <summary>
         /// The number of worker tasks that are free to run messages handlers right now,
         /// i.e. MaxWorkers - (the number of currently running workers)
-        /// Always in the range: 0 >= AvailableWorkers >= MaxWorkers
+        /// Always in the range 0 to MaxWorkers
         /// </summary>
         int AvailableWorkers { get; }
 

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -24,10 +24,10 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         void StartWorker(Func<Task> action);
 
         /// <summary>
-        /// after awaiting this, AvailableWorkers should be > 0,
-        /// i.e. you are in a position to add another one by calling ProcessMessage
+        /// After awaiting this, you should be in a position to start another worker
+        /// i.e. AvailableWorkers should be above 0
         /// </summary>
         /// <returns></returns>
-        Task AwaitAtLeastOneWorkerToComplete();
+        Task WaitForAvailableWorkers();
     }
 }

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -18,10 +18,10 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         int AvailableWorkers { get; }
 
         /// <summary>
-        /// Start processing a message. 
+        /// Launch a worker to start processing a message.
         /// </summary>
         /// <param name="action"></param>
-        void ProcessMessage(Func<Task> action);
+        void StartWorker(Func<Task> action);
 
         /// <summary>
         /// after awaiting this, AvailableWorkers should be > 0,
@@ -29,6 +29,5 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         /// </summary>
         /// <returns></returns>
         Task AwaitAtLeastOneWorkerToComplete();
-
     }
 }

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -12,8 +12,8 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
 
         /// <summary>
         /// The number of worker tasks that are free to run messages handlers right now,
-        /// i.e. MaxWorkers - (the number of currently running workers)
-        /// Always in the range 0 to MaxWorkers
+        /// Always in the range 0 to MaxWorkers 
+        /// the number of currently running workers will be = (MaxWorkers - AvailableWorkers)
         /// </summary>
         int AvailableWorkers { get; }
 

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -5,9 +5,30 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public interface IMessageProcessingStrategy
     {
-        Task AwaitAtLeastOneTaskToComplete();
+        /// <summary>
+        /// The maximum number of tasks that will be used to handle messages at any one time
+        /// </summary>
+        int MaxConcurrentMessageHandlers { get; }
+
+        /// <summary>
+        /// The number of tasks that are free to handle messages right now,
+        /// i.e. MaxConcurrentMessageHandlers - (the number of currently running tasks)
+        /// Always in the range 0 >= x >= MaxConcurrentMessageHandlers
+        /// </summary>
+        int AvailableMessageHandlers { get; }
+
+        /// <summary>
+        /// Start processing a message. 
+        /// </summary>
+        /// <param name="action"></param>
         void ProcessMessage(Func<Task> action);
 
-        int FreeTasks { get; }
+        /// <summary>
+        /// after awaiting this, AvailableMessageHandlers should be > 0,
+        /// i.e. you are in a position to add another one by calling ProcessMessage
+        /// </summary>
+        /// <returns></returns>
+        Task AwaitAtLeastOneTaskToComplete();
+
     }
 }

--- a/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -6,16 +6,16 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
     public interface IMessageProcessingStrategy
     {
         /// <summary>
-        /// The maximum number of tasks that will be used to handle messages at any one time
+        /// The maximum number of worker tasks that will be used to run messages handlers at any one time
         /// </summary>
-        int MaxConcurrentMessageHandlers { get; }
+        int MaxWorkers { get; }
 
         /// <summary>
-        /// The number of tasks that are free to handle messages right now,
-        /// i.e. MaxConcurrentMessageHandlers - (the number of currently running tasks)
-        /// Always in the range 0 >= x >= MaxConcurrentMessageHandlers
+        /// The number of worker tasks that are free to run messages handlers right now,
+        /// i.e. MaxWorkers - (the number of currently running workers)
+        /// Always in the range: 0 >= AvailableWorkers >= MaxWorkers
         /// </summary>
-        int AvailableMessageHandlers { get; }
+        int AvailableWorkers { get; }
 
         /// <summary>
         /// Start processing a message. 
@@ -24,11 +24,11 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         void ProcessMessage(Func<Task> action);
 
         /// <summary>
-        /// after awaiting this, AvailableMessageHandlers should be > 0,
+        /// after awaiting this, AvailableWorkers should be > 0,
         /// i.e. you are in a position to add another one by calling ProcessMessage
         /// </summary>
         /// <returns></returns>
-        Task AwaitAtLeastOneTaskToComplete();
+        Task AwaitAtLeastOneWorkerToComplete();
 
     }
 }

--- a/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
@@ -26,7 +26,12 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             _activeTasks = new List<Task>(_maximumAllowedMesagesInFlightProducer());
         }
 
-        public int FreeTasks
+        public int MaxConcurrentMessageHandlers
+        {
+            get { return _maximumAllowedMesagesInFlightProducer(); }
+        }
+
+        public int AvailableMessageHandlers
         {
             get
             {
@@ -45,7 +50,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             var watch = System.Diagnostics.Stopwatch.StartNew();
 
             // wait for some tasks to complete
-            while (FreeTasks == 0)
+            while (AvailableMessageHandlers == 0)
             {
                 Task[] activeTasksToWaitOn;
                 lock (_activeTasks)

--- a/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
@@ -45,7 +45,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             }
         }
 
-        public async Task AwaitAtLeastOneWorkerToComplete()
+        public async Task WaitForAvailableWorkers()
         {
             var watch = System.Diagnostics.Stopwatch.StartNew();
 

--- a/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
@@ -71,7 +71,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             _messageMonitor.HandleThrottlingTime(watch.ElapsedMilliseconds);
         }
 
-        public void ProcessMessage(Func<Task> action)
+        public void StartWorker(Func<Task> action)
         {
             // task is named but not yet started
             var messageProcessingTask = new Task<Task>(action);


### PR DESCRIPTION
On [`IMessageProcessingStrategy`](https://github.com/justeat/JustSaying/blob/master/JustSaying.Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs), rename `FreeTasks` property to `AvailableMessageHandlers` and add `MaxConcurrentMessageHandlers`.  i.e from 

````csharp
    public interface IMessageProcessingStrategy
    {
        int FreeTasks { get; }

        Task AwaitAtLeastOneTaskToComplete();
        void ProcessMessage(Func<Task> action);
    }
`````
to

````csharp
    public interface IMessageProcessingStrategy
    {
        int MaxConcurrentMessageHandlers { get; }
        int AvailableMessageHandlers { get; }

        void ProcessMessage(Func<Task> action);
        Task AwaitAtLeastOneTaskToComplete();
    }
`````

Thoughts on naming here?

I feel that `AvailableMessageHandlers` is a better name as `FreeTasks` could be misread as an action "this method will free up all the tasks".

Also surfaced the `MaxConcurrentMessageHandlers` value as I want to log this at startup (to monitor what the `DefaultThrottledThroughput` is doing). You *can* use `FreeTasks` for that on a newly created `IMessageProcessingStrategy` on the assumption that, at startup, the current available count equals the max available count, but that's not great.

This is a minor breaking change (which probably affects mostly me) as `FreeTasks` was added quite recently.

And added comments to `IMessageProcessingStrategy`.