### PR TITLE
Update structuremap nuget package

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying.AwsTools/MessageHandling/SnsTopicBase.cs
@@ -35,7 +35,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var subscriptionResponse = Client.Subscribe(Arn, "sqs", queue.Arn);
             
-            if (!string.IsNullOrEmpty(subscriptionResponse.SubscriptionArn))
+            if (!string.IsNullOrEmpty(subscriptionResponse?.SubscriptionArn))
             {
                 return true;
             }

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -76,12 +76,12 @@
       <HintPath>..\packages\Shouldly.2.8.0\lib\net40\Shouldly.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=3.1.6.186, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.3.1.6.186\lib\net40\StructureMap.dll</HintPath>
+    <Reference Include="StructureMap, Version=4.2.0.402, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\structuremap.4.2.0.402\lib\net40\StructureMap.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap.Net4, Version=3.1.6.186, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\structuremap.3.1.6.186\lib\net40\StructureMap.Net4.dll</HintPath>
+    <Reference Include="StructureMap.Net4, Version=4.2.0.402, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\structuremap.4.2.0.402\lib\net40\StructureMap.Net4.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/BlockingHandlerRegistry.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/BlockingHandlerRegistry.cs
@@ -1,7 +1,7 @@
 using JustSaying.IntegrationTests.JustSayingFluently;
 using JustSaying.IntegrationTests.TestHandlers;
 using JustSaying.Messaging.MessageHandling;
-using StructureMap.Configuration.DSL;
+using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/MultipleHandlerRegistry.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/MultipleHandlerRegistry.cs
@@ -1,7 +1,7 @@
 using JustSaying.IntegrationTests.JustSayingFluently;
 using JustSaying.IntegrationTests.TestHandlers;
 using JustSaying.Messaging.MessageHandling;
-using StructureMap.Configuration.DSL;
+using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/SingleHandlerRegistry.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/SingleHandlerRegistry.cs
@@ -1,7 +1,7 @@
 using JustSaying.IntegrationTests.JustSayingFluently;
 using JustSaying.IntegrationTests.TestHandlers;
 using JustSaying.Messaging.MessageHandling;
-using StructureMap.Configuration.DSL;
+using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -10,5 +10,5 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.0.1" targetFramework="net452" />
   <package id="Shouldly" version="2.8.0" targetFramework="net452" />
-  <package id="structuremap" version="3.1.6.186" targetFramework="net452" />
+  <package id="structuremap" version="4.2.0.402" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Update structuremap nuget package from 3.1.6 to latest 4.2.0.402
used only in integration tests
in  SnsTopicBase add a null check - it prevents a crash, makes integration tests pass