### PR TITLE
Deprecate sync handlers

### DIFF
--- a/JustSaying.AwsTools.UnitTests/MessageHandling/HandlerMetadataTest.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/HandlerMetadataTest.cs
@@ -65,7 +65,9 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling
         [Test]
         public void WrappedHandler_DoesHaveExactlyOnce()
         {
+#pragma warning disable 618
             var wrapped = new BlockingHandler<GenericMessage>(new OnceTestHandler());
+#pragma warning restore 618
 
             var reader = HandlerMetadata.ReadExactlyOnce(wrapped);
 

--- a/JustSaying.AwsTools.UnitTests/MessageHandling/HandlersWithMetadata.cs
+++ b/JustSaying.AwsTools.UnitTests/MessageHandling/HandlersWithMetadata.cs
@@ -21,8 +21,11 @@ namespace JustSaying.AwsTools.UnitTests.MessageHandling
         }
     }
 
+// we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
     [ExactlyOnce(TimeOut = 23)]
     public class OnceTestHandler : IHandler<GenericMessage>
+#pragma warning restore 618
     {
         public bool Handle(GenericMessage message)
         {

--- a/JustSaying.AwsTools/MessageHandling/ExactlyOnceReader.cs
+++ b/JustSaying.AwsTools/MessageHandling/ExactlyOnceReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using JustSaying.Messaging.MessageHandling;
@@ -14,8 +14,11 @@ namespace JustSaying.AwsTools.MessageHandling
             return asyncingHandler != null ? ReadExactlyOnce(asyncingHandler.Inner) : new ExactlyOnceReader(handler.GetType());
         }
 
+// we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
         public static ExactlyOnceReader ReadExactlyOnce<T>(IHandler<T> handler) where T : Message
             => new ExactlyOnceReader(handler.GetType());
+#pragma warning restore 618
     }
 
     internal class ExactlyOnceReader

--- a/JustSaying.AwsTools/MessageHandling/ExactlyOnceReader.cs
+++ b/JustSaying.AwsTools/MessageHandling/ExactlyOnceReader.cs
@@ -8,18 +8,18 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     internal static class HandlerMetadata
     {
+        // we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
         public static ExactlyOnceReader ReadExactlyOnce<T>(IHandlerAsync<T> handler) where T : Message
         {
             var asyncingHandler = handler as BlockingHandler<T>;
             return asyncingHandler != null ? ReadExactlyOnce(asyncingHandler.Inner) : new ExactlyOnceReader(handler.GetType());
         }
 
-// we use the obsolete interface"IHandler<T>" here
-#pragma warning disable 618
         public static ExactlyOnceReader ReadExactlyOnce<T>(IHandler<T> handler) where T : Message
             => new ExactlyOnceReader(handler.GetType());
-#pragma warning restore 618
     }
+#pragma warning restore 618
 
     internal class ExactlyOnceReader
     {

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructureMapHandlerResolver.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructureMapHandlerResolver.cs
@@ -1,4 +1,4 @@
-using JustSaying.Messaging.MessageHandling;
+﻿using JustSaying.Messaging.MessageHandling;
 using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
@@ -20,11 +20,14 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
                 return handler;
             }
 
+            // we use the obsolete interface"IHandler<T>" here
+            #pragma warning disable 618
             var syncHandler = _container.GetInstance<IHandler<T>>();
             if (syncHandler != null)
             {
                 return new BlockingHandler<T>(syncHandler);
             }
+            #pragma warning restore 618
 
             return null;
         }

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringABlockingHandlerViaContainer.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/WhenRegisteringABlockingHandlerViaContainer.cs
@@ -1,4 +1,4 @@
-using JustSaying.IntegrationTests.TestHandlers;
+﻿using JustSaying.IntegrationTests.TestHandlers;
 using JustSaying.Messaging.MessageHandling;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
@@ -20,8 +20,12 @@ namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
             var handler = handlerResolver.ResolveHandler<OrderPlaced>(resolutionContext);
             Assert.That(handler, Is.Not.Null);
 
+            // we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
             var blockingHandler = (BlockingHandler<OrderPlaced>)handler;
             _resolvedHandler = (BlockingOrderProcessor)blockingHandler.Inner;
