### PR TITLE
DNM: Separate named queues from default naming

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlers.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlers.cs
@@ -62,7 +62,7 @@ namespace JustSaying.AwsTools.IntegrationTests
                 .WithAwsClientFactory(() => proxyAwsClientFactory)
                 .WithNamingStrategy(() => uniqueTopicAndQueueNames)
                 .WithSqsTopicSubscriber()
-                .IntoQueue(baseQueueName) // generate unique queue name
+                .IntoQueueNamed(baseQueueName) // generate unique queue name
                 .WithMessageHandler<Order>(new OrderHandler())
                 .WithMessageHandler<Order>(new OrderHandler());
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -84,7 +84,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
 
                 .WithSnsMessagePublisher<GenericMessage>()
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename")
+                .IntoQueueNamed("queuename")
                 .ConfigureSubscriptionWith(cf =>
                 {
                     cf.MessageRetentionSeconds = 60;
@@ -95,7 +95,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
 
                 .WithSqsMessagePublisher<AnotherGenericMessage>(configuration => { })
                 .WithSqsPointToPointSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .WithMessageHandler(sqsHandler);
 
             ServiceBus.StartListening();

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenAFailoverRegionIsSetup.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenAFailoverRegionIsSetup.cs
@@ -55,7 +55,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
             _primaryBus = CreateMeABus
                 .InRegion(PrimaryRegion)
                 .WithSqsPointToPointSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .WithMessageHandler(primaryHandler);
             _primaryBus.StartListening();
 
@@ -68,7 +68,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
             _secondaryBus = CreateMeABus
                 .InRegion(SecondaryRegion)
                 .WithSqsPointToPointSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .WithMessageHandler(secondaryHandler);
             _secondaryBus.StartListening();
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsPointToPointSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
@@ -49,7 +49,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsPoin
                 .WithFailoverRegion(secondaryRegion)
                 .WithActiveRegion(() => primaryRegion)
                 .WithSqsPointToPointSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .WithMessageHandler(handler);
             _subscriber.StartListening();
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenAFailoverRegionIsSetup.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenAFailoverRegionIsSetup.cs
@@ -55,7 +55,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             _primaryBus = CreateMeABus
                 .InRegion(PrimaryRegion)
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename")
+                .IntoQueueNamed("queuename")
                 .WithMessageHandler(primaryHandler);
             _primaryBus.StartListening();
 
@@ -68,7 +68,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
             _secondaryBus = CreateMeABus
                 .InRegion(SecondaryRegion)
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename")
+                .IntoQueueNamed("queuename")
                 .WithMessageHandler(secondaryHandler);
             _secondaryBus.StartListening();
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenOneBusIsSubscribedToTwoRegions.cs
@@ -50,7 +50,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
                 .WithFailoverRegion(secondaryRegion)
                 .WithActiveRegion(() => primaryRegion)
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename")
+                .IntoQueueNamed("queuename")
                 .WithMessageHandler(handler);
             _subscriber.StartListening();
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
@@ -37,7 +37,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                     })
                 .WithSnsMessagePublisher<GenericMessage>()
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename")
+                .IntoQueueNamed("queuename")
                 .ConfigureSubscriptionWith(cfg =>
                     {
                         cfg.MessageRetentionSeconds = 60;

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
@@ -34,7 +34,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                     })
                 .WithSnsMessagePublisher<GenericMessage>()
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename")
+                .IntoQueueNamed("queuename")
                 .ConfigureSubscriptionWith(cfg => cfg.InstancePosition = 1)
                 .WithMessageHandler(_handler);
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenThrottlingIsEnabledALongRunningHandler.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenThrottlingIsEnabledALongRunningHandler.cs
@@ -41,7 +41,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                     c.PublishFailureBackoffMilliseconds = 1;
                 })
                 .WithSnsMessagePublisher<GenericMessage>()
