### PR TITLE
Define a compile-time constant

### DIFF
--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -54,7 +54,7 @@ namespace JustSaying.AwsTools.MessageHandling
             return false;
         }
 
-#if NET451
+#if AWS_SDK_HAS_SYNC
         public void Publish(Message message)
         {
             var request = BuildPublishRequest(message);

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -22,7 +22,7 @@ namespace JustSaying.AwsTools.MessageHandling
             _serialisationRegister = serialisationRegister;
         }
 
-#if NET451
+#if AWS_SDK_HAS_SYNC
         public void Publish(Message message)
         {
             var request = BuildSendMessageRequest(message);

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -25,4 +25,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+	<DefineConstants>$(DefineConstants);AWS_SDK_HAS_SYNC</DefineConstants> 
+  </PropertyGroup>
 </Project>

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -153,7 +153,7 @@ namespace JustSaying
             }
         }
 
-#if NET451
+#if AWS_SDK_HAS_SYNC
         public void Publish(Message message)
         {
             var publisher = GetActivePublisherForMessage(message);

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -147,7 +147,7 @@ namespace JustSaying
             _log.LogInformation("Stopped listening for messages");
         }
 
-#if NET451
+#if AWS_SDK_HAS_SYNC
         /// <summary>
         /// Publish a message to the stack.
         /// </summary>

--- a/JustSaying/Messaging/IMessagePublisher.cs
+++ b/JustSaying/Messaging/IMessagePublisher.cs
@@ -5,7 +5,7 @@ namespace JustSaying.Messaging
 {
     public interface IMessagePublisher
     {
-#if NET451
+#if AWS_SDK_HAS_SYNC
         void Publish(Message message);
 #endif
         Task PublishAsync(Message message);


### PR DESCRIPTION
Define a compile-time constant for the case where we can use sync methods on the AWS SDK (i.e. the full .Net framework case) 
`AWS_SDK_HAS_SYNC`  Use instead of `#if NET451`
So if we update the framework version we update in one place only.