### PR TITLE
Add ability to handle exception on a per notification basis

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
@@ -25,7 +25,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
         {
             var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new SnsWriteConfiguration
             {
-                OnException = (ex, request) => true
+                HandleException = ex => true
             });
 
             topic.Exists();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using JustBehave;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
+{
+    public class WhenPublishingAsyncExceptionCanBeHandled : XAsyncBehaviourTest<SnsTopicByName>
+    {
+        private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
+        private readonly IAmazonSimpleNotificationService _sns = Substitute.For<IAmazonSimpleNotificationService>();
+        private const string TopicArn = "topicarn";
+
+        protected override SnsTopicByName CreateSystemUnderTest()
+        {
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>())
+            {
+                SnsWriteConfiguration = new SnsWriteConfiguration
+                {
+                    OnException = (ex, request) => true
+                }
+            };
+
+            topic.Exists();
+            return topic;
+        }
+
+        protected override void Given()
+        {
+            _sns.FindTopicAsync("TopicName")
+                .Returns(new Topic { TopicArn = TopicArn });
+        }
+
+        protected override Task When()
+        {
+            _sns.PublishAsync(Arg.Any<PublishRequest>()).Returns(ThrowsException);
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public void FailSilently()
+        {
+            Should.NotThrow(() => SystemUnderTest.PublishAsync(new GenericMessage()).Wait());
+        }
+
+        private static Task<PublishResponse> ThrowsException(CallInfo callInfo)
+        {
+            throw new WebException("Operation timed out", WebExceptionStatus.Timeout);
+        }
+    }
+}

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
@@ -23,13 +23,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         protected override SnsTopicByName CreateSystemUnderTest()
         {
-            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>())
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new SnsWriteConfiguration
             {
-                SnsWriteConfiguration = new SnsWriteConfiguration
-                {
-                    OnException = (ex, request) => true
-                }
-            };
+                OnException = (ex, request) => true
+            });
 
             topic.Exists();
             return topic;

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using JustBehave;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Messaging.MessageSerialisation;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
+{
+    public class WhenPublishingAsyncExceptionCanBeThrown : XAsyncBehaviourTest<SnsTopicByName>
+    {
+        private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
+        private readonly IAmazonSimpleNotificationService _sns = Substitute.For<IAmazonSimpleNotificationService>();
+        private const string TopicArn = "topicarn";
+
+        protected override SnsTopicByName CreateSystemUnderTest()
+        {
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>())
+            {
+                SnsWriteConfiguration = new SnsWriteConfiguration
+                {
+                    OnException = (ex, request) => false
+                }
+            };
+
+            topic.Exists();
+            return topic;
+        }
+
+        protected override void Given()
+        {
+            _sns.FindTopicAsync("TopicName")
+                .Returns(new Topic { TopicArn = TopicArn });
+        }
+
+        protected override Task When()
+        {
+            _sns.PublishAsync(Arg.Any<PublishRequest>()).Returns(ThrowsException);
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task ExceptionIsThrown()
+        {
+            await Should.ThrowAsync<PublishException>(() => SystemUnderTest.PublishAsync(new GenericMessage()));
+        }
+
+        [Fact]
+        public async Task ExceptionContainsContext()
+        {
+            try
+            {
+                await SystemUnderTest.PublishAsync(new GenericMessage());
+            }
+            catch (Exception e)
+            {
+                var exception = (WebException) e.InnerException;
+                exception.Status.ShouldBe(WebExceptionStatus.Timeout);
+            }
+        }
+
+        private static Task<PublishResponse> ThrowsException(CallInfo callInfo)
+        {
+            throw new WebException("Operation timed out", WebExceptionStatus.Timeout);
+        }
+    }
+}

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -26,7 +26,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
         {
             var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new SnsWriteConfiguration
             {
-                OnException = (ex, request) => false
+                HandleException = ex => false
             });
 
             topic.Exists();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -24,13 +24,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         protected override SnsTopicByName CreateSystemUnderTest()
         {
-            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>())
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new SnsWriteConfiguration
             {
-                SnsWriteConfiguration = new SnsWriteConfiguration
-                {
-                    OnException = (ex, request) => false
-                }
-            };
+                OnException = (ex, request) => false
+            });
 
             topic.Exists();
             return topic;

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -63,7 +63,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }
             catch (Exception ex)
             {
-                if (!ClientExceptionHandler(ex, request))
+                if (!ClientExceptionHandler(ex))
                     throw new PublishException(
                         $"Failed to publish message to SNS. TopicArn: {request.TopicArn} Subject: {request.Subject} Message: {request.Message}",
                         ex);
@@ -83,18 +83,18 @@ namespace JustSaying.AwsTools.MessageHandling
             }
             catch (Exception ex)
             {
-                if (!ClientExceptionHandler(ex, request))
+                if (!ClientExceptionHandler(ex))
                     throw new PublishException(
                         $"Failed to publish message to SNS. TopicArn: {request.TopicArn} Subject: {request.Subject} Message: {request.Message}",
                         ex);
             }
         }
 
