### PR TITLE
Handler resolution context

### DIFF
--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -115,10 +115,12 @@
     <Compile Include="WhenRegisteringASqsSubscriber\WhenRegisteringLongNameMessageTypeTopicSubscriber.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\GivenAPublisher.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\MultipleHandlerRegistry.cs" />
+    <Compile Include="WhenRegisteringHandlersViaResolver\NamedHandlerResolverTests.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\SingleHandlerRegistry.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\StructureMapHandlerResolver.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\BlockingHandlerRegistry.cs" />
     <Compile Include="TestHandlers\BlockingOrderProcessor.cs" />
+    <Compile Include="WhenRegisteringHandlersViaResolver\StructureMapNamedHandlerResolver.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\WhenRegisteringAHandlerViaContainerWithMissingRegistration.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\WhenRegisteringABlockingHandlerViaContainer.cs" />
     <Compile Include="WhenRegisteringHandlersViaResolver\WhenRegisteringASingleHandlerViaContainer.cs" />

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/NamedHandlerResolverTests.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/NamedHandlerResolverTests.cs
@@ -8,16 +8,6 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         private readonly IHandlerResolver _handlerResolver = new StructureMapNamedHandlerResolver();
 
         [Test]
-        public void TestDefaultResolution()
-        {
-            var context = new HandlerResolutionContext("no_match");
-            var handler = _handlerResolver.ResolveHandler<TestMessage>(context);
-
-            Assert.That(handler, Is.Not.Null);
-            Assert.That(handler, Is.InstanceOf<HandlerC>());
-        }
-
-        [Test]
         public void TestQueueAResolution()
         {
             var context = new HandlerResolutionContext("QueueA");
@@ -36,5 +26,16 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
             Assert.That(handler, Is.Not.Null);
             Assert.That(handler, Is.InstanceOf<HandlerB>());
         }
+
+        [Test]
+        public void TestOtherQueueNameResolution()
+        {
+            var context = new HandlerResolutionContext("QueueWithAnyOtherName");
+            var handler = _handlerResolver.ResolveHandler<TestMessage>(context);
+
+            Assert.That(handler, Is.Not.Null);
+            Assert.That(handler, Is.InstanceOf<HandlerC>());
+        }
+
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/NamedHandlerResolverTests.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/NamedHandlerResolverTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+
+namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
+{
+    [TestFixture]
+    public class NamedHandlerResolverTests
+    {
+        private readonly IHandlerResolver _handlerResolver = new StructureMapNamedHandlerResolver();
+
+        [Test]
+        public void TestDefaultResolution()
+        {
+            var context = new HandlerResolutionContext("no_match");
+            var handler = _handlerResolver.ResolveHandler<TestMessage>(context);
+
+            Assert.That(handler, Is.Not.Null);
+            Assert.That(handler, Is.InstanceOf<HandlerC>());
+        }
+
+        [Test]
+        public void TestQueueAResolution()
+        {
+            var context = new HandlerResolutionContext("QueueA");
+            var handler = _handlerResolver.ResolveHandler<TestMessage>(context);
+
+            Assert.That(handler, Is.Not.Null);
+            Assert.That(handler, Is.InstanceOf<HandlerA>());
+        }
+
+        [Test]
+        public void TestQueueBResolution()
+        {
+            var context = new HandlerResolutionContext("QueueB");
+            var handler = _handlerResolver.ResolveHandler<TestMessage>(context);
+
+            Assert.That(handler, Is.Not.Null);
+            Assert.That(handler, Is.InstanceOf<HandlerB>());
+        }
+    }
+}

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructureMapHandlerResolver.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructureMapHandlerResolver.cs
@@ -12,7 +12,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
             _container = container;
         }
 
