### PR TITLE
An exception for when publishing fails

### DIFF
--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -73,6 +73,7 @@
     <Compile Include="MessageHandling\LocalTopicArnProvider.cs" />
     <Compile Include="MessageHandling\MessageDispatcher.cs" />
     <Compile Include="MessageHandling\MessageHandlerWrapper.cs" />
+    <Compile Include="MessageHandling\PublishException.cs" />
     <Compile Include="MessageHandling\SnsPolicy.cs" />
     <Compile Include="MessageHandling\SqsPolicy.cs" />
     <Compile Include="QueueCreation\AmazonQueueCreator.cs" />

--- a/JustSaying.AwsTools/MessageHandling/PublishException.cs
+++ b/JustSaying.AwsTools/MessageHandling/PublishException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    [Serializable]
+    public class PublishException : Exception
+    {
+        public PublishException()
+        {
+        }
+
+        public PublishException(string message) : base(message)
+        {
+        }
+        public PublishException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
@@ -1,3 +1,4 @@
+using System;
 using Amazon;
 using Amazon.SQS;
 using Amazon.SQS.Model;
@@ -21,11 +22,22 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public void Publish(Message message)
         {
-            _client.SendMessage(new SendMessageRequest
+            var request = new SendMessageRequest
+                {
+                    MessageBody = GetMessageInContext(message),
+                    QueueUrl = Url
+                };
+
+            try
             {
-                MessageBody = GetMessageInContext(message),
-                QueueUrl = Url
-            });
+                _client.SendMessage(request);
+            }
+            catch (Exception ex)
+            {
+                throw new PublishException(
+                    $"Failed to publish message to SQS. QueueUrl: {request.QueueUrl} MessageBody: {request.MessageBody}",
+                    ex);
+            }
         }
 
         public string GetMessageInContext(Message message) => _serialisationRegister.Serialise(message, serializeForSnsPublishing: false);

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -208,10 +208,11 @@ namespace JustSaying
                 if (attemptCount >= Config.PublishFailureReAttempts)
                 {
                     Monitor.IssuePublishingMessage();
-                    Log.Error(ex, $"Unable to publish message {message.GetType().Name} after {attemptCount} attempts");
+                    Log.Error(ex, $"Failed to publish message {message.GetType().Name}. Halting after attempt {attemptCount}");
                     throw;
                 }
 
+                Log.Warn(ex, $"Failed to publish message {message.GetType().Name}. Retrying after attempt {attemptCount} of {Config.PublishFailureReAttempts}");
                 Thread.Sleep(Config.PublishFailureBackoffMilliseconds * attemptCount);
                 Publish(publisher, message, attemptCount);
             }


### PR DESCRIPTION
Include the relevant message and destination data when throwing an exception that indicates that `Publish` failed
NB we retry publishing (3 times by default), so the exception seen outside of JustSaying will be from the last attempt. Previous exceptions will be discarded.