-        private bool ClientExceptionHandler(Exception ex, PublishRequest request)
+        private bool ClientExceptionHandler(Exception ex)
         {
             bool exceptionIsHandled = false;
-            if (_snsWriteConfiguration?.OnException != null)
-                exceptionIsHandled = _snsWriteConfiguration.OnException.Invoke(ex, request);
+            if (_snsWriteConfiguration?.HandleException != null)
+                exceptionIsHandled = _snsWriteConfiguration.HandleException.Invoke(ex);
 
             return exceptionIsHandled;
         }

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -13,7 +13,7 @@ namespace JustSaying.AwsTools.MessageHandling
     public abstract class SnsTopicBase : IMessagePublisher
     {
         private readonly IMessageSerialisationRegister _serialisationRegister; // ToDo: Grrr...why is this here even. GET OUT!
-        public SnsWriteConfiguration SnsWriteConfiguration { private get; set; }
+        private readonly SnsWriteConfiguration _snsWriteConfiguration;
         public string Arn { get; protected set; }
         protected IAmazonSimpleNotificationService Client { get; set; }
         private readonly ILogger _eventLog;
@@ -24,6 +24,14 @@ namespace JustSaying.AwsTools.MessageHandling
             _serialisationRegister = serialisationRegister;
             _log = loggerFactory.CreateLogger("JustSaying");
             _eventLog = loggerFactory.CreateLogger("EventLog");
+        }
+
+        protected SnsTopicBase(IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory, SnsWriteConfiguration snsWriteConfiguration)
+        {
+            _serialisationRegister = serialisationRegister;
+            _log = loggerFactory.CreateLogger("JustSaying");
+            _eventLog = loggerFactory.CreateLogger("EventLog");
+            _snsWriteConfiguration = snsWriteConfiguration;
         }
 
         protected abstract Task<bool> ExistsAsync();
@@ -85,8 +93,8 @@ namespace JustSaying.AwsTools.MessageHandling
         private bool ClientExceptionHandler(Exception ex, PublishRequest request)
         {
             bool exceptionIsHandled = false;
-            if (SnsWriteConfiguration?.OnException != null)
-                exceptionIsHandled = SnsWriteConfiguration.OnException(ex, request);
+            if (_snsWriteConfiguration?.OnException != null)
+                exceptionIsHandled = _snsWriteConfiguration.OnException.Invoke(ex, request);
 
             return exceptionIsHandled;
         }
@@ -102,6 +110,5 @@ namespace JustSaying.AwsTools.MessageHandling
                 Message = messageToSend
             };
         }
-
     }
 }

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -90,14 +90,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }
         }
 
