### PR TITLE
Longer polling timeout

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -166,7 +166,7 @@ namespace JustSaying.AwsTools.MessageHandling
                         WaitTimeSeconds = 20
                     };
 
-                var receiveTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                var receiveTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(300));
                 ReceiveMessageResponse sqsMessageResponse;
                 try
                 {


### PR DESCRIPTION
@JonahAcquah has done some investigation, and it appears that we hit the 30 second timeout very frequently, from some quick analysis I would estimate 25% of polls during quiet periods exceed this duration resulting in errors being logs, this invalidates my original assertion that 30 seconds is more than adequate.
Included #285 @JonahAcquah I think this is the branch you wanted it in.