### PR TITLE
DNM: stopwatch handler - metric name issue

### DIFF
--- a/JustSaying.Messaging.UnitTests/Monitoring/StopwatchHandlerTests.cs
+++ b/JustSaying.Messaging.UnitTests/Monitoring/StopwatchHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.Monitoring;
@@ -56,6 +57,36 @@ namespace JustSaying.Messaging.UnitTests.Monitoring
         }
 
         [Test]
+        public async Task WhenSyncHandlerIsWrappedInEverything_MonitoringIsCalledWithCorrectTypeNames()
+        {
+            var innerHandler = MockSyncHandler();
+            var innnerHandlerName = innerHandler.GetType().Name.ToLower();
+
+            var wrappedHandler1 = new BlockingHandler<OrderAccepted>(innerHandler);
+            var wrappedHandler2 = new ExactlyOnceHandler<OrderAccepted>(wrappedHandler1, MockMessageLock(), 100, "test");
+            var wrappedHandler3 = new ListHandler<OrderAccepted>(
+                new List<IHandlerAsync<OrderAccepted>> { wrappedHandler2 });
+            var wrappedHandler4 = new FutureHandler<OrderAccepted>(() => wrappedHandler3);
+
+            var monitoring = Substitute.For<IMeasureHandlerExecutionTime>();
+            var stopwatchHandler = new StopwatchHandler<OrderAccepted>(wrappedHandler4, monitoring);
+
+
+            await stopwatchHandler.Handle(new OrderAccepted());
+
+            monitoring.Received(1).HandlerExecutionTime(
+                innnerHandlerName, "orderaccepted", Arg.Any<TimeSpan>());
+        }
+
+        private static IMessageLock MockMessageLock()
+        {
+            var messageLock = Substitute.For<IMessageLock>();
+            messageLock.TryAquireLock(Arg.Any<string>(), Arg.Any<TimeSpan>())
+                .Returns(new MessageLockResponse());
+            return messageLock;
+        }
+
+        [Test]
         public async Task WhenHandlerIsWrappedinStopWatch_MonitoringIsCalledWithTiming()
         {
             var handler = MockHandler();
@@ -75,6 +106,14 @@ namespace JustSaying.Messaging.UnitTests.Monitoring
             var handler = Substitute.For<IHandlerAsync<OrderAccepted>>();
             handler.Handle(Arg.Any<OrderAccepted>())
                 .Returns(Task.FromResult(true));
+            return handler;
+        }
+
+        private static IHandler<OrderAccepted> MockSyncHandler()
+        {
+            var handler = Substitute.For<IHandler<OrderAccepted>>();
+            handler.Handle(Arg.Any<OrderAccepted>())
+                .Returns(true);
             return handler;
         }
     }


### PR DESCRIPTION
# Do not merge

The failing test demonstrates an issue: The `StopwatchHandler` assumes that it came get the name of the inner handler and send it in the metrics.  But the rest of the code assumes that we can safely wrap handlers at will, multiple times for different purposes. And we keep introducing more of them: recently there is `BlockingHandler` and `ListHandler`.

These assumptions don't play well together, so we see metrics in statds with names like: `stats.timers.myapp.handlers.orderaccepted.futurehandler1.mean` or `stats.timers.myapp.handlers.paid.stopwatchhandler1.upper_90`

The handler name here is just noise. Is there a good way to fix that, or do we have to remove it?
