### PR TITLE
Pass message type to INamingStrategy

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/WhenSettingUpMultipleHandlers.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenSettingUpMultipleHandlers.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Amazon;
 using JustBehave;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 using JustSaying.Messaging.MessageHandling;
 using Microsoft.Extensions.Logging;
 using Shouldly;
@@ -30,12 +31,12 @@ namespace JustSaying.IntegrationTests.AwsTools
         {
             private readonly long ticks = DateTime.UtcNow.Ticks;
 
-            public string GetTopicName(string topicName, string messageType)
+            public string GetTopicName(string topicName, Type messageType)
             {
-                return (messageType + ticks).ToLower();
+                return (messageType.ToTopicName() + ticks).ToLower();
             }
 
-            public string GetQueueName(SqsReadConfiguration sqsConfig, string messageType)
+            public string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType)
             {
                 return (sqsConfig.BaseQueueName + ticks).ToLower();
             }
@@ -57,8 +58,8 @@ namespace JustSaying.IntegrationTests.AwsTools
             proxyAwsClientFactory = new ProxyAwsClientFactory();
 
             var baseQueueName = "CustomerOrders_";
-            topicName = uniqueTopicAndQueueNames.GetTopicName(string.Empty, typeof(Order).Name);
-            queueName = uniqueTopicAndQueueNames.GetQueueName(new SqsReadConfiguration(SubscriptionType.ToTopic) { BaseQueueName = baseQueueName }, typeof(Order).Name);
+            topicName = uniqueTopicAndQueueNames.GetTopicName(string.Empty, typeof(Order));
+            queueName = uniqueTopicAndQueueNames.GetQueueName(new SqsReadConfiguration(SubscriptionType.ToTopic) { BaseQueueName = baseQueueName }, typeof(Order));
 
             bus = CreateMeABus.WithLogging(new LoggerFactory())
                 .InRegion(RegionEndpoint.EUWest1.SystemName)

--- a/JustSaying.IntegrationTests/AwsTools/WhenSettingUpMultipleHandlersFails.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenSettingUpMultipleHandlersFails.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Amazon;
 using JustBehave;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 using JustSaying.Messaging.MessageHandling;
 using Microsoft.Extensions.Logging;
 using Shouldly;
@@ -29,12 +30,12 @@ namespace JustSaying.IntegrationTests.AwsTools
         {
             private readonly long ticks = DateTime.UtcNow.Ticks;
 
-            public string GetTopicName(string topicName, string messageType)
+            public string GetTopicName(string topicName, Type messageType)
             {
-                return (messageType + ticks).ToLower();
+                return (messageType.ToTopicName() + ticks).ToLower();
             }
 
-            public string GetQueueName(SqsReadConfiguration sqsConfig, string messageType)
+            public string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType)
             {
                 return (sqsConfig.BaseQueueName + ticks).ToLower();
             }

--- a/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenSubscribingtoTopicInAnotherAccount.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/MultiRegion/WithSqsTopicSubscriber/WhenSubscribingtoTopicInAnotherAccount.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Amazon.Runtime;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 using JustSaying.IntegrationTests.TestHandlers;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
@@ -65,14 +66,14 @@ namespace JustSaying.IntegrationTests.JustSayingFluently.MultiRegion.WithSqsTopi
     }
     class NamingStrategy : INamingStrategy
     {
-        public string GetTopicName(string topicName, string messageType)
+        public string GetTopicName(string topicName, Type messageType)
         {
-            return "test-" + messageType;
+            return "test-" + messageType.ToTopicName();
         }
 
-        public string GetQueueName(SqsReadConfiguration sqsConfig, string messageType)
+        public string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType)
         {
-            return "test-" + messageType;
+            return "test-" + messageType.ToTopicName();
         }
     }
 }

