### PR TITLE
Single handler to WithMessageHandler

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="WhenIAccessAnExistingQueueWithoutAnErrorQueue.cs" />
     <Compile Include="WhenICreateAQueueByName.cs" />
     <Compile Include="WhenQueueIsDeleted.cs" />
+    <Compile Include="WhenSettingUpMultipleHandlersFails.cs" />
     <Compile Include="WhenSettingUpMultipleHandlers.cs" />
     <Compile Include="WhenUpdatingDeliveryDelay.cs" />
     <Compile Include="WhenUpdatingRedrivePolicy.cs" />

--- a/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlers.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlers.cs
@@ -63,8 +63,7 @@ namespace JustSaying.AwsTools.IntegrationTests
                 .WithNamingStrategy(() => uniqueTopicAndQueueNames)
                 .WithSqsTopicSubscriber()
                 .IntoQueue(baseQueueName) // generate unique queue name
-                .WithMessageHandler<Order>(new OrderHandler())
-                .WithMessageHandler<Order>(new OrderHandler());
+                .WithMessageHandlers(new OrderHandler(), new OrderHandler());
 
             bus
                 .StartListening();

--- a/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlersFails.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlersFails.cs
@@ -5,7 +5,6 @@ using JustBehave;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging.MessageHandling;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace JustSaying.AwsTools.IntegrationTests
 {

--- a/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlersFails.cs
+++ b/JustSaying.AwsTools.IntegrationTests/WhenSettingUpMultipleHandlersFails.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading.Tasks;
+using Amazon;
+using JustBehave;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Messaging.MessageHandling;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace JustSaying.AwsTools.IntegrationTests
+{
+    [TestFixture]
+    public class WhenSettingUpMultipleHandlersFails : BehaviourTest<IHaveFulfilledSubscriptionRequirements>
+    {
+        public class Order : Models.Message
+        {
+        }
+
+        public class OrderHandler : IHandlerAsync<Order>
+        {
+            public Task<bool> Handle(Order message)
+            {
+                return Task.FromResult(true);
+            }
+        }
+
+        public class UniqueTopicAndQueueNames : INamingStrategy
+        {
+            private readonly long ticks = DateTime.UtcNow.Ticks;
+
+            public string GetTopicName(string topicName, string messageType)
+            {
+                return (messageType + ticks).ToLower();
+            }
+
+            public string GetQueueName(SqsReadConfiguration sqsConfig, string messageType)
+            {
+                return (sqsConfig.BaseQueueName + ticks).ToLower();
+            }
+        }
+
+        protected string QueueUniqueKey;
+        private ProxyAwsClientFactory proxyAwsClientFactory;
+        private int handlersAttached = 0;
+        private ArgumentException _capturedException
+            ;
+
+        protected override void Given()
+        { }
+
+        protected override void When()
+        {
+        }
+
+        protected override IHaveFulfilledSubscriptionRequirements CreateSystemUnderTest()
+        {
+            proxyAwsClientFactory = new ProxyAwsClientFactory();
+
+            var busConfig = CreateMeABus.InRegion(RegionEndpoint.EUWest1.SystemName)
+                .WithAwsClientFactory(() => proxyAwsClientFactory);
+            try
+            {
+                // 2nd distinct handler declaration for the same queue should fail
+                AttachAHandler(busConfig);
+                AttachAHandler(busConfig);
+            }
+            catch (ArgumentException ex)
+            {
+                _capturedException = ex;
+            }
+            return null;
+        }
+
+        private void AttachAHandler(IMayWantOptionalSettings busConfig)
+        {
+            busConfig
+                .WithSqsTopicSubscriber()
+                .IntoDefaultQueue()
+                .WithMessageHandler(new OrderHandler());
+            handlersAttached++;
+        }
+
+        [Test]
+        public void ThenOnlyOneHandlerIsAttached()
+        {
+            Assert.That(handlersAttached, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ThenAnExceptionIsThrown()
+        {
+            Assert.That(_capturedException, Is.Not.Null);
+            Assert.That(_capturedException.Message, Does.StartWith("The handler for 'Order' messages on this queue has already been registered."));
+        }
+    }
+}

--- a/JustSaying.AwsTools/MessageHandling/HandlerMap.cs
+++ b/JustSaying.AwsTools/MessageHandling/HandlerMap.cs
@@ -25,5 +25,7 @@ namespace JustSaying.AwsTools.MessageHandling
             List<HandlerFunc> handlers;
             return _handlers.TryGetValue(messageType, out handlers) ? handlers : null;
         }
+
+        public bool ContainsKey(Type type) => _handlers.ContainsKey(type);
     }
 }

