### PR TITLE
DNM: Use "ConfigureAwait(false) everywhere

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -7,6 +7,7 @@ using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
 using Message = JustSaying.Models.Message;
 using SQSMessage = Amazon.SQS.Model.Message;
+using JustSaying.Messaging;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
@@ -63,7 +64,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 if (typedMessage != null)
                 {
-                    handlingSucceeded = await CallMessageHandlers(typedMessage);
+                    handlingSucceeded = await CallMessageHandlers(typedMessage).OnAnyThread();
                 }
 
                 if (handlingSucceeded)
@@ -100,12 +101,12 @@ namespace JustSaying.AwsTools.MessageHandling
             if (handlerFuncs.Count == 1)
             {
                 // a shortcut for the usual case
-                allHandlersSucceeded = await handlerFuncs[0](message);
+                allHandlersSucceeded = await handlerFuncs[0](message).OnAnyThread();
             }
             else
             {
                 var handlerTasks = handlerFuncs.Select(func => func(message));
-                var handlerResults = await Task.WhenAll(handlerTasks);
+                var handlerResults = await Task.WhenAll(handlerTasks).OnAnyThread();
                 allHandlersSucceeded = handlerResults.All(x => x);
             }
 

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -84,7 +84,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     while (!_cts.IsCancellationRequested)
                     {
-                        await ListenLoop(_cts.Token);
+                        await ListenLoop(_cts.Token).OnAnyThread();
                     }
                 })
                 .Unwrap()
@@ -154,7 +154,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             try
             {
-                var numberOfMessagesToReadFromSqs = await GetNumberOfMessagesToReadFromSqs();
+                var numberOfMessagesToReadFromSqs = await GetNumberOfMessagesToReadFromSqs().OnAnyThread();
 
                 var watch = new System.Diagnostics.Stopwatch();
                 watch.Start();
@@ -165,7 +165,7 @@ namespace JustSaying.AwsTools.MessageHandling
                         MaxNumberOfMessages = numberOfMessagesToReadFromSqs,
                         WaitTimeSeconds = 20
                     };
-                var sqsMessageResponse = await _queue.Client.ReceiveMessageAsync(request, ct);
+                var sqsMessageResponse = await _queue.Client.ReceiveMessageAsync(request, ct).OnAnyThread();
 
                 watch.Stop();
 
@@ -208,7 +208,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             if (numberOfMessagesToReadFromSqs == 0)
             {
-                await _messageProcessingStrategy.WaitForAvailableWorkers();
+                await _messageProcessingStrategy.WaitForAvailableWorkers().OnAnyThread();
 
                 numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
             }

--- a/JustSaying.Messaging/JustSaying.Messaging.csproj
+++ b/JustSaying.Messaging/JustSaying.Messaging.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Monitoring\NullOpMessageMonitor.cs" />
     <Compile Include="Monitoring\StopwatchHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TaskHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj">

--- a/JustSaying.Messaging/MessageHandling/ExactlyOnceHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/ExactlyOnceHandler.cs
@@ -38,7 +38,7 @@ namespace JustSaying.Messaging.MessageHandling
 
             try
             {
-                var successfullyHandled = await _inner.Handle(message);
+                var successfullyHandled = await _inner.Handle(message).OnAnyThread();
                 if (successfullyHandled)
                 {
                     _messageLock.TryAquireLockPermanently(lockKey);

--- a/JustSaying.Messaging/MessageHandling/FutureHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/FutureHandler.cs
@@ -16,7 +16,7 @@ namespace JustSaying.Messaging.MessageHandling
         public async Task<bool> Handle(T message)
         {
             var handler = _futureHandler();
-            return await handler.Handle(message);
+            return await handler.Handle(message).OnAnyThread();
         }
     }
 }

--- a/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying.Messaging/MessageProcessingStrategies/Throttled.cs
@@ -64,7 +64,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
                 }
 
                 _messageMonitor.IncrementThrottlingStatistic();
-                await Task.WhenAny(activeTasksToWaitOn);
+                await Task.WhenAny(activeTasksToWaitOn).OnAnyThread();
             }
 
             watch.Stop();

--- a/JustSaying.Messaging/Monitoring/StopwatchHandler.cs
+++ b/JustSaying.Messaging/Monitoring/StopwatchHandler.cs
@@ -19,7 +19,7 @@ namespace JustSaying.Messaging.Monitoring
         public async Task<bool> Handle(T message)
         {
             var watch = Stopwatch.StartNew();
-            var result = await _inner.Handle(message);
+            var result = await _inner.Handle(message).OnAnyThread();
 
             watch.Stop();
 

--- a/JustSaying.Messaging/TaskHelpers.cs
+++ b/JustSaying.Messaging/TaskHelpers.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+namespace JustSaying.Messaging
+{
+    public static class TaskHelpers
+    {
+        public static ConfiguredTaskAwaitable<T> OnAnyThread<T>(this Task<T> task)
+        {
+            return task.ConfigureAwait(continueOnCapturedContext: false);
+        }
+
+        public static ConfiguredTaskAwaitable OnAnyThread(this Task task)
+        {
+            return task.ConfigureAwait(continueOnCapturedContext: false);
+        }
+    }
+}


### PR DESCRIPTION
Use "ConfigureAwait(false) everywhere
via a wrapper fn that is shorter and expresses intent
see:
http://blog.stephencleary.com/2012/02/async-and-await.html
http://stackoverflow.com/a/38118550/5599
http://stackoverflow.com/questions/13489065/best-practice-to-call-configureawait-for-all-server-side-code

What do you think?