--- a/JustSaying/DefaultNamingStrategy.cs
+++ b/JustSaying/DefaultNamingStrategy.cs
@@ -1,4 +1,6 @@
+using System;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 
 namespace JustSaying
 {
@@ -11,11 +13,11 @@ namespace JustSaying
     /// </summary>
     class DefaultNamingStrategy : INamingStrategy
     {
-        public string GetTopicName(string topicName, string messageType) => messageType.ToLower();
+        public string GetTopicName(string topicName, Type messageType) => messageType.ToTopicName().ToLower();
 
-        public string GetQueueName(SqsReadConfiguration sqsConfig, string messageType)
+        public string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType)
             => string.IsNullOrWhiteSpace(sqsConfig.BaseQueueName)
-                ? messageType.ToLower()
+                ? messageType.ToTopicName().ToLower()
                 : sqsConfig.BaseQueueName.ToLower();
     }
 }

--- a/JustSaying/Extensions/TypeExtensions.cs
+++ b/JustSaying/Extensions/TypeExtensions.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace JustSaying.Extensions
 {
-    internal static class TypeExtensions
+    public static class TypeExtensions
     {
         private const int MAX_TOPIC_NAME_LENGTH = 256;
 

--- a/JustSaying/INamingStrategy.cs
+++ b/JustSaying/INamingStrategy.cs
@@ -1,10 +1,11 @@
+using System;
 using JustSaying.AwsTools.QueueCreation;
 
 namespace JustSaying
 {
     public interface INamingStrategy
     {
-        string GetTopicName(string topicName, string messageType);
-        string GetQueueName(SqsReadConfiguration sqsConfig, string messageType);
+        string GetTopicName(string topicName, Type messageType);
+        string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType);
     }
 }

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -43,8 +43,6 @@ namespace JustSaying
             _awsClientFactoryProxy = awsClientFactoryProxy;
         }
 
-        private static string GetMessageTypeName<T>() => typeof(T).ToTopicName();
-
         public virtual INamingStrategy GetNamingStrategy()
             => _busNamingStrategyFunc != null
                 ? _busNamingStrategyFunc()
@@ -77,12 +75,12 @@ namespace JustSaying
             var snsWriteConfig = new SnsWriteConfiguration();
             configBuilder?.Invoke(snsWriteConfig);
 
-            _subscriptionConfig.Topic = GetMessageTypeName<T>();
+            _subscriptionConfig.Topic = typeof(T).ToTopicName();
             var namingStrategy = GetNamingStrategy();
 
             Bus.SerialisationRegister.AddSerialiser<T>(_serialisationFactory.GetSerialiser<T>());
 
-            var topicName = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, GetMessageTypeName<T>());
+            var topicName = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, typeof(T));
             foreach (var region in Bus.Config.Regions)
             {
                 // TODO pass region down into topic creation for when we have foreign topics so we can generate the arn
@@ -119,8 +117,7 @@ namespace JustSaying
             var config = new SqsWriteConfiguration();
             configBuilder(config);
 
-            var messageTypeName = typeof(T).ToTopicName();
-            var queueName = GetNamingStrategy().GetQueueName(new SqsReadConfiguration(SubscriptionType.PointToPoint){BaseQueueName = config.QueueName}, messageTypeName);
+            var queueName = GetNamingStrategy().GetQueueName(new SqsReadConfiguration(SubscriptionType.PointToPoint){BaseQueueName = config.QueueName}, typeof(T));
 
             Bus.SerialisationRegister.AddSerialiser<T>(_serialisationFactory.GetSerialiser<T>());
 
@@ -146,7 +143,7 @@ namespace JustSaying
                 Bus.AddMessagePublisher<T>(eventPublisher, region);
             }
 
-            _log.LogInformation($"Created SQS publisher - MessageName: {messageTypeName}, QueueName: {queueName}");
+            _log.LogInformation($"Created SQS publisher - MessageType: {typeof(T)}, QueueName: {queueName}");
 
             return this;
         }