--- a/JustSaying.AwsTools/MessageHandling/HandlerMap.cs
+++ b/JustSaying.AwsTools/MessageHandling/HandlerMap.cs
@@ -6,26 +6,16 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     public class HandlerMap
     {
-        private readonly Dictionary<Type, List<HandlerFunc>> _handlers = new Dictionary<Type, List<HandlerFunc>>();
+        private readonly Dictionary<Type, HandlerFunc> _handlers = new Dictionary<Type, HandlerFunc>();
 
-        public void Add(Type messageType, HandlerFunc handlerFunc)
+        public bool ContainsKey(Type messageType) => _handlers.ContainsKey(messageType);
+
+        public void Add(Type messageType, HandlerFunc handlerFunc) => _handlers.Add(messageType, handlerFunc);
+
+        public HandlerFunc Get(Type messageType)
         {
-            List<HandlerFunc> handlersForType;
-            if (!_handlers.TryGetValue(messageType, out handlersForType))
-            {
-                handlersForType = new List<HandlerFunc>();
-                _handlers.Add(messageType, handlersForType);
-            }
-
-            handlersForType.Add(handlerFunc);
+            HandlerFunc handler;
+            return _handlers.TryGetValue(messageType, out handler) ? handler : null;
         }
-
-        public List<HandlerFunc> Get(Type messageType)
-        {
-            List<HandlerFunc> handlers;
-            return _handlers.TryGetValue(messageType, out handlers) ? handlers : null;
-        }
-
-        public bool ContainsKey(Type type) => _handlers.ContainsKey(type);
     }
 }

--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using NLog;
 using Amazon.SQS.Model;
@@ -86,33 +85,22 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private async Task<bool> CallMessageHandlers(Message message)
         {
-            var handlerFuncs = _handlerMap.Get(message.GetType());
+            var handler = _handlerMap.Get(message.GetType());
 
-            if ((handlerFuncs == null) || (handlerFuncs.Count == 0))
+            if (handler == null)
             {
                 return true;
             }
 
-            bool allHandlersSucceeded;
             var watch = System.Diagnostics.Stopwatch.StartNew();
 
-            if (handlerFuncs.Count == 1)
-            {
-                // a shortcut for the usual case
-                allHandlersSucceeded = await handlerFuncs[0](message).ConfigureAwait(false);
-            }
-            else
-            {
-                var handlerTasks = handlerFuncs.Select(func => func(message));
-                var handlerResults = await Task.WhenAll(handlerTasks).ConfigureAwait(false);
-                allHandlersSucceeded = handlerResults.All(x => x);
-            }
+            var handlerSucceeded = await handler(message).ConfigureAwait(false);
 
             watch.Stop();
             Log.Trace($"Handled message - MessageType: {message.GetType().Name}");
             _messagingMonitor.HandleTime(watch.ElapsedMilliseconds);
 
-            return allHandlersSucceeded;
+            return handlerSucceeded;
         }
 
         private void DeleteMessageFromQueue(string receiptHandle)

--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -61,7 +61,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 if (typedMessage != null)
                 {
-                    handlingSucceeded = await CallMessageHandlers(typedMessage).ConfigureAwait(false);
+                    handlingSucceeded = await CallMessageHandler(typedMessage).ConfigureAwait(false);
                 }
 
                 if (handlingSucceeded)
@@ -83,7 +83,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }
         }
 
