### PR TITLE
#208 Set Queue Attriute after Queue Creation

### DIFF
--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
@@ -51,13 +51,12 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             try
             {
-                var result = await Client.CreateQueueAsync(new CreateQueueRequest{
-                    QueueName = QueueName,
-                    Attributes = GetCreateQueueAttributes(queueConfig)});
+                var queueResponse = await Client.CreateQueueAsync(QueueName);
 
-                if (!string.IsNullOrWhiteSpace(result?.QueueUrl))
+                if (!string.IsNullOrWhiteSpace(queueResponse?.QueueUrl))
                 {
-                    Url = result.QueueUrl;
+                    Url = queueResponse.QueueUrl;
+                    await Client.SetQueueAttributesAsync(queueResponse.QueueUrl, GetCreateQueueAttributes(queueConfig));
                     await SetQueuePropertiesAsync();
 
                     _log.LogInformation($"Created Queue: {QueueName} on Arn: {Arn}");


### PR DESCRIPTION
This is to fix the issue of "Amazon.SQS.Model.QueueNameExistsException A queue already exists with the same name and a different value for attribute MessageRetentionPeriod"

The error happens intermittently and not always reproducible. So far, we (GOPD Team 1) had to tear down the environment and bring it back, when encountered with the error. This change will fix the issue by overriding the attribute settings. Please have a look on https://github.com/justeat/JustSaying/issues/208