### PR TITLE
#189 - Exposing queue URL as well not to implement queue discovery in the consuming code

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -64,6 +64,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 if (typedMessage != null)
                 {
                     typedMessage.ReceiptHandle = message.ReceiptHandle;
+                    typedMessage.QueueUrl = new Uri(_queue.Url);
                     handlingSucceeded = await CallMessageHandlers(typedMessage).ConfigureAwait(false);
                 }
 

--- a/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying.AwsTools/MessageHandling/MessageDispatcher.cs
@@ -64,7 +64,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 if (typedMessage != null)
                 {
                     typedMessage.ReceiptHandle = message.ReceiptHandle;
-                    typedMessage.QueueUrl = new Uri(_queue.Url);
+                    typedMessage.QueueUrl = _queue.Url;
                     handlingSucceeded = await CallMessageHandlers(typedMessage).ConfigureAwait(false);
                 }
 

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -18,6 +18,7 @@ namespace JustSaying.Models
         public string Tenant { get; set; }
         public string Conversation { get; set; }
         public string ReceiptHandle { get; set; }
+        public Uri QueueUrl { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey()

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -18,7 +18,7 @@ namespace JustSaying.Models
         public string Tenant { get; set; }
         public string Conversation { get; set; }
         public string ReceiptHandle { get; set; }
-        public Uri QueueUrl { get; set; }
+        public string QueueUrl { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey()


### PR DESCRIPTION
Originally I was thinking it would be easier to figure out queue URL in the consuming code, however it is not aware of the AWS region and the default naming strategy.
This adds a bit more metadata to the ```Message``` class that should go to the envelope in v5.