-        private async Task<bool> CallMessageHandlers(Message message)
+        private async Task<bool> CallMessageHandler(Message message)
         {
             var handler = _handlerMap.Get(message.GetType());
 

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -64,6 +64,11 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public void AddMessageHandler<T>(Func<IHandlerAsync<T>> futureHandler) where T : Message
         {
+            if (_handlerMap.ContainsKey(typeof(T)))
+            {
+                throw new ArgumentException("THis handler has already been registered");
+            }
+
             Subscribers.Add(new Subscriber(typeof(T)));
 
             var handlerFunc = _messageHandlerWrapper.WrapMessageHandler(futureHandler);

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -66,7 +66,9 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             if (_handlerMap.ContainsKey(typeof(T)))
             {
-                throw new ArgumentException($"The handler for '{typeof(T).Name}' messages has already been registered. Use 'WithMessageHandlers'");
+                throw new ArgumentException(
+                    $"The handler for '{typeof(T).Name}' messages on this queue has already been registered." +
+                    "Use 'WithMessageHandlers' if you need multiple handlers on the same queue");
             }
 
             Subscribers.Add(new Subscriber(typeof(T)));

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -66,9 +66,8 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             if (_handlerMap.ContainsKey(typeof(T)))
             {
-                throw new ArgumentException(
-                    $"The handler for '{typeof(T).Name}' messages on this queue has already been registered." +
-                    "Use 'WithMessageHandlers' if you need multiple handlers on the same queue");
+                throw new NotSupportedException(
+                    $"The handler for '{typeof(T).Name}' messages on this queue has already been registered.");
             }
 
             Subscribers.Add(new Subscriber(typeof(T)));

--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -66,7 +66,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             if (_handlerMap.ContainsKey(typeof(T)))
             {
-                throw new ArgumentException("THis handler has already been registered");
+                throw new ArgumentException($"The handler for '{typeof(T).Name}' messages has already been registered. Use 'WithMessageHandlers'");
             }
 
             Subscribers.Add(new Subscriber(typeof(T)));

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
@@ -56,8 +56,8 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
                 .WithMonitoring(new Monitoring())
                 .WithMessageLockStoreOf(new MessageLockStore())
                 .WithSqsTopicSubscriber().IntoQueue(QueueName)
-                .WithMessageHandler(_handler1)
-                .WithMessageHandler(_handler2);
+                .WithMessageHandlers(_handler1, _handler2);
+
             publisher.StartListening();
             bus.StartListening();
 

--- a/JustSaying.Messaging/JustSaying.Messaging.csproj
+++ b/JustSaying.Messaging/JustSaying.Messaging.csproj
@@ -59,6 +59,7 @@
     <Compile Include="MessageHandling\FutureHandler.cs" />
     <Compile Include="MessageHandling\IHandlerAsync.cs" />
     <Compile Include="MessageHandling\IMessageLock.cs" />
+    <Compile Include="MessageHandling\ListHandler.cs" />
     <Compile Include="MessageProcessingStrategies\DefaultThrottledThroughput.cs" />
     <Compile Include="MessageProcessingStrategies\IMessageProcessingStrategy.cs" />
     <Compile Include="MessageProcessingStrategies\MessageConstants.cs" />

--- a/JustSaying.Messaging/MessageHandling/ListHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/ListHandler.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace JustSaying.Messaging.MessageHandling
+{
+    public class ListHandler<T> : IHandlerAsync<T>
+    {
+        private readonly IEnumerable<IHandlerAsync<T>> _handlers;
+
+        public ListHandler(IEnumerable<IHandlerAsync<T>> handlers)
+        {
+            _handlers = handlers;
+        }
+
+        public async Task<bool> Handle(T message)
+        {
+            var handlerTasks = _handlers.Select(h => h.Handle(message));
+            var handlerResults = await Task.WhenAll(handlerTasks)
+                .ConfigureAwait(false);
+
+            return handlerResults.All(x => x);
+        }
+    }
+}

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -237,13 +237,11 @@ namespace JustSaying
 
             if (proposedHandlers.Count == 0)
             {
-                throw new HandlerNotRegisteredWithContainerException(
-                    $"IHandler<{typeof(T).Name}> is not registered in the container.");
+                throw new HandlerNotRegisteredWithContainerException($"There is no handler for '{typeof(T).Name}' messages.");
             }
             if (proposedHandlers.Count > 1)
             {
-                throw new NotSupportedException(
-                    $"There are more than one registration for IHandler<{typeof(T).Name}>. JustSaying currently does not support multiple registration for IHandler<T>.");
+                throw new NotSupportedException($"There is more than one handler for '{typeof(T).Name}' messages.");
             }
 
             foreach (var region in Bus.Config.Regions)

--- a/JustSaying/JustSayingFluentlyExtensions.cs
+++ b/JustSaying/JustSayingFluentlyExtensions.cs
@@ -1,3 +1,6 @@
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Models;
+
 namespace JustSaying
 {
     public static class JustSayingFluentlyExtensions
@@ -5,6 +8,13 @@ namespace JustSaying
         public static IFluentSubscription IntoDefaultQueue(this ISubscriberIntoQueue subscriber)
         {
             return subscriber.IntoQueue(string.Empty);
+        }
+
+        public static IHaveFulfilledSubscriptionRequirements WithMessageHandlers<T>(
+             this IFluentSubscription sub, params IHandlerAsync<T>[] handlers) where T : Message
+        {
+            var listHandler = new ListHandler<T>(handlers);
+            return sub.WithMessageHandler(listHandler);
         }
     }
 }

--- a/JustSaying/JustSayingFluentlyExtensions.cs
+++ b/JustSaying/JustSayingFluentlyExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 
@@ -13,6 +14,16 @@ namespace JustSaying
         public static IHaveFulfilledSubscriptionRequirements WithMessageHandlers<T>(
              this IFluentSubscription sub, params IHandlerAsync<T>[] handlers) where T : Message
         {
+            if (handlers.Length == 0)
+            {
+                throw new ArgumentException("No handlers in list");
+            }
+
+            if (handlers.Length == 1)
+            {
+                sub.WithMessageHandler(handlers[0]);
+            }
+
             var listHandler = new ListHandler<T>(handlers);
             return sub.WithMessageHandler(listHandler);
         }


### PR DESCRIPTION
One handler at a time: You can only call `WithMessageHandler` once for a given queue and message type.
This is intended to make it harder to accidentally put multiple handlers on the same queue.
You use a new extension `WithMessageHandlers` if you still want to do this, and it's clear that you have 1 queue definition, and multiple handlers together on the end of it.

And as a consequence, the internals in `HandlerMap` and `MessageDispatcher` become simpler for the usual case, the support for multiple handlers moves out into `ListHandler`

What do you think?
Needs more tests?