@@ -275,8 +272,7 @@ namespace JustSaying
             {
                 Bus.AddMessageHandler(region, _subscriptionConfig.QueueName, () => handler);
             }
-            var messageTypeName = GetMessageTypeName<T>();
-            _log.LogInformation($"Added a message handler - MessageName: {messageTypeName}, QueueName: {_subscriptionConfig.QueueName}, HandlerName: {handler.GetType().Name}");
+            _log.LogInformation($"Added a message handler - MessageType: {typeof(T)}, QueueName: {_subscriptionConfig.QueueName}, HandlerName: {handler.GetType().Name}");
 
             return thing;
         }
@@ -309,8 +305,7 @@ namespace JustSaying
 
         private IHaveFulfilledSubscriptionRequirements TopicHandler<T>() where T : Message
         {
-            var messageTypeName = GetMessageTypeName<T>();
-            ConfigureSqsSubscriptionViaTopic(messageTypeName);
+            ConfigureSqsSubscriptionViaTopic<T>();
 
             foreach (var region in Bus.Config.Regions)
             {
@@ -324,14 +319,13 @@ namespace JustSaying
 
         private IHaveFulfilledSubscriptionRequirements PointToPointHandler<T>() where T : Message
         {
-            var messageTypeName = GetMessageTypeName<T>();
-            ConfigureSqsSubscription(messageTypeName);
+            ConfigureSqsSubscription<T>();
 
             foreach (var region in Bus.Config.Regions)
             {
                 var queue = _amazonQueueCreator.EnsureQueueExistsAsync(region, _subscriptionConfig).GetAwaiter().GetResult();
                 CreateSubscriptionListener<T>(region, queue);
-                _log.LogInformation($"Created SQS subscriber - MessageName: {messageTypeName}, QueueName: {_subscriptionConfig.QueueName}");
+                _log.LogInformation($"Created SQS subscriber - MessageType: {typeof(T)}, QueueName: {_subscriptionConfig.QueueName}");
             }
 
             return this;
@@ -354,19 +348,19 @@ namespace JustSaying
             }
         }
 
-        private void ConfigureSqsSubscriptionViaTopic(string messageTypeName)
+        private void ConfigureSqsSubscriptionViaTopic<T>() where T : Message
         {
             var namingStrategy = GetNamingStrategy();
-            _subscriptionConfig.PublishEndpoint = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, messageTypeName);
-            _subscriptionConfig.Topic = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, messageTypeName);
-            _subscriptionConfig.QueueName = namingStrategy.GetQueueName(_subscriptionConfig, messageTypeName);
+            _subscriptionConfig.PublishEndpoint = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, typeof(T));
+            _subscriptionConfig.Topic = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, typeof(T));
+            _subscriptionConfig.QueueName = namingStrategy.GetQueueName(_subscriptionConfig, typeof(T));
             _subscriptionConfig.Validate();
         }
 
-        private void ConfigureSqsSubscription(string messageTypeName)
+        private void ConfigureSqsSubscription<T>() where T : Message
         {
             _subscriptionConfig.ValidateSqsConfiguration();
-            _subscriptionConfig.QueueName = GetNamingStrategy().GetQueueName(_subscriptionConfig, messageTypeName);
+            _subscriptionConfig.QueueName = GetNamingStrategy().GetQueueName(_subscriptionConfig, typeof(T));
         }
 
         /// <summary>


### PR DESCRIPTION
Addresses #358 

- Updates `INamingStrategy` to take actual message `Type` rather than pre-stringified version.

- Updates `DefaultNamingStategy` to replicate existing behaviour 

- Exposes `TypeExtensions` publicly so that consumers can replicate existing behaviour similarly

n.b. this is a **breaking change**, not sure if anything needs to be done to signify that? It would probably be helpful for something to go into release notes telling consumers how to keep compatibility when they upgrade (by using `ToTopicName` in their naming strategies)?