### PR TITLE
Update develop to aws sdk v3.3.4

### DIFF
--- a/JustSaying.AwsTools.IntegrationTests/project.json
+++ b/JustSaying.AwsTools.IntegrationTests/project.json
@@ -33,9 +33,6 @@
     }
   },
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
     "JustBehave": "1.0.0.12",
     "JustSaying": "5.0.0",
     "JustSaying.AwsTools": "5.0.0",
@@ -46,7 +43,10 @@
     "NLog": "4.4.0-betaV15",
     "NSubstitute": "1.10.0",
     "NUnit": "3.5.0",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-2",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2"
   },
   "testRunner": "nunit",
   "frameworks": {

--- a/JustSaying.AwsTools.UnitTests/project.json
+++ b/JustSaying.AwsTools.UnitTests/project.json
@@ -33,9 +33,6 @@
     }
   },
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
     "JustBehave": "1.0.0.12",
     "JustSaying.AwsTools": "5.0.0",
     "JustSaying.Messaging": "5.0.0",
@@ -45,7 +42,10 @@
     "NLog": "4.4.0-betaV15",
     "NSubstitute": "1.10.0",
     "NUnit": "3.5.0",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-2",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2"
   },
   "testRunner": "nunit",
   "frameworks": {

--- a/JustSaying.AwsTools/project.json
+++ b/JustSaying.AwsTools/project.json
@@ -33,9 +33,9 @@
 		}
 	},
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2",
     "JustSaying.Messaging": "5.0.0",
     "Newtonsoft.Json": "9.0.1",
     "NLog": "4.4.0-betaV15"

--- a/JustSaying.IntegrationTests/project.json
+++ b/JustSaying.IntegrationTests/project.json
@@ -33,9 +33,6 @@
     }
   },
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
     "JustBehave": "1.0.0.12",
     "JustSaying": "5.0.0",
     "JustSaying.AwsTools": "5.0.0",
@@ -47,7 +44,10 @@
     "NSubstitute": "1.10.0",
     "NUnit": "3.5.0",
     "StructureMap": "4.4.1",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-2",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2"
   },
   "testRunner": "nunit",
   "frameworks": {

--- a/JustSaying.Messaging.UnitTests/project.json
+++ b/JustSaying.Messaging.UnitTests/project.json
@@ -33,9 +33,6 @@
     }
   },
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
     "JustBehave": "1.0.0.12",
     "JustSaying.AwsTools": "5.0.0",
     "JustSaying.Messaging": "5.0.0",
@@ -45,7 +42,10 @@
     "NLog": "4.4.0-betaV15",
     "NSubstitute": "1.10.0",
     "NUnit": "3.5.0",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-2",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2"
   },
   "testRunner": "nunit",
   "frameworks": {

--- a/JustSaying.TestingFramework/project.json
+++ b/JustSaying.TestingFramework/project.json
@@ -33,9 +33,9 @@
 		}
 	},
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2",
     "JustBehave": "1.0.0.12",
     "JustSaying.AwsTools": "5.0.0",
     "JustSaying.Messaging": "5.0.0",

--- a/JustSaying.Tools/project.json
+++ b/JustSaying.Tools/project.json
@@ -33,8 +33,8 @@
 		}
 	},
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SQS": "3.3.0",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SQS": "3.3.0.2",
     "JustSaying.AwsTools": "5.0.0",
     "JustSaying.Messaging": "5.0.0",
     "JustSaying.Models": "5.0.0",

--- a/JustSaying.UnitTests/project.json
+++ b/JustSaying.UnitTests/project.json
@@ -33,9 +33,6 @@
     }
   },
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
     "JustBehave": "1.0.0.12",
     "JustSaying": "5.0.0",
     "JustSaying.AwsTools": "5.0.0",
@@ -47,7 +44,10 @@
     "NSubstitute": "1.10.0",
     "NUnit": "3.5.0",
     "RhinoMocks": "3.6.1",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-2",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2"
   },
   "testRunner": "nunit",
   "frameworks": {

--- a/JustSaying/project.json
+++ b/JustSaying/project.json
@@ -33,9 +33,9 @@
 		}
 	},
   "dependencies": {
-    "AWSSDK.Core": "3.3.0.2",
-    "AWSSDK.SimpleNotificationService": "3.3.0",
-    "AWSSDK.SQS": "3.3.0",
+    "AWSSDK.Core": "3.3.4",
+    "AWSSDK.SimpleNotificationService": "3.3.0.2",
+    "AWSSDK.SQS": "3.3.0.2",
     "JustSaying.AwsTools": "5.0.0",
     "JustSaying.Messaging": "5.0.0",
     "JustSaying.Models": "5.0.0",


### PR DESCRIPTION
This is the latest release version and contains a fix to https://github.com/aws/aws-sdk-net/issues/152
Which is likely the case of our "hangs when reading from queues" issue
We have a workaround, but the internal fix is IMHO better.

The question is, do we still need the "linkedCancellationToken" measure that fixes it?
If we view it as a fix to a very specific bug that we are sure is fixed then no.
If we view it as a general "belt and braces" reliability measure then yes.