### PR TITLE
Revert fix to "ExactlyOnce"

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/HandlerMetadataTest.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/HandlerMetadataTest.cs
@@ -35,7 +35,7 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling
             Assert.That(reader.GetTimeOut(), Is.EqualTo(42));
         }
 
-        [Test]
+        [Test, Ignore("reverted")]
         public void OnceHandlerWithImplicitTimeoutAsync_DefaultsToMaximum()
         {
             var handler = new OnceHandlerWithImplicitTimeoutAsync();

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -10,7 +10,8 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling.SqsNotificationListener
 {
     public class WhenExactlyOnceIsAppliedWithoutSpecificTimeout : BaseQueuePollingTest
     {
-        private readonly int _maximumTimeout = int.MaxValue;
+        //private readonly int _maximumTimeout = int.MaxValue;
+        private readonly int _maximumTimeout = (int)TimeSpan.MaxValue.TotalSeconds;
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         private ExactlyOnceSignallingHandler _handler;
 

--- a/JustSaying.Messaging/MessageHandling/ExactlyOnceAttribute.cs
+++ b/JustSaying.Messaging/MessageHandling/ExactlyOnceAttribute.cs
@@ -7,7 +7,8 @@ namespace JustSaying.Messaging.MessageHandling
     {
         public ExactlyOnceAttribute()
         {
-            TimeOut = int.MaxValue;
+            //TimeOut = int.MaxValue;
+            TimeOut = (int)TimeSpan.MaxValue.TotalSeconds;
         }
         public int TimeOut { get; set; }
     }


### PR DESCRIPTION
revert https://github.com/justeat/JustSaying/commit/15635c3e8961371498f1c84f94eec4af8c78bdf3
It's not great to revert a bug fix.
But
This turned out to not be a trivial change, it changes the behaviour of an important live system, which has been working fine for more than a year with existing code.
 
Unfortunately we also need changes to `SqsNotificationListener` which were applied *after* https://github.com/justeat/JustSaying/commit/15635c3e8961371498f1c84f94eec4af8c78bdf3, for reliability of connection to queues. And we cannot apply it.

So we are stuck. One way to get us moving again is to
 * back out of this change to `ExactlyOnce` 
 * build and package with all the other fixes. We can use this package
 * re-apply this change in a safe manner
