### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.{build}-beta01
+version: 5.0.{build}-beta
 configuration: Release
 assembly_info:
   patch: true


### PR DESCRIPTION
Changed `beta01` to `beta`, we already have the build number in there, so I don't think we need different phases of beta, we can just introduce new builds keeping the beta suffix