### PR TITLE
ExactlyOnce timeout should default to max.

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/HandlerMetadataTest.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/HandlerMetadataTest.cs
@@ -36,6 +36,15 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling
         }
 
         [Test]
+        public void OnceHandlerWithImplicitTimeoutAsync_DefaultsToMaximum()
+        {
+            var handler = new OnceHandlerWithImplicitTimeoutAsync();
+            var reader = HandlerMetadata.ReadExactlyOnce(handler);
+
+            Assert.That(reader.GetTimeOut(), Is.EqualTo(int.MaxValue));
+        }
+
+        [Test]
         public void OnceTestHandler_DoesHaveExactlyOnce()
         {
             var handler = new OnceTestHandler();

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/HandlersWithMetadata.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/HandlersWithMetadata.cs
@@ -29,4 +29,13 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling
             return true;
         }
     }
+
+    [ExactlyOnce]
+    public class OnceHandlerWithImplicitTimeoutAsync : IHandlerAsync<GenericMessage>
+    {
+        public Task<bool> Handle(GenericMessage message)
+        {
+            return Task.FromResult(true);
+        }
+    }
 }

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -10,7 +10,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
     public class WhenExactlyOnceIsAppliedWithoutSpecificTimeout : BaseQueuePollingTest
     {
-        private readonly int _maximumTimeout = (int)TimeSpan.MaxValue.TotalSeconds;
+        private readonly int _maximumTimeout = int.MaxValue;
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         private ExactlyOnceSignallingHandler _handler;
 

--- a/JustSaying.Messaging/MessageHandling/ExactlyOnceAttribute.cs
+++ b/JustSaying.Messaging/MessageHandling/ExactlyOnceAttribute.cs
@@ -7,7 +7,7 @@ namespace JustSaying.Messaging.MessageHandling
     {
         public ExactlyOnceAttribute()
         {
-            TimeOut = (int) TimeSpan.MaxValue.TotalSeconds;
+            TimeOut = int.MaxValue;
         }
         public int TimeOut { get; set; }
     }


### PR DESCRIPTION
Removing incorrect cast from double to int that is causing integer overflow.