### PR TITLE
DNM: Make message publishing async

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/Sns/TopicByName/WhenPublishing.cs
@@ -38,7 +38,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sns.TopicByName
         [Then]
         public void MessageIsPublishedToSnsTopic()
         {
-            _sns.Received().Publish(Arg.Is<PublishRequest>(x => B(x)));
+            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => B(x)));
         }
 
         private static bool B(PublishRequest x)
@@ -49,13 +49,13 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sns.TopicByName
         [Then]
         public void MessageSubjectIsObjectType()
         {
-            _sns.Received().Publish(Arg.Is<PublishRequest>(x => x.Subject == typeof(GenericMessage).Name));
+            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => x.Subject == typeof(GenericMessage).Name));
         }
 
         [Then]
         public void MessageIsPublishedToCorrectLocation()
         {
-            _sns.Received().Publish(Arg.Is<PublishRequest>(x => x.TopicArn == TopicArn));
+            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => x.TopicArn == TopicArn));
         }
     }
 }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/Sns/TopicByName/WhenPublishing.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.SimpleNotificationService;
+﻿using System.Threading.Tasks;
+using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using JustBehave;
 using JustSaying.AwsTools.MessageHandling;
@@ -9,7 +10,7 @@ using NSubstitute;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sns.TopicByName
 {
-    public class WhenPublishing : BehaviourTest<SnsTopicByName>
+    public class WhenPublishing : AsyncBehaviourTest<SnsTopicByName>
     {
         private const string Message = "the_message_in_json";
         private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
@@ -29,9 +30,9 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sns.TopicByName
             _sns.FindTopic("TopicName").Returns(new Topic { TopicArn = TopicArn });
         }
 
-        protected override void When()
+        protected override async Task When()
         {
-            SystemUnderTest.Publish(new GenericMessage());
+            await SystemUnderTest.Publish(new GenericMessage());
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/Sqs/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/Sqs/WhenPublishing.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.SQS;
 using Amazon.SQS.Model;
@@ -10,7 +11,7 @@ using NSubstitute;
 
 namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sqs
 {
-    public class WhenPublishing : BehaviourTest<SqsPublisher>
+    public class WhenPublishing : AsyncBehaviourTest<SqsPublisher>
     {
         private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
         private readonly IAmazonSQS _sqs = Substitute.For<IAmazonSQS>();
@@ -32,9 +33,9 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sqs
             _serialisationRegister.Serialise(_message, false).Returns("serialized_contents");
         }
 
-        protected override void When()
+        protected override async Task When()
         {
-            SystemUnderTest.Publish(_message);
+            await SystemUnderTest.Publish(_message);
         }
 
         [Then]

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/Sqs/WhenPublishing.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/Sqs/WhenPublishing.cs
@@ -42,13 +42,13 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sqs
         public void MessageIsPublishedToQueue()
         {
             // ToDo: Can be better...
-            _sqs.Received().SendMessage(Arg.Is<SendMessageRequest>(x => x.MessageBody.Equals("serialized_contents")));
+            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(x => x.MessageBody.Equals("serialized_contents")));
         }
 
         [Then]
         public void MessageIsPublishedToCorrectLocation()
         {
-            _sqs.Received().SendMessage(Arg.Is<SendMessageRequest>(x => x.QueueUrl == Url));
+            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(x => x.QueueUrl == Url));
         }
     }
 }

--- a/JustSaying.AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying.AwsTools/MessageHandling/SnsTopicBase.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
@@ -44,17 +45,20 @@ namespace JustSaying.AwsTools.MessageHandling
             return false;
         }
 
-        public void Publish(Message message)
+        public async Task Publish(Message message)
         {
             var messageToSend = _serialisationRegister.Serialise(message, serializeForSnsPublishing:true);
             var messageType = message.GetType().Name;
 
-            Client.Publish(new PublishRequest
+            var request = new PublishRequest
                 {
                     Subject = messageType,
                     Message = messageToSend,
                     TopicArn = Arn
-                });
+                };
+
+            await Client.PublishAsync(request)
+                .ConfigureAwait(false);
 
             EventLog.Info($"Published message: '{messageType}' with content {messageToSend}");
         }

