### PR TITLE
 Support the publishing of Message attributes

### DIFF
--- a/JustSaying.Models.version.props
+++ b/JustSaying.Models.version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(MSBuildProjectName)' == 'JustSaying.Models' ">
-    <VersionPrefix>5.0.0</VersionPrefix>
-    <!-- <VersionSuffix></VersionSuffix> -->
+    <VersionPrefix>6.1.0</VersionPrefix>
+    <VersionSuffix>beta1</VersionSuffix>
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>

--- a/JustSaying.Models.version.props
+++ b/JustSaying.Models.version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(MSBuildProjectName)' == 'JustSaying.Models' ">
-    <VersionPrefix>6.1.0</VersionPrefix>
-    <VersionSuffix>beta1</VersionSuffix>
+    <VersionPrefix>5.0.0</VersionPrefix>
+    <!-- <VersionSuffix></VersionSuffix> -->
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>

--- a/JustSaying.Models.version.props
+++ b/JustSaying.Models.version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition=" '$(MSBuildProjectName)' == 'JustSaying.Models' ">
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <!-- <VersionSuffix></VersionSuffix> -->
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>

--- a/JustSaying.Models/JustSaying.Models.csproj
+++ b/JustSaying.Models/JustSaying.Models.csproj
@@ -6,7 +6,4 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.11" />
-  </ItemGroup>
 </Project>

--- a/JustSaying.Models/JustSaying.Models.csproj
+++ b/JustSaying.Models/JustSaying.Models.csproj
@@ -6,4 +6,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.11" />
+  </ItemGroup>
 </Project>

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -1,4 +1,6 @@
+using Amazon.SimpleNotificationService.Model;
 using System;
