### PR TITLE
Update aws sdk to 2.3.55.2

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
+++ b/JustSaying.AwsTools.IntegrationTests/JustSaying.AwsTools.IntegrationTests.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">

--- a/JustSaying.AwsTools.IntegrationTests/packages.config
+++ b/JustSaying.AwsTools.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />

--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">

--- a/JustSaying.AwsTools.UnitTests/packages.config
+++ b/JustSaying.AwsTools.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
   <package id="NSubstitute" version="1.9.1.0" targetFramework="net452" />

--- a/JustSaying.AwsTools/JustSaying.AwsTools.csproj
+++ b/JustSaying.AwsTools/JustSaying.AwsTools.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/JustSaying.AwsTools/packages.config
+++ b/JustSaying.AwsTools/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
 </packages>

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JustBehave, Version=1.0.0.12, Culture=neutral, processorArchitecture=MSIL">

--- a/JustSaying.IntegrationTests/packages.config
+++ b/JustSaying.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.36.9" targetFramework="net452" />
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="JustBehave" version="1.0.0.12" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -41,8 +41,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/JustSaying.TestingFramework/packages.config
+++ b/JustSaying.TestingFramework/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
   <package id="NUnit" version="3.0.1" targetFramework="net452" />
 </packages>

--- a/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/JustSaying.Tools/JustSaying.Tools.csproj
@@ -38,8 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Magnum, Version=2.1.3.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">

--- a/JustSaying.Tools/packages.config
+++ b/JustSaying.Tools/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="Magnum" version="2.1.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
 </packages>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.52.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.52.0\lib\net45\AWSSDK.dll</HintPath>
+    <Reference Include="AWSSDK, Version=2.3.55.2, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.2.3.55.2\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/JustSaying/packages.config
+++ b/JustSaying/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.3.52.0" targetFramework="net452" />
+  <package id="AWSSDK" version="2.3.55.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This is the latest release version and contains a fix to https://github.com/aws/aws-sdk-net/issues/152
Which is likely the case of our "hangs when reading from queues" issue
We have a workaround, but the internal fix is IMHO better.

The question is, do we still need the "linkedCancellationToken" measure that fixes it? 
If we view it as a fix to a very specific bug that we are sure is fixed then no.
If we view it as a general "belt and braces" reliability measure then yes.