### PR TITLE
Fix memory leak introduced by Linked CTS

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -170,10 +170,11 @@ namespace JustSaying.AwsTools.MessageHandling
                 ReceiveMessageResponse sqsMessageResponse;
                 try
                 {
-                    var linkedCancellationToken =
-                        CancellationTokenSource.CreateLinkedTokenSource(ct, receiveTimeout.Token).Token;
-                    sqsMessageResponse = await _queue.Client.ReceiveMessageAsync(request, linkedCancellationToken)
-                        .ConfigureAwait(false);
+                    using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, receiveTimeout.Token))
+                    {
+                        sqsMessageResponse = await _queue.Client.ReceiveMessageAsync(request, linkedCts.Token)
+                            .ConfigureAwait(false);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
Fixes leak that was introduced by not disposing the CTS returned from ```CreateLinkedTokenSource```. Thanks to those that spotted this leak so quickly.