### PR TITLE
Handler instance per request from IHandlerResolver

### DIFF
--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -247,11 +247,10 @@ namespace JustSaying
                 throw new NotSupportedException(string.Format("There are more than one registration for IHandler<{0}>. JustSaying currently does not support multiple registration for IHandler<T>.", typeof(T).Name));
             }
 
-            var singleHandler = proposedHandlers[0];
-
             foreach (var region in Bus.Config.Regions)
             {
-                Bus.AddMessageHandler(region, _subscriptionConfig.QueueName, () => singleHandler);
+                Bus.AddMessageHandler(region, _subscriptionConfig.QueueName,
+                    () => handlerResolver.ResolveHandlers<T>().Single());
             }
             
 


### PR DESCRIPTION
When using `IHandlerResolver`, resolve the handler per request, not once upfront
This needs tests (this behaviour was changed without tests breaking, so it's not well defined)  and docs and maybe breaking changes as the other overload of `WithMessageHandler` works differently.

But a quick, non-breaking start is going back to old behaviour (it was like this earlier this year: https://github.com/justeat/JustSaying/blob/3aee35f286c247ba2739f6ba57ec770a13dc7656/JustSaying/JustSayingFluently.cs#L247) as per this discussion https://github.com/justeat/JustSaying/issues/206#issuecomment-225610603