+using System.Collections.Generic;
 
 namespace JustSaying.Models
 {
@@ -20,6 +22,7 @@ namespace JustSaying.Models
         public string ReceiptHandle { get; set; }
         public string QueueUrl { get; set; }
         public int? DelaySeconds { get; set; }
+        public Dictionary<string, MessageAttributeValue> MessageAttributes { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey() => Id.ToString();

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -1,4 +1,3 @@
-using Amazon.SimpleNotificationService.Model;
 using System;
 using System.Collections.Generic;
 
@@ -22,7 +21,7 @@ namespace JustSaying.Models
         public string ReceiptHandle { get; set; }
         public string QueueUrl { get; set; }
         public int? DelaySeconds { get; set; }
-        public Dictionary<string, MessageAttributeValue> MessageAttributes { get; set; }
+        public IDictionary<string, MessageAttributeValue> MessageAttributes { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey() => Id.ToString();

--- a/JustSaying.Models/MessageAttributeValue.cs
+++ b/JustSaying.Models/MessageAttributeValue.cs
@@ -31,7 +31,7 @@ namespace JustSaying.Models
         /// data, or images.
         /// </para>
         /// </summary>
-        public MemoryStream BinaryValue { get; set; }
+        public byte[] BinaryValue { get; set; }
 
         /// <summary>
         /// Gets and sets the property StringValue. 

--- a/JustSaying.Models/MessageAttributeValue.cs
+++ b/JustSaying.Models/MessageAttributeValue.cs
@@ -1,0 +1,54 @@
+/* The code in this file is a subset of the MessageAttributeValue class as defined here:
+ * https://github.com/aws/aws-sdk-net/blob/0b18c061daf81f4966fddd3a3cbe953101394282/sdk/src/Services/SimpleNotificationService/Generated/Model/MessageAttributeValue.cs
+ */
+
+
+using System.IO;
+
+
+namespace JustSaying.Models
+{
+    /// <summary>
+    /// The user-specified message attribute value. For string data types, the value attribute
+    /// has the same restrictions on the content as the message body. For more information,
+    /// see <a href="http://docs.aws.amazon.com/sns/latest/api/API_Publish.html">Publish</a> in the AWS docs.
+    /// 
+    ///  
+    /// <para>
+    /// Name, type, and value must not be empty or null. In addition, the message body should
+    /// not be empty or null. All parts of the message attribute, including name, type, and
+    /// value, are included in the message size restriction, which is currently 256 KB (262,144
+    /// bytes). For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html">Using
+    /// Amazon SNS Message Attributes</a> in the AWS docs.
+    /// </para>
+    /// </summary>
+    public class MessageAttributeValue
+    {
+        /// <summary>
+        /// Gets and sets the property BinaryValue. 
+        /// <para>
+        /// Binary type attributes can store any binary data, for example, compressed data, encrypted
+        /// data, or images.
+        /// </para>
+        /// </summary>
+        public MemoryStream BinaryValue { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property StringValue. 
+        /// <para>
+        /// Strings are Unicode with UTF8 binary encoding. For a list of code values, see <a href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.
+        /// </para>
+        /// </summary>
+        public string StringValue { get; set; }
+
+        /// <summary>
+        /// Gets and sets the property DataType. 
+        /// <para>
+        /// Amazon SNS supports the following logical data types: String, String.Array, Number,
+        /// and Binary. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html#SNSMessageAttributes.DataTypes">Message
+        /// Attribute Data Types in the AWS docs</a>.
+        /// </para>
+        /// </summary>
+        public string DataType { get; set; }
+    }
+}

--- a/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
@@ -37,14 +37,14 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
 
         /// Note: Ignored tests are here for fluent api exploration & expecting compile time issues when working on the fluent interface stuff...
         [Fact(Skip = "Testing compile-time issues")]
-        public void ASqsPublisherCanBeSetup()
+        public void ASnsPublisherCanBeSetup()
         {
             SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50)
                 .WithSnsMessagePublisher<GenericMessage>();
         }
 
         [Fact(Skip = "Testing compile-time issues")]
-        public void MultipleSqsPublishersCanBeSetup()
+        public void MultipleSnsPublishersCanBeSetup()
         {
             SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50)
                 .WithSnsMessagePublisher<GenericMessage>()

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -125,7 +125,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     return new MessageAttributeValue
                     {
                         StringValue = source.Value.StringValue,
-                        BinaryValue = new MemoryStream(source.Value.BinaryValue, false),
+                        BinaryValue = source.Value.BinaryValue != null ? new MemoryStream(source.Value.BinaryValue, false) : null,
                         DataType = source.Value.DataType
                     };
                 });

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
@@ -112,11 +113,13 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var messageToSend = _serialisationRegister.Serialise(message, serializeForSnsPublishing: true);
             var messageType = message.GetType().Name;
+
             return new PublishRequest
             {
                 TopicArn = Arn,
                 Subject = messageType,
-                Message = messageToSend
+                Message = messageToSend,
+                MessageAttributes = message.MessageAttributes
             };
         }
     }

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -125,7 +125,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     return new MessageAttributeValue
                     {
                         StringValue = source.Value.StringValue,
-                        BinaryValue = source.Value.BinaryValue,
+                        BinaryValue = new MemoryStream(source.Value.BinaryValue, false),
                         DataType = source.Value.DataType
                     };
                 });

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -114,12 +115,27 @@ namespace JustSaying.AwsTools.MessageHandling
             var messageToSend = _serialisationRegister.Serialise(message, serializeForSnsPublishing: true);
             var messageType = message.GetType().Name;
 
+            var messageAttributeValues = message.MessageAttributes?.ToDictionary(
+                source => source.Key,
+                source =>
+                {
+                    if (source.Value == null)
+                        return null;
+
+                    return new MessageAttributeValue
+                    {
+                        StringValue = source.Value.StringValue,
+                        BinaryValue = source.Value.BinaryValue,
+                        DataType = source.Value.DataType
+                    };
+                });
+            
             return new PublishRequest
             {
                 TopicArn = Arn,
                 Subject = messageType,
                 Message = messageToSend,
-                MessageAttributes = message.MessageAttributes
+                MessageAttributes = messageAttributeValues
             };
         }
     }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition=" '$(MSBuildProjectName)' != 'JustSaying.Models' ">
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.1.0</VersionPrefix>
     <VersionSuffix>beta1</VersionSuffix>
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>


### PR DESCRIPTION
Allow SNS Message Attributes to be specified and published.
This is an iteration that will eventually enable message filtering as requested in #26

I referenced the AWS SNS in the Message base class, as I thought it was much cleaner to simply pass MessageAttributes around rather than implement an abstraction on top of this. This can be changed if there's disagreement.