-                .WithSqsTopicSubscriber().IntoQueue("queuename").ConfigureSubscriptionWith(
+                .WithSqsTopicSubscriber().IntoQueueNamed("queuename").ConfigureSubscriptionWith(
                     cfg =>
                     {
                         cfg.InstancePosition = 1;

--- a/JustSaying.IntegrationTests/WhenOptingOutOfErrorQueue.cs
+++ b/JustSaying.IntegrationTests/WhenOptingOutOfErrorQueue.cs
@@ -34,7 +34,7 @@ namespace JustSaying.IntegrationTests
                 .WithSnsMessagePublisher<GenericMessage>()
 
                 .WithSqsTopicSubscriber()
-                .IntoQueue(queueName)
+                .IntoQueueNamed(queueName)
                 .ConfigureSubscriptionWith(policy =>
                 {
                     policy.ErrorQueueOptOut = true;

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
@@ -100,7 +100,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
                 .WithMonitoring(new Monitoring())
                 .WithMessageLockStoreOf(new MessageLockStore())
                 .WithSqsTopicSubscriber()
-                .IntoQueue(QueueName)
+                .IntoQueueNamed(QueueName)
                 .ConfigureSubscriptionWith(cfg =>
                 {
                     cfg.MessageRetentionSeconds = 60;

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
@@ -55,7 +55,8 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             var bus = CreateMeABus.InRegion(region)
                 .WithMonitoring(new Monitoring())
                 .WithMessageLockStoreOf(new MessageLockStore())
-                .WithSqsTopicSubscriber().IntoQueue(QueueName)
+                .WithSqsTopicSubscriber()
+                .IntoQueueNamed(QueueName)
                 .WithMessageHandler(_handler1)
                 .WithMessageHandler(_handler2);
             publisher.StartListening();

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
@@ -21,7 +21,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         protected override void When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
-                .IntoQueue(QueueName)
+                .IntoQueueNamed(QueueName)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<GenericMessage<TopicA>>>())
                 .WithMessageHandler(Substitute.For<IHandlerAsync<GenericMessage<TopicB>>>());
         }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsGenericMessageTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsGenericMessageTopicSubscriber.cs
@@ -16,7 +16,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         protected override void When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
-                .IntoQueue(QueueName)
+                .IntoQueueNamed(QueueName)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<GenericMessage<MyMessage>>>());
         }
     }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
@@ -38,7 +38,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         protected override void When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
-                .IntoQueue(QueueName)
+                .IntoQueueNamed(QueueName)
                 .ConfigureSubscriptionWith(cfg =>
                     {
                         cfg.MessageRetentionSeconds = 60;
@@ -75,7 +75,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         protected override void When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
-                .IntoQueue(QueueName)
+                .IntoQueueNamed(QueueName)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
         }
     }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
@@ -34,7 +34,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         protected override void When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
-            .IntoQueue(_queueName)
+            .IntoQueueNamed(_queueName)
             .ConfigureSubscriptionWith(cfg => cfg.MessageRetentionSeconds = 60)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
         }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
@@ -15,7 +15,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             protected override void When()
             {
                 SystemUnderTest.WithSqsTopicSubscriber()
-                    .IntoQueue(QueueName)
+                    .IntoQueueNamed(QueueName)
                     .WithMessageHandler(Substitute.For<IHandlerAsync<LongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongMessage>>());
             }
         } 

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringABlockingHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringABlockingHandlerViaContainer.cs
@@ -25,7 +25,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 
             Subscriber = CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
-                .IntoQueue("container-test")
+                .IntoQueueNamed("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);
 
             Subscriber.StartListening();

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringAHandlerViaContainerWithMissingRegistration.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringAHandlerViaContainerWithMissingRegistration.cs
@@ -19,7 +19,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 
             CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
-                .IntoQueue("container-test")
+                .IntoQueueNamed("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);
 
             return Task.FromResult(true);

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
@@ -24,7 +24,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 
             Subscriber = CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
-                .IntoQueue("container-test")
+                .IntoQueueNamed("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);
 
             Subscriber.StartListening();

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringMultipleHandlersViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringMultipleHandlersViaContainer.cs
@@ -24,7 +24,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 
             CreateMeABus.InRegion("eu-west-1")
                 .WithSqsTopicSubscriber()
-                .IntoQueue("container-test")
+                .IntoQueueNamed("container-test")
                 .WithMessageHandler<OrderPlaced>(handlerResolver);
 
             return Task.FromResult(true);

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -23,7 +23,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
         }

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
@@ -26,7 +26,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
         }

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
@@ -16,7 +16,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
             _bus = SystemUnderTest
                 .WithSqsTopicSubscriber()
-                .IntoQueue("queuename");
+                .IntoQueueNamed("queuename");
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -23,7 +23,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
             _response = SystemUnderTest
                 .WithSqsPointToPointSubscriber()
-                .IntoQueue(string.Empty)
+                .IntoDefaultQueue()
                 .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
         }

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -191,7 +191,7 @@ namespace JustSaying
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
-                throw new ArgumentNullException(nameof(queueName));
+                throw new ArgumentException("You must supply a queue name or use IntoDefaultQueue");
             }
 
             _subscriptionConfig.BaseQueueName = queueName;

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -187,9 +187,20 @@ namespace JustSaying
 
         #region Implementation of Queue Subscription
 
-        public IFluentSubscription IntoQueue(string queuename)
+        public IFluentSubscription IntoQueueNamed(string queueName)
         {
-            _subscriptionConfig.BaseQueueName = queuename;
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentNullException(nameof(queueName));
+            }
+
+            _subscriptionConfig.BaseQueueName = queueName;
+            return this;
+        }
+
+        public IFluentSubscription IntoDefaultQueue()
+        {
+            _subscriptionConfig.BaseQueueName = string.Empty;
             return this;
         }
 
@@ -460,7 +471,8 @@ namespace JustSaying
 
     public interface ISubscriberIntoQueue
     {
-        IFluentSubscription IntoQueue(string queuename);
+        IFluentSubscription IntoQueueNamed(string queueName);
+        IFluentSubscription IntoDefaultQueue();
     }
 
     public interface IHaveFulfilledPublishRequirements : IAmJustSayingFluently


### PR DESCRIPTION
Intended to make the difference clear when the subscriber is trying to control multiple queues or not
What do you think?
or a deeper look at `INamingStrategy` instead?