--- a/JustSaying.AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying.AwsTools/MessageHandling/SnsTopicBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
@@ -57,10 +58,18 @@ namespace JustSaying.AwsTools.MessageHandling
                     TopicArn = Arn
                 };
 
-            await Client.PublishAsync(request)
-                .ConfigureAwait(false);
+            try
+            {
+                await Client.PublishAsync(request)
+                    .ConfigureAwait(false);
 
-            EventLog.Info($"Published message: '{messageType}' with content {messageToSend}");
+                EventLog.Info($"Published message: '{messageType}' with content {messageToSend}");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to publish message to SNS.TopicArn: {request.TopicArn} Subject: {request.Subject} Message: {request.Message}", ex);
+            }
+
         }
     }
 }

--- a/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.SQS;
@@ -28,8 +29,15 @@ namespace JustSaying.AwsTools.MessageHandling
                     QueueUrl = Url
                 };
 
-            await _client.SendMessageAsync(request)
-                .ConfigureAwait(false);
+            try
+            {
+                await _client.SendMessageAsync(request)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to publish message to SQS. QueueUrl: {request.QueueUrl} MessageBody: {request.MessageBody}", ex);
+            }
         }
 
         public string GetMessageInContext(Message message) => _serialisationRegister.Serialise(message, serializeForSnsPublishing: false);

--- a/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.SQS;
 using Amazon.SQS.Model;
@@ -19,13 +20,16 @@ namespace JustSaying.AwsTools.MessageHandling
             _serialisationRegister = serialisationRegister;
         }
 
-        public void Publish(Message message)
+        public async Task Publish(Message message)
         {
-            _client.SendMessage(new SendMessageRequest
-            {
-                MessageBody = GetMessageInContext(message),
-                QueueUrl = Url
-            });
+            var request = new SendMessageRequest
+                {
+                    MessageBody = GetMessageInContext(message),
+                    QueueUrl = Url
+                };
+
+            await _client.SendMessageAsync(request)
+                .ConfigureAwait(false);
         }
 
         public string GetMessageInContext(Message message) => _serialisationRegister.Serialise(message, serializeForSnsPublishing: false);

