### PR TITLE
Add ApproximateReceiveCount to Message

### DIFF
--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -20,6 +20,7 @@ namespace JustSaying.Models
         public string ReceiptHandle { get; set; }
         public string QueueUrl { get; set; }
         public int? DelaySeconds { get; set; }
+        public int ApproximateReceiveCount { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey() => Id.ToString();

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -71,6 +71,8 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     typedMessage.ReceiptHandle = message.ReceiptHandle;
                     typedMessage.QueueUrl = _queue.Url;
+                    TryGetApproxReceiveCount(message.Attributes, out int approxReceiveCount);
+                    typedMessage.ApproximateReceiveCount = approxReceiveCount;
                     handlingSucceeded = await CallMessageHandler(typedMessage).ConfigureAwait(false);
                 }
 


### PR DESCRIPTION
Including `ApproximateReceiveCount` on `Message` would allow handlers to perform different actions based on approximately how many times a message has been received. For example, checking a cache before falling back to calling an API for data.