-        public IHandlerAsync<T> ResolveHandler<T>()
+        public IHandlerAsync<T> ResolveHandler<T>(HandlerResolutionContext context)
         {
             var handler = _container.GetInstance<IHandlerAsync<T>>();
             if (handler != null)

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructuremapNamedHandlerResolver.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructuremapNamedHandlerResolver.cs
@@ -1,0 +1,59 @@
+﻿using System.Threading.Tasks;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Models;
+using StructureMap;
+
+namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
+{
+    public class TestMessage : Message
+    { }
+
+    public class HandlerA : IHandlerAsync<TestMessage>
+    {
+        public Task<bool> Handle(TestMessage message) => Task.FromResult(true);
+    }
+
+    public class HandlerB : IHandlerAsync<TestMessage>
+    {
+        public Task<bool> Handle(TestMessage message) => Task.FromResult(true);
+    }
+
+    public class HandlerC : IHandlerAsync<TestMessage>
+    {
+        public Task<bool> Handle(TestMessage message) => Task.FromResult(true);
+    }
+
+    public class StructureMapNamedHandlerResolver : IHandlerResolver
+    {
+        private readonly IContainer _container;
+
+        public StructureMapNamedHandlerResolver()
+        {
+            _container = new Container(ConfigureContainer);
+        }
+
+        private void ConfigureContainer(ConfigurationExpression config)
+        {
+            config.For<IHandlerAsync<TestMessage>>()
+                .Use<HandlerA>().Named("QueueA");
+
+            config.For<IHandlerAsync<TestMessage>>()
+                .Use<HandlerB>().Named("QueueB");
+
+            config.For<IHandlerAsync<TestMessage>>()
+                .Use<HandlerC>();
+        }
+
+        public IHandlerAsync<T> ResolveHandler<T>(HandlerResolutionContext context)
+        {
+            var namedHandler = _container.TryGetInstance<IHandlerAsync<T>>(context.QueueName);
+            if (namedHandler != null)
+            {
+                return namedHandler;
+            }
+
+            return _container.GetInstance<IHandlerAsync<T>>();
+        }
+    }
+
+}

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringABlockingHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringABlockingHandlerViaContainer.cs
@@ -13,9 +13,10 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         protected override void Given()
         {
            var container = new Container(x => x.AddRegistry(new BlockingHandlerRegistry()));
+            var resolutionContext = new HandlerResolutionContext("test");
 
            var handlerResolver = new StructureMapHandlerResolver(container);
-            var handler = handlerResolver.ResolveHandler<OrderPlaced>();
+            var handler = handlerResolver.ResolveHandler<OrderPlaced>(resolutionContext);
             Assert.That(handler, Is.Not.Null);
 
             var blockingHandler = (BlockingHandler<OrderPlaced>)handler;

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringASingleHandlerViaContainer.cs
@@ -12,9 +12,10 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
         protected override void Given()
         {
            var container = new Container(x => x.AddRegistry(new SingleHandlerRegistry()));
+            var resolutionContext = new HandlerResolutionContext("test");
 
-           var handlerResolver = new StructureMapHandlerResolver(container);
-            var handler = handlerResolver.ResolveHandler<OrderPlaced>();
+            var handlerResolver = new StructureMapHandlerResolver(container);
+            var handler = handlerResolver.ResolveHandler<OrderPlaced>(resolutionContext);
             Assert.That(handler, Is.Not.Null);
 
             _handlerFuture = ((OrderProcessor)handler).Future;

--- a/JustSaying/HandlerResolutionContext.cs
+++ b/JustSaying/HandlerResolutionContext.cs
@@ -1,0 +1,12 @@
+namespace JustSaying
+{
+    public class HandlerResolutionContext
+    {
+        public HandlerResolutionContext(string queueName)
+        {
+            QueueName = queueName;
+        }
+
+        public string QueueName { get; private set; }
+    }
+}

--- a/JustSaying/IHandlerResolver.cs
+++ b/JustSaying/IHandlerResolver.cs
@@ -4,6 +4,6 @@ namespace JustSaying
 {
     public interface IHandlerResolver
     {
-        IHandlerAsync<T> ResolveHandler<T>();
+        IHandlerAsync<T> ResolveHandler<T>(HandlerResolutionContext context);
     }
 }

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -64,6 +64,7 @@
     <Compile Include="DefaultNamingStrategy.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="HandlerNotRegisteredWithContainerException.cs" />
+    <Compile Include="HandlerResolutionContext.cs" />
     <Compile Include="IHandlerResolver.cs" />
     <Compile Include="IMessagingConfig.cs" />
     <Compile Include="CreateMeABus.cs" />

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -235,7 +235,8 @@ namespace JustSaying
 
             Bus.SerialisationRegister.AddSerialiser<T>(_serialisationFactory.GetSerialiser<T>());
 
-            var proposedHandler = handlerResolver.ResolveHandler<T>();
+            var resolutionContext = new HandlerResolutionContext(_subscriptionConfig.QueueName);
+            var proposedHandler = handlerResolver.ResolveHandler<T>(resolutionContext);
 
             if (proposedHandler == null)
             {
@@ -244,7 +245,7 @@ namespace JustSaying
 
             foreach (var region in Bus.Config.Regions)
             {
-                Bus.AddMessageHandler(region, _subscriptionConfig.QueueName, () => handlerResolver.ResolveHandler<T>());
+                Bus.AddMessageHandler(region, _subscriptionConfig.QueueName, () => handlerResolver.ResolveHandler<T>(resolutionContext));
             }
 
             Log.Info(


### PR DESCRIPTION
I would like Sebastien and others to have a look, as this related to a problem that Sebastien encountered.

When resolving a handler, provide a context so that different handlers can be resolved in different contexts if needed. The problem that we are addressing is that when we have two queues on the same topic, we want a different handler for each queue and this doesn't work well with the `IHandlerResolver`.

e.g.

````csharp
_fluentNotificationStack
    .WithSqsTopicSubscriber()
        .IntoQueue("QueueA")
        .WithMessageHandler<OrderPlaced>(_resolver)

    .WithSqsTopicSubscriber()
        .IntoQueue("QueueB")
        .WithMessageHandler<OrderPlaced>(_resolver)
````

Then we would like the resolver to resolve an instance of `OrderPlacedHandlerA` in the first case and an instance of `OrderPlacedHandlerB` in the second case. 

This change will give the handler resolver information that can be used to do this using IoC container mechanisms such as [named bindings](https://github.com/ninject/Ninject/wiki/Contextual-Binding#simple-constrained-resolution-named-bindings)

I'm not thrilled by the class name `HandlerResolutionContext` - it's long and the word "Context" is general enough to mean anything. But it is best to have a separate object for this task as it can be extended as been be without breaking anything else. Right now it looks like we only need the (short) queue name.

If the design is good, it probably needs a test demonstrating how to hook this into an IoC container and resolve different handlers?