--- a/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
+++ b/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
@@ -12,7 +13,7 @@ using NSubstitute;
 
 namespace JustSaying.IntegrationTests
 {
-    public abstract class FluentNotificationStackTestBase : BehaviourTest<JustSaying.JustSayingFluently>
+    public abstract class FluentNotificationStackTestBase : AsyncBehaviourTest<JustSaying.JustSayingFluently>
     {
         private static readonly RegionEndpoint DefaultEndpoint = RegionEndpoint.EUWest1;
         protected static RegionEndpoint TestEndpoint { get; set; }
@@ -57,7 +58,7 @@ namespace JustSaying.IntegrationTests
             notificationStackField.SetValue(fns, NotificationStack);
         }
 
-        protected override void When()
+        protected override Task When()
         {
             throw new NotImplementedException();
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
@@ -49,7 +49,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             // When 
             bus.StartListening();
 
-            bus.Publish(new GenericMessage());
+            await bus.Publish(new GenericMessage());
 
             // Teardown
             await _handler.DoneSignal.Task;

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSnsToSqsSubscriber.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSnsToSqsSubscriber.cs
@@ -19,7 +19,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
 
         protected override async Task When()
         {
-            ServiceBus.Publish(new GenericMessage());
+            await ServiceBus.Publish(new GenericMessage());
 
             await _handler.DoneSignal;
         }

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSqsToSqsSubscriber.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAMessageIsPublishedViaSqsToSqsSubscriber.cs
@@ -19,7 +19,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
 
         protected override async Task When()
         {
-            ServiceBus.Publish(new AnotherGenericMessage());
+            await ServiceBus.Publish(new AnotherGenericMessage());
             await _handler.DoneSignal;
         }
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
@@ -25,7 +25,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
 
         protected override async Task When()
         {
-            ServiceBus.Publish(new GenericMessage());
+            await ServiceBus.Publish(new GenericMessage());
             await _handler.DoneSignal;
         }
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
@@ -42,7 +42,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
 
             // When
             _bus.StartListening();
-            _bus.Publish(new GenericMessage());
+            await _bus.Publish(new GenericMessage());
 
             // Teardown
             await doneSignal.Task;

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenPublishingAndNotInstantiated.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenPublishingAndNotInstantiated.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.TestingFramework;
 using NUnit.Framework;
@@ -16,9 +17,9 @@ namespace JustSaying.IntegrationTests.WhenRegisteringAPublisher
             RecordAnyExceptionsThrown();
         }
 
-        protected override void When()
+        protected override async Task When()
         {
-            SystemUnderTest.Publish(new GenericMessage());
+            await SystemUnderTest.Publish(new GenericMessage());
         }
 
         [Then]

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherAPublisherIsAddedToTheNotificationStack.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherAPublisherIsAddedToTheNotificationStack.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageSerialisation;
@@ -24,9 +25,10 @@ namespace JustSaying.IntegrationTests.WhenRegisteringAPublisher
             DeleteTopicIfItAlreadyExists(TestEndpoint, _topicName);
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSnsMessagePublisher<Message>();
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringAPublisher/WhenRegisteringAPublisherInANonDefaultRegion.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Amazon.SimpleNotificationService.Model;
 using JustBehave;
 using JustSaying.Models;
@@ -22,9 +23,10 @@ namespace JustSaying.IntegrationTests.WhenRegisteringAPublisher
 
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSnsMessagePublisher<Message>();
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
@@ -18,12 +18,13 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         public class TopicA : Message { }
         public class TopicB : Message { }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
                 .IntoQueue(QueueName)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<GenericMessage<TopicA>>>())
                 .WithMessageHandler(Substitute.For<IHandlerAsync<GenericMessage<TopicB>>>());
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsGenericMessageTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsGenericMessageTopicSubscriber.cs
@@ -1,4 +1,5 @@
-﻿using JustSaying.Messaging.MessageHandling;
+﻿using System.Threading.Tasks;
+using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 using NSubstitute;
 
@@ -13,11 +14,12 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 
     public class WhenRegisteringASqsGenericMessageTopicSubscriber : WhenRegisteringASqsTopicSubscriber
     {
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
                 .IntoQueue(QueueName)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<GenericMessage<MyMessage>>>());
+            return Task.FromResult(true);
         }
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
@@ -35,7 +35,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             Client = CreateMeABus.DefaultClientFactory().GetSqsClient(RegionEndpoint.EUWest1);
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
                 .IntoQueue(QueueName)
@@ -44,6 +44,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
                         cfg.MessageRetentionSeconds = 60;
                     })
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
+            return Task.FromResult(true);
         }
 
         [Then]
@@ -72,11 +73,12 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 
     public class WhenRegisteringASqsTopicSubscriberUsingBasicSyntax : WhenRegisteringASqsTopicSubscriber
     {
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
                 .IntoQueue(QueueName)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
+            return Task.FromResult(true);
         }
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.SimpleNotificationService.Model;
 using JustBehave;
@@ -31,12 +32,13 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             DeleteTopicIfItAlreadyExists(_regionEndpoint, _topicName);
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.WithSqsTopicSubscriber()
             .IntoQueue(_queueName)
             .ConfigureSubscriptionWith(cfg => cfg.MessageRetentionSeconds = 60)
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
@@ -1,4 +1,5 @@
-﻿using JustSaying.Messaging.MessageHandling;
+﻿using System.Threading.Tasks;
+using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 using NSubstitute;
 
