### PR TITLE
SQS Message Timers

### DIFF
--- a/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
+++ b/JustSaying.AwsTools.UnitTests/JustSaying.AwsTools.UnitTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageProcessingThrowsDuring.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageProcessingThrowsBefore.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\WhenMessageHandlingThrows.cs" />
+    <Compile Include="MessageHandling\Sqs\WhenPublishingDelayedMessage.cs" />
     <Compile Include="QueueCreation\WhenSerializingRedrivePolicy.cs" />
     <Compile Include="MessageHandling\Sns\TopicByName\WhenPublishing.cs" />
     <Compile Include="MessageHandling\SqsNotificationListener\WhenAttemptingToInterrogateASubscriber.cs" />

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/Sqs/WhenPublishingDelayedMessage.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/Sqs/WhenPublishingDelayedMessage.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Amazon;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using JustBehave;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.TestingFramework;
+using NSubstitute;
+
+namespace JustSaying.AwsTools.UnitTests.MessageHandling.Sqs
+{
+    public class WhenPublishingDelayedMessage : BehaviourTest<SqsPublisher>
+    {
+        private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
+        private readonly IAmazonSQS _sqs = Substitute.For<IAmazonSQS>();
+        private const string Url = "https://blablabla/" + QueueName;
+        private readonly DelayedMessage _message = new DelayedMessage(delaySeconds: 1);
+        private const string QueueName = "queuename";
+
+        protected override SqsPublisher CreateSystemUnderTest()
+        {
+            var sqs = new SqsPublisher(RegionEndpoint.EUWest1, QueueName, _sqs, 0, _serialisationRegister);
+            sqs.Exists();
+            return sqs;
+        }
+
+        protected override void Given()
+        {
+            _sqs.ListQueues(Arg.Any<ListQueuesRequest>()).Returns(new ListQueuesResponse { QueueUrls = new List<string> { Url } });
+            _sqs.GetQueueAttributes(Arg.Any<GetQueueAttributesRequest>()).Returns(new GetQueueAttributesResponse());
+        }
+
+        protected override void When()
+        {
+            SystemUnderTest.Publish(_message);
+        }
+
+        [Then]
+        public void MessageIsPublishedWithDelaySecondsPropertySet()
+        {
+            _sqs.Received().SendMessage(Arg.Is<SendMessageRequest>(x => x.DelaySeconds.Equals(1)));
+        }
+    }
+}

--- a/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
@@ -24,7 +24,8 @@ namespace JustSaying.AwsTools.MessageHandling
             _client.SendMessage(new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                QueueUrl = Url
+                QueueUrl = Url,
+                DelaySeconds = message.DelaySeconds
             });
         }
 

--- a/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
@@ -25,7 +25,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 MessageBody = GetMessageInContext(message),
                 QueueUrl = Url,
-                DelaySeconds = message.DelaySeconds
+                DelaySeconds = message.DelaySeconds ?? 0
             });
         }
 

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -8,7 +8,6 @@ namespace JustSaying.Models
         {
             TimeStamp = DateTime.UtcNow;
             Id = Guid.NewGuid();
-            DelaySeconds = 0;
         }
 
         public Guid Id { get; set; }
@@ -20,7 +19,7 @@ namespace JustSaying.Models
         public string Conversation { get; set; }
         public string ReceiptHandle { get; set; }
         public string QueueUrl { get; set; }
-        public int DelaySeconds { get; set; }
+        public int? DelaySeconds { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey()

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -8,6 +8,7 @@ namespace JustSaying.Models
         {
             TimeStamp = DateTime.UtcNow;
             Id = Guid.NewGuid();
+            DelaySeconds = 0;
         }
 
         public Guid Id { get; set; }
@@ -19,6 +20,7 @@ namespace JustSaying.Models
         public string Conversation { get; set; }
         public string ReceiptHandle { get; set; }
         public string QueueUrl { get; set; }
+        public int DelaySeconds { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey()

--- a/JustSaying.TestingFramework/MessageStubs.cs
+++ b/JustSaying.TestingFramework/MessageStubs.cs
@@ -18,6 +18,14 @@ namespace JustSaying.TestingFramework
         public string Content { get; set; }
     }
 
+    public class DelayedMessage : Message
+    {
+        public DelayedMessage(int delaySeconds)
+        {
+            DelaySeconds = delaySeconds;
+        }
+    }
+
     public class MessageWithEnum : Message
     {
         public MessageWithEnum(Values enumVal)


### PR DESCRIPTION
Implementing SQS message timers.
http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html
Partially fixes #22 , because at the moment message can be delayed up to 15 mins when _DelaySecconds_ message property set (default is 0).