### PR TITLE
When a message is created from another message, store the parent id

### DIFF
--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace JustSaying.Models
 {
@@ -8,11 +8,20 @@ namespace JustSaying.Models
         {
             TimeStamp = DateTime.UtcNow;
             Id = Guid.NewGuid();
+            CorrelationId = Id;
         }
 
+        protected Message(Message message)
+        {
+            TimeStamp = DateTime.UtcNow;
+            Id = Guid.NewGuid();
+            CorrelationId = message.CorrelationId;
+        }
+        
         public Guid Id { get; set; }
         public DateTime TimeStamp { get; set; }
         public string RaisingComponent { get; set; }
+        public Guid CorrelationId { get; private set; }
         public string Version{ get; private set; }
         public string SourceIp { get; private set; }
         public string Tenant { get; set; }

--- a/JustSaying.TestingFramework/MessageStubs.cs
+++ b/JustSaying.TestingFramework/MessageStubs.cs
@@ -15,6 +15,11 @@ namespace JustSaying.TestingFramework
 
     public class AnotherGenericMessage : Message
     {
+
+        public AnotherGenericMessage() 
+        {
+        }
+
         public string Content { get; set; }
     }
 
@@ -37,4 +42,11 @@ namespace JustSaying.TestingFramework
     }
 
     public enum Values { One, Two };
+
+    public class DownStreamMessage : Message
+    {
+        public DownStreamMessage(Message message) : base(message)
+        {
+        }
+    }
 }

--- a/JustSaying.UnitTests/Traceability/TraceablityTests.cs
+++ b/JustSaying.UnitTests/Traceability/TraceablityTests.cs
@@ -1,0 +1,19 @@
+﻿using JustSaying.TestingFramework;
+using NUnit.Framework;
+
+namespace JustSaying.UnitTests.Traceability
+{
+    [TestFixture]
+    public class TraceablityTests
+    {
+        [Test]
+        public void ParentMessageIdIsRecorded()
+        {
+            var message = new OrderAccepted();
+
+            var downStreamMessage = new DownStreamMessage(message);            
+
+            Assert.That(downStreamMessage.CorrelationId, Is.EqualTo(message.Id));
+        }
+    }
+}


### PR DESCRIPTION
We have an issue, where we are at least 3rd in the chain of messages which have missing OrderId's. Trying to trace the source of message, which has been created from other messages. 

Would be grateful for any feedback or an alternate solution.