### PR TITLE
Split up the big file JustSayingFluently

### DIFF
--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -71,9 +71,11 @@
     <Compile Include="JustSayingFluently.cs" />
     <Compile Include="IPublishConfiguration.cs" />
     <Compile Include="JustSayingBus.cs" />
+    <Compile Include="JustSayingFluentlyInterfaces.cs" />
     <Compile Include="MessagingConfig.cs" />
     <Compile Include="IAmJustSaying.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="JustSayingFluentlyExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JustSaying.AwsTools\JustSaying.AwsTools.csproj">

--- a/JustSaying/JustSayingFluentlyExtensions.cs
+++ b/JustSaying/JustSayingFluentlyExtensions.cs
@@ -1,0 +1,10 @@
+namespace JustSaying
+{
+    public static class JustSayingFluentlyExtensions
+    {
+        public static IFluentSubscription IntoDefaultQueue(this ISubscriberIntoQueue subscriber)
+        {
+            return subscriber.IntoQueue(string.Empty);
+        }
+    }
+}

--- a/JustSaying/JustSayingFluentlyInterfaces.cs
+++ b/JustSaying/JustSayingFluentlyInterfaces.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using JustSaying.AwsTools;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.Messaging.Monitoring;
+using JustSaying.Models;
+
+namespace JustSaying
+{
+
+    public interface IMayWantOptionalSettings : IMayWantMonitoring, IMayWantMessageLockStore, IMayWantCustomSerialisation,
+        IMayWantAFailoverRegion, IMayWantNamingStrategy, IMayWantAwsClientFactory
+    { }
+
+    public interface IMayWantAwsClientFactory
+    {
+        IMayWantOptionalSettings WithAwsClientFactory(Func<IAwsClientFactory> awsClientFactory);
+    }
+
+    public interface IMayWantNamingStrategy
+    {
+        IMayWantOptionalSettings WithNamingStrategy(Func<INamingStrategy> busNamingStrategy);
+    }
+
+    public interface IMayWantAFailoverRegion
+    {
+        IMayWantARegionPicker WithFailoverRegion(string region);
+    }
+
+    public interface IMayWantARegionPicker : IMayWantAFailoverRegion
+    {
+        IMayWantOptionalSettings WithActiveRegion(Func<string> getActiveRegion);
+    }
+
+    public interface IMayWantMonitoring : IAmJustSayingFluently
+    {
+        IMayWantOptionalSettings WithMonitoring(IMessageMonitor messageMonitor);
+    }
+
+    public interface IMayWantMessageLockStore : IAmJustSayingFluently
+    {
+        IMayWantOptionalSettings WithMessageLockStoreOf(IMessageLock messageLock);
+    }
+
+    public interface IMayWantCustomSerialisation : IAmJustSayingFluently
+    {
+        IMayWantOptionalSettings WithSerialisationFactory(IMessageSerialisationFactory factory);
+    }
+
+    public interface IAmJustSayingFluently : IMessagePublisher
+    {
+        IHaveFulfilledPublishRequirements ConfigurePublisherWith(Action<IPublishConfiguration> confBuilder);
+        IHaveFulfilledPublishRequirements WithSnsMessagePublisher<T>() where T : Message;
+        IHaveFulfilledPublishRequirements WithSqsMessagePublisher<T>(Action<SqsWriteConfiguration> config) where T : Message;
+
+        /// <summary>
+        /// Adds subscriber to topic. 
+        /// </summary>
+        /// <param name="topicName">Topic name to subscribe to. If left empty,
+        /// topic name will be message type name</param>
+        /// <returns></returns>
+        ISubscriberIntoQueue WithSqsTopicSubscriber(string topicName = null);
+        ISubscriberIntoQueue WithSqsPointToPointSubscriber();
+        void StartListening();
+        void StopListening();
+        bool Listening { get; }
+    }
+
+    public interface IFluentSubscription
+    {
+        IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandler<T> handler) where T : Message;
+
+        IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerAsync<T> handler) where T : Message;
+
+        IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerResolver handlerResolver) where T : Message;
+        IFluentSubscription ConfigureSubscriptionWith(Action<SqsReadConfiguration> config);
+    }
+
+    public interface IHaveFulfilledSubscriptionRequirements : IAmJustSayingFluently, IFluentSubscription
+    {
+
+    }
+
+    public interface ISubscriberIntoQueue
+    {
+        IFluentSubscription IntoQueue(string queuename);
+    }
+
+    public interface IHaveFulfilledPublishRequirements : IAmJustSayingFluently
+    {
+    }
+
+}

--- a/JustSaying/JustSayingFluentlyInterfaces.cs
+++ b/JustSaying/JustSayingFluentlyInterfaces.cs
@@ -80,7 +80,6 @@ namespace JustSaying
 
     public interface IHaveFulfilledSubscriptionRequirements : IAmJustSayingFluently, IFluentSubscription
     {
-
     }
 
     public interface ISubscriberIntoQueue
@@ -91,5 +90,4 @@ namespace JustSaying
     public interface IHaveFulfilledPublishRequirements : IAmJustSayingFluently
     {
     }
-
 }


### PR DESCRIPTION
Split up the big file JustSayingFluently.cs by moving out the interfaces and extensions
and delete regions