### PR TITLE
lighter dependencies for the models assembly

### DIFF
--- a/JustSaying.Models/JustSaying.Models.csproj
+++ b/JustSaying.Models/JustSaying.Models.csproj
@@ -3,15 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageReference Include="System.Net.WebHeaderCollection" Version="4.3.0" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />


### PR DESCRIPTION
`JustSaying.Models` is very small, contains just the `Message` base class. 
It doesn't use `Newtonsoft.json`, so should not specify a version for consumers etc