+#pragma warning restore 618
+
             DoneSignal = _resolvedHandler.DoneSignal.Task;
 
             Subscriber = CreateMeABus.WithLogging(new LoggerFactory())

--- a/JustSaying.Messaging.UnitTests/MessageHandling/BlockingHandlerTests.cs
+++ b/JustSaying.Messaging.UnitTests/MessageHandling/BlockingHandlerTests.cs
@@ -5,6 +5,9 @@ using JustSaying.TestingFramework;
 using NSubstitute;
 using NUnit.Framework;
 
+// we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
+
 namespace JustSaying.Messaging.UnitTests.MessageHandling
 {
     [TestFixture]

--- a/JustSaying.Messaging/MessageHandling/BlockingHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/BlockingHandler.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+// we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
+
 namespace JustSaying.Messaging.MessageHandling
 {
 

--- a/JustSaying.Messaging/MessageHandling/BlockingHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/BlockingHandler.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-// we use the obsolete interface"IHandler<T>" here
-#pragma warning disable 618
-
 namespace JustSaying.Messaging.MessageHandling
 {
 
@@ -12,12 +9,15 @@ namespace JustSaying.Messaging.MessageHandling
     /// So that the rest of the system only has to deal with IAsyncHandler
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    [Obsolete("Use IHandlerAsync")]
     public class BlockingHandler<T> : IHandlerAsync<T>
     {
         public BlockingHandler(IHandler<T> inner)
         {
             if (inner == null)
+            {
                 throw new ArgumentNullException(nameof(inner));
+            }
 
             Inner = inner;
         }

--- a/JustSaying.Messaging/MessageHandling/IHandler.cs
+++ b/JustSaying.Messaging/MessageHandling/IHandler.cs
@@ -1,9 +1,12 @@
-﻿namespace JustSaying.Messaging.MessageHandling
+﻿using System;
+
+namespace JustSaying.Messaging.MessageHandling
 {
     /// <summary>
     /// Synchronous message handler, will be obsoleted by IHandlerAsync
     /// </summary>
     /// <typeparam name="T">Type of message to be handled</typeparam>
+    [Obsolete("Use IHandlerAsync")]
     public interface IHandler<in T>
     {
         /// <summary>

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -210,11 +210,9 @@ namespace JustSaying
             return this;
         }
 
-// we use the obsolete interface"IHandler<T>" here
-#pragma warning disable 618
+        [Obsolete("Use WithMessageHandler<T>(IHandlerAsync<T> handler)")]
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandler<T> handler) where T : Message
             => WithMessageHandler(new BlockingHandler<T>(handler));
-#pragma warning restore 618
 
         /// <summary>
         /// Set message handlers for the given topic

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Amazon;
 using JustSaying.AwsTools;
@@ -210,8 +210,11 @@ namespace JustSaying
             return this;
         }
 
+// we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandler<T> handler) where T : Message
             => WithMessageHandler(new BlockingHandler<T>(handler));
+#pragma warning restore 618
 
         /// <summary>
         /// Set message handlers for the given topic

--- a/JustSaying/JustSayingFluentlyInterfaces.cs
+++ b/JustSaying/JustSayingFluentlyInterfaces.cs
@@ -70,10 +70,8 @@ namespace JustSaying
 
     public interface IFluentSubscription
     {
-// we use the obsolete interface"IHandler<T>" here
-#pragma warning disable 618
+        [Obsolete("Use WithMessageHandler<T>(IHandlerAsync<T> handler)")]
         IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandler<T> handler) where T : Message;
-#pragma warning restore 618
 
         IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerAsync<T> handler) where T : Message;
 

--- a/JustSaying/JustSayingFluentlyInterfaces.cs
+++ b/JustSaying/JustSayingFluentlyInterfaces.cs
@@ -70,7 +70,10 @@ namespace JustSaying
 
     public interface IFluentSubscription
     {
+// we use the obsolete interface"IHandler<T>" here
+#pragma warning disable 618
         IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandler<T> handler) where T : Message;
+#pragma warning restore 618
 
         IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerAsync<T> handler) where T : Message;
 


### PR DESCRIPTION
The non-async `IHandler` interface is now deprecated in favour of `IHandlerAsync`