-        private bool ClientExceptionHandler(Exception ex)
-        {
-            bool exceptionIsHandled = false;
-            if (_snsWriteConfiguration?.HandleException != null)
-                exceptionIsHandled = _snsWriteConfiguration.HandleException.Invoke(ex);
-
-            return exceptionIsHandled;
-        }
+        private bool ClientExceptionHandler(Exception ex) => _snsWriteConfiguration?.HandleException?.Invoke(ex) ?? false;
 
         private PublishRequest BuildPublishRequest(Message message)
         {

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging.MessageSerialisation;
 using Microsoft.Extensions.Logging;
 
@@ -16,6 +17,14 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public SnsTopicByName(string topicName, IAmazonSimpleNotificationService client, IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory)
             : base(serialisationRegister, loggerFactory)
+        {
+            TopicName = topicName;
+            Client = client;
+            _log = loggerFactory.CreateLogger("JustSaying");
+        }
+
+        public SnsTopicByName(string topicName, IAmazonSimpleNotificationService client, IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory, SnsWriteConfiguration snsWriteConfiguration)
+            : base(serialisationRegister, loggerFactory, snsWriteConfiguration)
         {
             TopicName = topicName;
             Client = client;

--- a/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -6,7 +6,7 @@ namespace JustSaying.AwsTools.QueueCreation
     public class SnsWriteConfiguration
     {
         /// <summary>
-        /// Extension point enabling custom error handling on a per notification basis, including ability handle the exception.
+        /// Extension point enabling custom error handling on a per notification basis, including ability handle raised exceptions.
         /// </summary>
         /// <returns>Boolean indicating whether the exception has been handled</returns>
         public Func<Exception, bool> HandleException { get; set; }

--- a/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -9,6 +9,6 @@ namespace JustSaying.AwsTools.QueueCreation
         /// Extension point allows custom error handling, including ability to specify whether exception has been explictly handled by consumer.
         /// </summary>
         /// <returns>Boolean to indicate whether the exception has already been handled by the consumer</returns>
-        public Func<Exception, PublishRequest, bool> OnException { get; set; }
+        public Func<Exception, bool> HandleException { get; set; }
     }
 }

--- a/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -6,9 +6,9 @@ namespace JustSaying.AwsTools.QueueCreation
     public class SnsWriteConfiguration
     {
         /// <summary>
-        /// Extension point allows custom error handling, including ability to specify whether exception has been explictly handled by consumer.
+        /// Extension point enabling custom error handling on a per notification basis, including ability handle the exception.
         /// </summary>
-        /// <returns>Boolean to indicate whether the exception has already been handled by the consumer</returns>
+        /// <returns>Boolean indicating whether the exception has been handled</returns>
         public Func<Exception, bool> HandleException { get; set; }
     }
 }

--- a/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Amazon.SimpleNotificationService.Model;
+
+namespace JustSaying.AwsTools.QueueCreation
+{
+    public class SnsWriteConfiguration
+    {
+        /// <summary>
+        /// Extension point allows custom error handling, including ability to specify whether exception has been explictly handled by consumer.
+        /// </summary>
+        /// <returns>Boolean to indicate whether the exception has already been handled by the consumer</returns>
+        public Func<Exception, PublishRequest, bool> OnException { get; set; }
+    }
+}

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -26,6 +26,6 @@
     <Reference Include="System" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-	<DefineConstants>$(DefineConstants);AWS_SDK_HAS_SYNC</DefineConstants> 
