### PR TITLE
Only set DelaySeconds if provided

### DIFF
--- a/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying.AwsTools/MessageHandling/SqsPublisher.cs
@@ -33,9 +33,13 @@ namespace JustSaying.AwsTools.MessageHandling
             var request = new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                QueueUrl = Url,
-                DelaySeconds = message.DelaySeconds ?? 0
+                QueueUrl = Url
             };
+
+            if (message.DelaySeconds.HasValue)
+            {
+                request.DelaySeconds = message.DelaySeconds.Value;
+            }
 
             try
             {


### PR DESCRIPTION
DelaySeconds on the SendMessageRequest was being set to 0 if no value was provided which would override any Delivery Delay set on the queue.

This change only sets the DelaySeconds if the message to be published has provided a value so that any queue delay is still honoured.