@@ -12,11 +13,12 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 
         public class WhenRegisteringASqsGenericMessageTopicSubscriber : WhenRegisteringASqsTopicSubscriber
         {
-            protected override void When()
+            protected override Task When()
             {
                 SystemUnderTest.WithSqsTopicSubscriber()
                     .IntoQueue(QueueName)
                     .WithMessageHandler(Substitute.For<IHandlerAsync<LongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongMessage>>());
+                return Task.FromResult(true);
             }
         } 
     }

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/GivenAPublisher.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/GivenAPublisher.cs
@@ -23,7 +23,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 
         protected override async Task When()
         {
-            Publisher.Publish(new OrderPlaced("1234"));
+            await Publisher.Publish(new OrderPlaced("1234"));
 
             await WaitForDone();
 

--- a/JustSaying.Messaging/IMessagePublisher.cs
+++ b/JustSaying.Messaging/IMessagePublisher.cs
@@ -1,9 +1,10 @@
-﻿using JustSaying.Models;
+﻿using System.Threading.Tasks;
+using JustSaying.Models;
 
 namespace JustSaying.Messaging
 {
     public interface IMessagePublisher
     {
-        void Publish(Message message);
+        Task Publish(Message message);
     }
 }

--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
@@ -5,7 +5,7 @@ using NSubstitute;
 
 namespace JustSaying.UnitTests.JustSayingBus
 {
-    public abstract class GivenAServiceBus : BehaviourTest<JustSaying.JustSayingBus>
+    public abstract class GivenAServiceBus : AsyncBehaviourTest<JustSaying.JustSayingBus>
     {
         protected IMessagingConfig Config;
         protected IMessageMonitor Monitor;

--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBusWithoutMonitoring.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBusWithoutMonitoring.cs
@@ -4,7 +4,7 @@ using NSubstitute;
 
 namespace JustSaying.UnitTests.JustSayingBus
 {
-    public abstract class GivenAServiceBusWithoutMonitoring : BehaviourTest<JustSaying.JustSayingBus>
+    public abstract class GivenAServiceBusWithoutMonitoring : AsyncBehaviourTest<JustSaying.JustSayingBus>
     {
         protected IMessagingConfig Config;
         protected IMessageMonitor Monitor;

--- a/JustSaying.UnitTests/JustSayingBus/WhenAddingAPublisherWithNoTopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenAddingAPublisherWithNoTopic.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
@@ -13,9 +14,10 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddMessagePublisher<GenericMessage>(Substitute.For<IMessagePublisher>(), string.Empty);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
@@ -23,11 +24,11 @@ namespace JustSaying.UnitTests.JustSayingBus
                 .Do(x => { throw new TestException("Thrown by test WhenPublishingFails"); });
         }
 
-        protected override void When()
+        protected override async Task When()
         {
             SystemUnderTest.AddMessagePublisher<GenericMessage>(_publisher, string.Empty);
 
-            SystemUnderTest.Publish(new GenericMessage());
+            await SystemUnderTest.Publish(new GenericMessage());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessageWithoutMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessageWithoutMonitor.cs
@@ -4,6 +4,7 @@ using JustSaying.Messaging.Monitoring;
 using JustSaying.TestingFramework;
 using NSubstitute;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace JustSaying.UnitTests.JustSayingBus
 {
@@ -11,10 +12,10 @@ namespace JustSaying.UnitTests.JustSayingBus
     {
         private readonly IMessagePublisher _publisher = Substitute.For<IMessagePublisher>();
         
-        protected override void When()
+        protected override async Task When()
         {
             SystemUnderTest.AddMessagePublisher<GenericMessage>(_publisher, string.Empty);
-            SystemUnderTest.Publish(new GenericMessage());
+            await SystemUnderTest.Publish(new GenericMessage());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
@@ -9,11 +10,11 @@ namespace JustSaying.UnitTests.JustSayingBus
     {
         private readonly IMessagePublisher _publisher = Substitute.For<IMessagePublisher>();
         
-        protected override void When()
+        protected override async Task When()
         {
             SystemUnderTest.AddMessagePublisher<GenericMessage>(_publisher, string.Empty);
 
-            SystemUnderTest.Publish(new GenericMessage());
+            await SystemUnderTest.Publish(new GenericMessage());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingWithoutRegistering.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingWithoutRegistering.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Models;
 using NSubstitute;
@@ -14,9 +15,9 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override void When()
+        protected override async Task When()
         {
-            SystemUnderTest.Publish(Substitute.For<Message>());
+            await SystemUnderTest.Publish(Substitute.For<Message>());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageHandling;
@@ -31,13 +32,14 @@ namespace JustSaying.UnitTests.JustSayingBus
             _region = "west-1";
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddNotificationSubscriber(_region, _subscriber);
             SystemUnderTest.AddNotificationSubscriber(_region, _subscriber);
             SystemUnderTest.AddMessageHandler(_region, _subscriber.Queue, _futureHandler1);
             SystemUnderTest.AddMessageHandler(_region, _subscriber.Queue, _futureHandler2);
             SystemUnderTest.Start();
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.TestingFramework;
@@ -17,13 +18,14 @@ namespace JustSaying.UnitTests.JustSayingBus
             _publisher = Substitute.For<IMessagePublisher>();
         }
 
-        protected override void When()
+        protected override async Task When()
         {
             SystemUnderTest.AddMessagePublisher<OrderAccepted>(_publisher, string.Empty);
             SystemUnderTest.AddMessagePublisher<OrderRejected>(_publisher, string.Empty);
-            SystemUnderTest.Publish(new OrderAccepted());
-            SystemUnderTest.Publish(new OrderRejected());
-            SystemUnderTest.Publish(new OrderRejected());
+
+            await SystemUnderTest.Publish(new OrderAccepted());
+            await SystemUnderTest.Publish(new OrderRejected());
+            await SystemUnderTest.Publish(new OrderRejected());
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Messaging.Interrogation;
@@ -30,11 +31,12 @@ namespace JustSaying.UnitTests.JustSayingBus
             _subscriber2.Subscribers.Returns(new Collection<ISubscriber> {new Subscriber(typeof (GenericMessage))});
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber2);
             SystemUnderTest.Start();
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using JustSaying.Models;
@@ -19,10 +20,11 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddMessagePublisher<Message>(_publisher, string.Empty);
             SystemUnderTest.AddMessagePublisher<Message>(_publisher, string.Empty);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStartingThenStopping.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using NSubstitute;
@@ -15,11 +16,12 @@ namespace JustSaying.UnitTests.JustSayingBus
             _subscriber1 = Substitute.For<INotificationSubscriber>();
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
             SystemUnderTest.Start();
             SystemUnderTest.Stop();
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenStopping.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging;
 using NSubstitute;
@@ -18,12 +19,13 @@ namespace JustSaying.UnitTests.JustSayingBus
             _subscriber2.Queue.Returns("queue2");
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber2);
             SystemUnderTest.Start();
             SystemUnderTest.Stop();
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using JustBehave;
 using NUnit.Framework;
 
@@ -12,9 +13,10 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override void When()
+        protected override Task When()
         {
             SystemUnderTest.AddNotificationSubscriber(" ", null);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingBus/WhenUsingMultipleRegions.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenUsingMultipleRegions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NSubstitute;
 using JustBehave;
 using Shouldly;
@@ -14,8 +15,9 @@ namespace JustSaying.UnitTests.JustSayingBus
             Config.Regions.Returns(new List<string>{"region1", "region2"});
         }
 
-        protected override void When()
+        protected override Task When()
         {
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
@@ -19,13 +20,14 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
         }
 
-        protected override void When()
+        protected override Task When()
         {
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoDefaultQueue()
                 .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
@@ -22,13 +23,14 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
         }
 
-        protected override void When()
+        protected override Task When()
         {
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoDefaultQueue()
                 .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
@@ -12,11 +13,12 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
 
         protected override void Given() { }
 
-        protected override void When()
+        protected override Task When()
         {
             _bus = SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoQueue("queuename");
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging;
@@ -19,13 +20,14 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
         }
 
-        protected override void When()
+        protected override Task When()
         {
             _response = SystemUnderTest
                 .WithSqsPointToPointSubscriber()
                 .IntoDefaultQueue()
                 .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingMonitoring/WhenAddingACustomMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingMonitoring/WhenAddingACustomMonitor.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Messaging.Monitoring;
 using NSubstitute;
@@ -12,9 +13,10 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingMonitoring
 
         protected override void Given() { }
 
-        protected override void When()
+        protected override Task When()
         {
             _response = SystemUnderTest.WithMonitoring(_monitor);
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using JustBehave;
 using NUnit.Framework;
 
@@ -16,11 +17,12 @@ namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
             RecordAnyExceptionsThrown();
         }
 
-        protected override void When()
+        protected override Task When()
         {
             CreateMeABus
                 .InRegion(null)
                 .ConfigurePublisherWith(configuration => { });
+            return Task.FromResult(true);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluently/Publishing/WhenPublishing.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/Publishing/WhenPublishing.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.Models;
 using JustSaying.TestingFramework;
@@ -11,9 +12,9 @@ namespace JustSaying.UnitTests.JustSayingFluently.Publishing
 
         protected override void Given(){}
 
-        protected override void When()
+        protected override async Task When()
         {
-            SystemUnderTest.Publish(_message);
+            await SystemUnderTest.Publish(_message);
         }
 
         [Then]

--- a/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
+++ b/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
@@ -5,7 +5,7 @@ using NSubstitute;
 
 namespace JustSaying.UnitTests
 {
-    public abstract class JustSayingFluentlyTestBase : BehaviourTest<JustSaying.JustSayingFluently>
+    public abstract class JustSayingFluentlyTestBase : AsyncBehaviourTest<JustSaying.JustSayingFluently>
     {
         protected IPublishConfiguration Configuration;
         protected IAmJustSaying Bus;

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Extensions;
 using JustSaying.Messaging;
@@ -177,8 +177,7 @@ namespace JustSaying
             var publishersByTopic = _publishersByRegionAndTopic[activeRegion];
             if (!publishersByTopic.ContainsKey(topic))
             {
-                var errorMessage =
-                    $"Error publishing message, no publishers registered for message type {message} in {activeRegion}.";
+                var errorMessage = $"Error publishing message, no publishers registered for message type {message} in {activeRegion}.";
                 Log.Error(errorMessage);
                 throw new InvalidOperationException(errorMessage);
             }
@@ -191,8 +190,7 @@ namespace JustSaying
             attemptCount++;
             try
             {
-                var watch = new System.Diagnostics.Stopwatch();
-                watch.Start();
+                var watch = Stopwatch.StartNew();
 
                 await publisher.Publish(message);
 
@@ -204,10 +202,7 @@ namespace JustSaying
                 if (attemptCount >= Config.PublishFailureReAttempts)
                 {
                     Monitor.IssuePublishingMessage();
-
-                    // todo: log the raw text of the failed message
-                    var errorMessage = "Unable to publish message " + message.GetType().Name;
-                    Log.Error(ex, errorMessage);
+                    Log.Error(ex, $"Unable to publish message {message.GetType().Name} after {attemptCount} attempts");
                     throw;
                 }
 

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Amazon;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.MessageHandling;
@@ -144,14 +145,14 @@ namespace JustSaying
         /// Publish a message to the stack.
         /// </summary>
         /// <param name="message"></param>
-        public virtual void Publish(Message message)
+        public virtual async Task Publish(Message message)
         {
             if (Bus == null)
             {
                 throw new InvalidOperationException("You must register for message publication before publishing a message");
             }
             
-            Bus.Publish(message);
+            await Bus.Publish(message);
         }
 
         /// <summary>


### PR DESCRIPTION
**Do not merge** we are rethinking this.

Publishing a message is awaitable
Review the retry code.
Also add more details when publishing fails altogether (it does sometimes happen).

What is the policy on `throw new Exception` ? Should I throw this, some other existing type, or declare a new exception type for the purpose?