+    <DefineConstants>$(DefineConstants);AWS_SDK_HAS_SYNC</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -58,7 +58,26 @@ namespace JustSaying
         /// <returns></returns>
         public IHaveFulfilledPublishRequirements WithSnsMessagePublisher<T>() where T : Message
         {
+            return WithSnsMessagePublisher<T>(null);
+        }
+
+        /// <summary>
+        /// Register for publishing messages to SNS
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public IHaveFulfilledPublishRequirements WithSnsMessagePublisher<T>(Action<SnsWriteConfiguration> configBuilder) where T : Message
+        {
+            return AddSnsMessagePublisher<T>(configBuilder);
+        }
+
+        private IHaveFulfilledPublishRequirements AddSnsMessagePublisher<T>(Action<SnsWriteConfiguration> configBuilder) where T : Message
+        {
             _log.LogInformation("Adding SNS publisher");
+
+            var config = new SnsWriteConfiguration();
+            configBuilder?.Invoke(config);
+
             _subscriptionConfig.Topic = GetMessageTypeName<T>();
             var namingStrategy = GetNamingStrategy();
 
@@ -72,7 +91,7 @@ namespace JustSaying
                     topicName,
                     _awsClientFactoryProxy.GetAwsClientFactory().GetSnsClient(RegionEndpoint.GetBySystemName(region)),
                     Bus.SerialisationRegister,
-                    _loggerFactory);
+                    _loggerFactory) {SnsWriteConfiguration = config};
 
                 eventPublisher.Create();
 

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -75,8 +75,8 @@ namespace JustSaying
         {
             _log.LogInformation("Adding SNS publisher");
 
-            var config = new SnsWriteConfiguration();
-            configBuilder?.Invoke(config);
+            var snsWriteConfig = new SnsWriteConfiguration();
+            configBuilder?.Invoke(snsWriteConfig);
 
             _subscriptionConfig.Topic = GetMessageTypeName<T>();
             var namingStrategy = GetNamingStrategy();
@@ -91,7 +91,7 @@ namespace JustSaying
                     topicName,
                     _awsClientFactoryProxy.GetAwsClientFactory().GetSnsClient(RegionEndpoint.GetBySystemName(region)),
                     Bus.SerialisationRegister,
-                    _loggerFactory) {SnsWriteConfiguration = config};
+                    _loggerFactory, snsWriteConfig);
 
                 eventPublisher.Create();
 

--- a/JustSaying/JustSayingFluentlyInterfaces.cs
+++ b/JustSaying/JustSayingFluentlyInterfaces.cs
@@ -53,10 +53,11 @@ namespace JustSaying
     {
         IHaveFulfilledPublishRequirements ConfigurePublisherWith(Action<IPublishConfiguration> confBuilder);
         IHaveFulfilledPublishRequirements WithSnsMessagePublisher<T>() where T : Message;
+        IHaveFulfilledPublishRequirements WithSnsMessagePublisher<T>(Action<SnsWriteConfiguration> config) where T : Message;
         IHaveFulfilledPublishRequirements WithSqsMessagePublisher<T>(Action<SqsWriteConfiguration> config) where T : Message;
 
         /// <summary>
-        /// Adds subscriber to topic. 
+        /// Adds subscriber to topic.
         /// </summary>
         /// <param name="topicName">Topic name to subscribe to. If left empty,
         /// topic name will be message type name</param>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here's how to get up & running with simple message publishing.
 ````
 
 ### 2. Registering publishers
-* You will need to tell JustSaying which messages you intend to publish in order that it can setup any missing topics for you.
+* You will need to tell JustSaying which messages you intend to publish in order so it can setup any missing topics for you.
 * In this case, we are telling it to publish the OrderAccepted messages.
 * The topic will be the message type.
 
@@ -74,7 +74,7 @@ BOOM! You're done publishing!
 
 ## Consuming messages
 Here's how to get up & running with message consumption.
-We currently support SQS subscriptions only, but keep checking back for other methods too (http, Kinesis)
+We currently support SQS subscriptions only, but keep checking back for other methods too (HTTP, Kinesis)
 (although we are kinda at the mercy of AWS here for internal HTTP delivery...)
 
 


### PR DESCRIPTION
There are instances where it's acceptable if a notification fails to publish (say it times out for instance). This adds the ability for the consumer to dictate how exceptions are handled on a notification by notification basis as opposed to having to litter their code with try/catches in every instance the notification is published.