### PR TITLE
Support for generic messages

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/WhenCreatingTopicAndNoPermission.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenCreatingTopicAndNoPermission.cs
@@ -17,7 +17,7 @@ namespace JustSaying.IntegrationTests.AwsTools
         protected override void When()
         {
             var snsClient = new NoTopicCreationAwsClientFactory().GetSnsClient(RegionEndpoint.EUWest1);
-            _topic = new SnsTopicByName(UniqueName, snsClient, new MessageSerialisationRegister(), new LoggerFactory());
+            _topic = new SnsTopicByName(UniqueName, snsClient, new MessageSerialisationRegister(new NonGenericMessageSubjectProvider()), new LoggerFactory(), new NonGenericMessageSubjectProvider());
             _createWasSuccessful = _topic.CreateAsync().GetAwaiter().GetResult();
         }
 

--- a/JustSaying.IntegrationTests/AwsTools/WhenCreatingTopicByName.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenCreatingTopicByName.cs
@@ -21,7 +21,7 @@ namespace JustSaying.IntegrationTests.AwsTools
         {
             Bus = CreateMeABus.DefaultClientFactory().GetSnsClient(RegionEndpoint.EUWest1);
             UniqueName = "test" + DateTime.Now.Ticks;
-            CreatedTopic = new SnsTopicByName(UniqueName, Bus , new MessageSerialisationRegister(), new LoggerFactory());
+            CreatedTopic = new SnsTopicByName(UniqueName, Bus , new MessageSerialisationRegister(new NonGenericMessageSubjectProvider()), new LoggerFactory(), new NonGenericMessageSubjectProvider());
             CreatedTopic.CreateAsync().GetAwaiter().GetResult();
             return CreatedTopic;
         }

--- a/JustSaying.IntegrationTests/AwsTools/WhenCreatingTopicThatExistsAlready.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenCreatingTopicThatExistsAlready.cs
@@ -14,7 +14,7 @@ namespace JustSaying.IntegrationTests.AwsTools
 
         protected override void When()
         {
-            _topic = new SnsTopicByName(UniqueName, Bus, new MessageSerialisationRegister(), new LoggerFactory());
+            _topic = new SnsTopicByName(UniqueName, Bus, new MessageSerialisationRegister(new NonGenericMessageSubjectProvider()), new LoggerFactory(), new NonGenericMessageSubjectProvider());
             _createWasSuccessful = _topic.CreateAsync().GetAwaiter().GetResult();
         }
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenHandlersThrowAnException.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JustSaying.IntegrationTests.TestHandlers;
 using JustSaying.TestingFramework;
@@ -32,7 +33,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         {
             _handler.ReceivedMessageCount.ShouldBeGreaterThan(0);
 
-            Monitoring.Received().HandleException(Arg.Any<string>());
+            Monitoring.Received().HandleException(Arg.Any<Type>());
         }
     }
 }

--- a/JustSaying.TestingFramework/Tasks.cs
+++ b/JustSaying.TestingFramework/Tasks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using NLog;
 
@@ -8,7 +8,7 @@ namespace JustSaying.TestingFramework
     {
         private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-        private const int DefaultTimeoutMillis = 5000;
+        private const int DefaultTimeoutMillis = 10000;
         private const int DelaySendMillis = 200;
 
         public static async Task<bool> WaitWithTimeoutAsync(Task task)

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsync.cs
@@ -21,7 +21,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         protected override SnsTopicByName CreateSystemUnderTest()
         {
-            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>());
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new NonGenericMessageSubjectProvider());
             topic.ExistsAsync().GetAwaiter().GetResult();;
             return topic;
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
@@ -26,7 +26,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
             var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new SnsWriteConfiguration
             {
                 HandleException = (ex, m) => true
-            });
+            }, Substitute.For<IMessageSubjectProvider>());
 
             topic.ExistsAsync().GetAwaiter().GetResult();;
             return topic;

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -27,7 +27,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
             var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new SnsWriteConfiguration
             {
                 HandleException = (ex, m) => false
-            });
+            }, Substitute.For<IMessageSubjectProvider>());
 
             topic.ExistsAsync().GetAwaiter().GetResult();;
             return topic;

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncResponseLoggerIsCalled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncResponseLoggerIsCalled.cs
@@ -28,7 +28,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         protected override SnsTopicByName CreateSystemUnderTest()
         {
-            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), Substitute.For<SnsWriteConfiguration>())
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), Substitute.For<SnsWriteConfiguration>(), Substitute.For<IMessageSubjectProvider>())
             {
                 MessageResponseLogger = (r, m) =>
                 {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
@@ -57,7 +57,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
         [Fact]
         public void MessageSubjectIsObjectType()
         {
-            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => x.Subject == new GenericMessageSubjectProvider().GetTypeForSubject(typeof(MessageWithTypeParameters<int, string>))));
+            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => x.Subject == new GenericMessageSubjectProvider().GetSubjectForType(typeof(MessageWithTypeParameters<int, string>))));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
@@ -12,8 +12,13 @@ using Xunit;
 
 namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 {
-    public class WhenPublishing : XAsyncBehaviourTest<SnsTopicByName>
+    public class WhenPublishingAsyncWithGenericMessageSubjectProvider : XAsyncBehaviourTest<SnsTopicByName>
     {
+        public class MessageWithTypeParameters<T, U> : Message
+        {
+
+        }
+
         private const string Message = "the_message_in_json";
         private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
         private readonly IAmazonSimpleNotificationService _sns = Substitute.For<IAmazonSimpleNotificationService>();
@@ -21,7 +26,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         protected override SnsTopicByName CreateSystemUnderTest()
         {
-            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new NonGenericMessageSubjectProvider());
+            var topic = new SnsTopicByName("TopicName", _sns, _serialisationRegister, Substitute.For<ILoggerFactory>(), new GenericMessageSubjectProvider());
             topic.ExistsAsync().GetAwaiter().GetResult();;
             return topic;
         }
@@ -35,7 +40,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         protected override async Task When()
         {
-            await SystemUnderTest.PublishAsync(new GenericMessage());
+            await SystemUnderTest.PublishAsync(new MessageWithTypeParameters<int, string>());
         }
 
         [Fact]
@@ -52,7 +57,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
         [Fact]
         public void MessageSubjectIsObjectType()
         {
-            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => x.Subject == typeof(GenericMessage).Name));
+            _sns.Received().PublishAsync(Arg.Is<PublishRequest>(x => x.Subject == new GenericMessageSubjectProvider().GetTypeForSubject(typeof(MessageWithTypeParameters<int, string>))));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingFails.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingFails.cs
@@ -1,3 +1,4 @@
+using System;
 using Amazon.SQS.Model;
 using JustSaying.TestingFramework;
 using NSubstitute;
@@ -29,7 +30,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void ExceptionIsNotLoggedToMonitor()
         {
-            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<string>());
+            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<Type>());
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
@@ -1,3 +1,4 @@
+using System;
 using Amazon.SQS.Model;
 using NSubstitute;
 using Xunit;
@@ -39,7 +40,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void ExceptionIsNotLoggedToMonitor()
         {
-            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<string>());
+            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<Type>());
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -1,3 +1,4 @@
+using System;
 using Amazon.SQS.Model;
 using JustSaying.TestingFramework;
 using NSubstitute;
@@ -42,7 +43,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void ExceptionIsLoggedToMonitor()
         {
-            Monitor.ReceivedWithAnyArgs().HandleException(Arg.Any<string>());
+            Monitor.ReceivedWithAnyArgs().HandleException(Arg.Any<Type>());
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
 using JustSaying.TestingFramework;
@@ -47,7 +48,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void ExceptionIsLoggedToMonitor()
         {
-            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<string>());
+            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<Type>());
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
 using JustSaying.TestingFramework;
@@ -47,7 +48,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void ExceptionIsLoggedToMonitor()
         {
-            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<string>());
+            Monitor.DidNotReceiveWithAnyArgs().HandleException(Arg.Any<Type>());
         }
     }
 }

--- a/JustSaying.UnitTests/JustSayingBus/CustomMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingBus/CustomMonitor.cs
@@ -5,13 +5,13 @@ namespace JustSaying.UnitTests.JustSayingBus
 {
     public class CustomMonitor : IMessageMonitor, IMeasureHandlerExecutionTime
     {
-        public void HandleException(string messageType) { }
+        public void HandleException(Type messageType) { }
         public void HandleTime(long handleTimeMs) { }
         public void IssuePublishingMessage() { }
         public void IncrementThrottlingStatistic() { }
         public void HandleThrottlingTime(long handleTimeMs) { }
         public void PublishMessageTime(long handleTimeMs) { }
         public void ReceiveMessageTime(long handleTimeMs, string queueName, string region) { }
-        public void HandlerExecutionTime(string typeName, string eventName, TimeSpan executionTime) { }
+        public void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan executionTime) { }
     }
 }

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -34,8 +34,8 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Fact]
         public void TheTopicAndQueueIsCreatedInEachRegion()
         {
-            QueueVerifier.Received().EnsureTopicExistsWithQueueSubscribedAsync("defaultRegion", Bus.SerialisationRegister, Arg.Any<SqsReadConfiguration>());
-            QueueVerifier.Received().EnsureTopicExistsWithQueueSubscribedAsync("failoverRegion", Bus.SerialisationRegister, Arg.Any<SqsReadConfiguration>());
+            QueueVerifier.Received().EnsureTopicExistsWithQueueSubscribedAsync("defaultRegion", Bus.SerialisationRegister, Arg.Any<SqsReadConfiguration>(), Bus.Config.MessageSubjectProvider);
+            QueueVerifier.Received().EnsureTopicExistsWithQueueSubscribedAsync("failoverRegion", Bus.SerialisationRegister, Arg.Any<SqsReadConfiguration>(), Bus.Config.MessageSubjectProvider);
         }
 
         [Fact]

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -67,7 +67,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         {
             QueueVerifier
                 .DidNotReceiveWithAnyArgs()
-                .EnsureTopicExistsWithQueueSubscribedAsync(Arg.Any<string>(), Arg.Any<IMessageSerialisationRegister>(), Arg.Any<SqsReadConfiguration>());
+                .EnsureTopicExistsWithQueueSubscribedAsync(Arg.Any<string>(), Arg.Any<IMessageSerialisationRegister>(), Arg.Any<SqsReadConfiguration>(), Arg.Any<IMessageSubjectProvider>());
         }
     }
 }

--- a/JustSaying.UnitTests/Messaging/Monitoring/StopwatchHandlerTests.cs
+++ b/JustSaying.UnitTests/Messaging/Monitoring/StopwatchHandlerTests.cs
@@ -36,11 +36,11 @@ namespace JustSaying.UnitTests.Messaging.Monitoring
             await stopWatchHandler.Handle(new OrderAccepted());
 
             monitoring.Received(1). HandlerExecutionTime(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>());
+                Arg.Any<Type>(), Arg.Any<Type>(), Arg.Any<TimeSpan>());
         }
 
         [Fact]
-        public async Task WhenHandlerIsWrappedinStopWatch_MonitoringIsCalledWithCorrectTypeNames()
+        public async Task WhenHandlerIsWrappedinStopWatch_MonitoringIsCalledWithCorrectTypes()
         {
             var handler = MockHandler();
             var innnerHandlerName = handler.GetType().Name.ToLower();
@@ -52,7 +52,7 @@ namespace JustSaying.UnitTests.Messaging.Monitoring
             await stopWatchHandler.Handle(new OrderAccepted());
 
             monitoring.Received(1).HandlerExecutionTime(
-                innnerHandlerName, "orderaccepted", Arg.Any<TimeSpan>());
+                handler.GetType(), typeof(OrderAccepted), Arg.Any<TimeSpan>());
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace JustSaying.UnitTests.Messaging.Monitoring
             await stopWatchHandler.Handle(new OrderAccepted());
 
             monitoring.Received(1).HandlerExecutionTime(
-                Arg.Any<string>(), Arg.Any<string>(), 
+                Arg.Any<Type>(), Arg.Any<Type>(), 
                 Arg.Is<TimeSpan>(ts => ts > TimeSpan.Zero));
         }
 

--- a/JustSaying.UnitTests/Messaging/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.Messaging.Serialisation.Newtonsoft
 
         protected override void When()
         {
-            _jsonMessage = SystemUnderTest.Serialise(_messageOut, serializeForSnsPublishing:false);
+            _jsonMessage = SystemUnderTest.Serialise(_messageOut, false, _messageOut.GetType().Name);
 
             //add extra property to see what happens:
             _jsonMessage = _jsonMessage.Replace("{__", "{\"New\":\"Property\",__");

--- a/JustSaying.UnitTests/Messaging/Serialisation/Newtonsoft/WhenSerialisingAndDeserialising.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/Newtonsoft/WhenSerialisingAndDeserialising.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.Messaging.Serialisation.Newtonsoft
 
         protected override void When()
         {
-            _jsonMessage = SystemUnderTest.Serialise(_messageOut, serializeForSnsPublishing: false);
+            _jsonMessage = SystemUnderTest.Serialise(_messageOut, false, _messageOut.GetType().Name);
             _messageIn = SystemUnderTest.Deserialise(_jsonMessage, typeof(MessageWithEnum)) as MessageWithEnum;
         }
 

--- a/JustSaying.UnitTests/Messaging/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/Newtonsoft/WhenUsingCustomSettings.cs
@@ -24,7 +24,7 @@ namespace JustSaying.UnitTests.Messaging.Serialisation.Newtonsoft
 
         public string GetMessageInContext(MessageWithEnum message)
         {
-            var context = new { Subject = message.GetType().Name, Message = SystemUnderTest.Serialise(message, false) };
+            var context = new { Subject = message.GetType().Name, Message = SystemUnderTest.Serialise(message, false, message.GetType().Name) };
             return JsonConvert.SerializeObject(context);
         }
 

--- a/JustSaying.UnitTests/Messaging/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/SerialisationRegister/WhenAddingASerialiserTwice.cs
@@ -9,6 +9,9 @@ namespace JustSaying.UnitTests.Messaging.Serialisation.SerialisationRegister
 {
     public class WhenAddingASerialiserTwice : XBehaviourTest<MessageSerialisationRegister>
     {
+        protected override MessageSerialisationRegister CreateSystemUnderTest() =>
+            new MessageSerialisationRegister(new NonGenericMessageSubjectProvider());
+
         protected override void Given()
         {
             RecordAnyExceptionsThrown();

--- a/JustSaying.UnitTests/Messaging/Serialisation/SerialisationRegister/WhenDeserializingMessage.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/SerialisationRegister/WhenDeserializingMessage.cs
@@ -14,6 +14,9 @@ namespace JustSaying.UnitTests.Messaging.Serialisation.SerialisationRegister
         {
         }
 
+        protected override MessageSerialisationRegister CreateSystemUnderTest() =>
+            new MessageSerialisationRegister(new NonGenericMessageSubjectProvider());
+
         private string messageBody = "msgBody";
         protected override void Given()
         {
@@ -23,7 +26,7 @@ namespace JustSaying.UnitTests.Messaging.Serialisation.SerialisationRegister
         protected override void When()
         {
             var messageSerialiser = Substitute.For<IMessageSerialiser>();
-            messageSerialiser.GetMessageType(messageBody).Returns(typeof(CustomMessage).Name);
+            messageSerialiser.GetMessageSubject(messageBody).Returns(typeof(CustomMessage).Name);
             messageSerialiser.Deserialise(messageBody, typeof (CustomMessage)).Returns(new CustomMessage());
             SystemUnderTest.AddSerialiser<CustomMessage>(messageSerialiser);
         }

--- a/JustSaying.UnitTests/Messaging/Serialisation/SubjectProviders/GenericMessageSubjectProviderTests.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/SubjectProviders/GenericMessageSubjectProviderTests.cs
@@ -1,0 +1,26 @@
+using JustSaying.Messaging.MessageSerialisation;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Messaging.Serialisation.SubjectProviders
+{
+    public class GenericMessageSubjectProviderTests
+    {
+        class Foo { }
+
+        class Bar<T> { }
+
+        [Fact]
+        public void GetSubjectForType_NonGenericType_ReturnsTypeNameWithNamespace_NonWordCharactersReplaced() =>
+            new GenericMessageSubjectProvider().GetSubjectForType(typeof(Foo))
+                .ShouldBe("Foo_JustSaying_UnitTests_Messaging_Serialisation_SubjectProviders");
+
+        [Fact]
+        public void GetSubjectForType_GenericType_ReturnsFlattenedTypeNamesWithNamepaces_TrunactedToMaxSnsSubjectLength()
+        {
+            var subject = new GenericMessageSubjectProvider().GetSubjectForType(typeof(Bar<Foo>));
+            subject.ShouldStartWith("Bar_1_JustSaying_UnitTests_Messaging_Serialisation_SubjectProviders_Foo_JustSaying_");
+            subject.Length.ShouldBe(100);
+        }
+    }
+}

--- a/JustSaying.UnitTests/Messaging/Serialisation/SubjectProviders/NonGenericMessageSubjectProviderTests.cs
+++ b/JustSaying.UnitTests/Messaging/Serialisation/SubjectProviders/NonGenericMessageSubjectProviderTests.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using JustSaying.Messaging.MessageSerialisation;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Messaging.Serialisation.SubjectProviders
+{
+    public class NonGenericMessageSubjectProviderTests
+    {
+        class Foo { }
+
+        [Fact]
+        public void GetSubjectForType_ReturnsTypeName() =>
+            new NonGenericMessageSubjectProvider().GetSubjectForType(typeof(Foo))
+                .ShouldBe("Foo");
+
+        [Fact]
+        public void GetSubjectForType_IgnoresAnyTypeParameters() =>
+            new NonGenericMessageSubjectProvider().GetSubjectForType(typeof(List<Foo>))
+                .ShouldBe("List`1");
+    }
+}

--- a/JustSaying.UnitTests/TypeExtensionTests.cs
+++ b/JustSaying.UnitTests/TypeExtensionTests.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+using JustSaying.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests
+{
+    public class TypeExtensionTests
+    {
+        public class Foo { }
+
+        public class Bar<T> { }
+
+        [Fact]
+        public void ToTopicName_NonGenericType_GivesLowercaseName() =>
+            typeof(Foo).ToTopicName()
+                .ShouldBe("foo");
+
+        [Fact]
+        public void ToTopicName_GenericType_GivesLowercaseFullNameWithNonWordCharactersReplaced()
+        {
+            //Don't hardcode this, otherwise test will fail on assembly version upgrade
+            var assemblyNamePart = Regex.Replace(typeof(Bar<>).Assembly.FullName.ToLower(), @"\W", "_");
+            typeof(Bar<Foo>).ToTopicName()
+                .ShouldBe($"justsaying_unittests_typeextensiontests_bar_1__justsaying_unittests_typeextensiontests_foo__{assemblyNamePart}__");
+        }
+
+        [Fact]
+        public void ToTopicName_LongGenericType_TruncatesToMaxAllowedSnsTopicLength() =>
+            typeof(Bar<Bar<Bar<Foo>>>).ToTopicName().Length
+                .ShouldBe(256);
+    }
+}

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.SQS;
@@ -86,7 +86,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 if (typedMessage != null)
                 {
-                    _messagingMonitor.HandleException(typedMessage.GetType().Name);
+                    _messagingMonitor.HandleException(typedMessage.GetType());
                 }
 
                 _onError(ex, message);
@@ -116,7 +116,7 @@ namespace JustSaying.AwsTools.MessageHandling
             var handlerSucceeded = await handler(message).ConfigureAwait(false);
 
             watch.Stop();
-            _log.LogTrace($"Handled message - MessageType: {message.GetType().Name}");
+            _log.LogTrace($"Handled message - MessageType: {message.GetType()}");
             _messagingMonitor.HandleTime(watch.ElapsedMilliseconds);
 
             return handlerSucceeded;

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -14,6 +14,7 @@ namespace JustSaying.AwsTools.MessageHandling
     public abstract class SnsTopicBase : IMessagePublisher
     {
         private readonly IMessageSerialisationRegister _serialisationRegister; // ToDo: Grrr...why is this here even. GET OUT!
+        private readonly IMessageSubjectProvider _messageSubjectProvider;
         private readonly SnsWriteConfiguration _snsWriteConfiguration;
         public Action<MessageResponse, Message> MessageResponseLogger { get; set; }
         public string Arn { get; protected set; }
@@ -21,20 +22,23 @@ namespace JustSaying.AwsTools.MessageHandling
         private readonly ILogger _eventLog;
         private readonly ILogger _log;
 
-        protected SnsTopicBase(IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory)
+        protected SnsTopicBase(IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory, IMessageSubjectProvider messageSubjectProvider)
         {
             _serialisationRegister = serialisationRegister;
+            _messageSubjectProvider = messageSubjectProvider;
             _log = loggerFactory.CreateLogger("JustSaying");
             _eventLog = loggerFactory.CreateLogger("EventLog");
         }
 
         protected SnsTopicBase(IMessageSerialisationRegister serialisationRegister,
-            ILoggerFactory loggerFactory, SnsWriteConfiguration snsWriteConfiguration)
+            ILoggerFactory loggerFactory, SnsWriteConfiguration snsWriteConfiguration,
+            IMessageSubjectProvider messageSubjectProvider)
         {
             _serialisationRegister = serialisationRegister;
             _log = loggerFactory.CreateLogger("JustSaying");
             _eventLog = loggerFactory.CreateLogger("EventLog");
             _snsWriteConfiguration = snsWriteConfiguration;
+            _messageSubjectProvider = messageSubjectProvider;
         }
 
         public abstract Task<bool> ExistsAsync();
@@ -111,7 +115,7 @@ namespace JustSaying.AwsTools.MessageHandling
         private PublishRequest BuildPublishRequest(Message message)
         {
             var messageToSend = _serialisationRegister.Serialise(message, serializeForSnsPublishing: true);
-            var messageType = message.GetType().Name;
+            var messageType = _messageSubjectProvider.GetTypeForSubject(message.GetType());
             return new PublishRequest
             {
                 TopicArn = Arn,

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -115,7 +115,7 @@ namespace JustSaying.AwsTools.MessageHandling
         private PublishRequest BuildPublishRequest(Message message)
         {
             var messageToSend = _serialisationRegister.Serialise(message, serializeForSnsPublishing: true);
-            var messageType = _messageSubjectProvider.GetTypeForSubject(message.GetType());
+            var messageType = _messageSubjectProvider.GetSubjectForType(message.GetType());
             return new PublishRequest
             {
                 TopicArn = Arn,

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
@@ -16,8 +16,8 @@ namespace JustSaying.AwsTools.MessageHandling
         public string TopicName { get; }
         private readonly ILogger _log;
 
-        public SnsTopicByName(string topicName, IAmazonSimpleNotificationService client, IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory)
-            : base(serialisationRegister, loggerFactory)
+        public SnsTopicByName(string topicName, IAmazonSimpleNotificationService client, IMessageSerialisationRegister serialisationRegister, ILoggerFactory loggerFactory, IMessageSubjectProvider messageSubjectProvider)
+            : base(serialisationRegister, loggerFactory, messageSubjectProvider)
         {
             TopicName = topicName;
             Client = client;
@@ -26,8 +26,9 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public SnsTopicByName(string topicName, IAmazonSimpleNotificationService client,
             IMessageSerialisationRegister serialisationRegister,
-            ILoggerFactory loggerFactory, SnsWriteConfiguration snsWriteConfiguration)
-            : base(serialisationRegister, loggerFactory, snsWriteConfiguration)
+            ILoggerFactory loggerFactory, SnsWriteConfiguration snsWriteConfiguration,
+            IMessageSubjectProvider messageSubjectProvider)
+            : base(serialisationRegister, loggerFactory, snsWriteConfiguration, messageSubjectProvider)
         {
             TopicName = topicName;
             Client = client;

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -77,7 +77,7 @@ namespace JustSaying.AwsTools.MessageHandling
             if (_handlerMap.ContainsKey(typeof(T)))
             {
                 throw new NotSupportedException(
-                    $"The handler for '{typeof(T).Name}' messages on this queue has already been registered.");
+                    $"The handler for '{typeof(T)}' messages on this queue has already been registered.");
             }
 
             Subscribers.Add(new Subscriber(typeof(T)));

--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -19,7 +19,7 @@ namespace JustSaying.AwsTools.QueueCreation
             _loggerFactory = loggerFactory;
         }
 
-        public async Task<SqsQueueByName> EnsureTopicExistsWithQueueSubscribedAsync(string region, IMessageSerialisationRegister serialisationRegister, SqsReadConfiguration queueConfig)
+        public async Task<SqsQueueByName> EnsureTopicExistsWithQueueSubscribedAsync(string region, IMessageSerialisationRegister serialisationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider)
         {
             var regionEndpoint = RegionEndpoint.GetBySystemName(region);
             var sqsClient = _awsClientFactory.GetAwsClientFactory().GetSqsClient(regionEndpoint);
@@ -36,7 +36,7 @@ namespace JustSaying.AwsTools.QueueCreation
             }
             else
             {
-                var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint, snsClient, serialisationRegister, _loggerFactory);
+                var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint, snsClient, serialisationRegister, _loggerFactory, messageSubjectProvider);
                 await eventTopic.CreateAsync().ConfigureAwait(false);
 
                 await EnsureQueueIsSubscribedToTopic(eventTopic, queue).ConfigureAwait(false);

--- a/JustSaying/AwsTools/QueueCreation/IVerifyAmazonQueues.cs
+++ b/JustSaying/AwsTools/QueueCreation/IVerifyAmazonQueues.cs
@@ -6,7 +6,7 @@ namespace JustSaying.AwsTools.QueueCreation
 {
     public interface IVerifyAmazonQueues
     {
-        Task<SqsQueueByName> EnsureTopicExistsWithQueueSubscribedAsync(string region, IMessageSerialisationRegister serialisationRegister, SqsReadConfiguration queueConfig);
+        Task<SqsQueueByName> EnsureTopicExistsWithQueueSubscribedAsync(string region, IMessageSerialisationRegister serialisationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider);
         Task<SqsQueueByName> EnsureQueueExistsAsync(string region, SqsReadConfiguration queueConfig);
     }
 }

--- a/JustSaying/Extensions/StringExtensions.cs
+++ b/JustSaying/Extensions/StringExtensions.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+
+namespace JustSaying.Extensions
+{
+    internal static class StringExtensions
+    {
+        public static string TruncateTo(this string s, int maxLength)
+        {
+            if (s.Length > maxLength)
+            {
+                var suffix = s.GetInvariantHashCode().ToString();
+                s = s.Substring(0, maxLength - suffix.Length) + suffix;
+            }
+
+            return s;
+        }
+
+        private static int GetInvariantHashCode(this string value)
+        {
+            return value.Aggregate(5381, (current, character) => (current * 397) ^ character);
+        }
+    }
+}

--- a/JustSaying/Extensions/TypeExtensions.cs
+++ b/JustSaying/Extensions/TypeExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -15,18 +14,7 @@ namespace JustSaying.Extensions
                 ? Regex.Replace(type.FullName, "\\W", "_").ToLower()
                 : type.Name.ToLower();
 
-            if (name.Length > MAX_TOPIC_NAME_LENGTH)
-            {
-                var suffix = name.GetInvariantHashCode().ToString();
-                name = name.Substring(0, MAX_TOPIC_NAME_LENGTH - suffix.Length) + suffix;
-            }
-
-            return name;
-        }
-
-        private static int GetInvariantHashCode(this string value)
-        {
-            return value.Aggregate(5381, (current, character) => (current*397) ^ character);
+            return name.TruncateTo(MAX_TOPIC_NAME_LENGTH);
         }
     }
 }

--- a/JustSaying/IMessagingConfig.cs
+++ b/JustSaying/IMessagingConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using JustSaying.Messaging.MessageSerialisation;
 
 namespace JustSaying
 {
@@ -7,6 +8,7 @@ namespace JustSaying
     {
         IList<string> Regions { get; }
         Func<string> GetActiveRegion { get; set; }
+        IMessageSubjectProvider MessageSubjectProvider { get; }
 
         void Validate();
     }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -219,11 +219,11 @@ namespace JustSaying
                 if (attemptCount >= Config.PublishFailureReAttempts)
                 {
                     Monitor.IssuePublishingMessage();
-                    _log.LogError(0, ex, $"Failed to publish message {message.GetType().Name}. Halting after attempt {attemptCount}");
+                    _log.LogError(0, ex, $"Failed to publish message {message.GetType()}. Halting after attempt {attemptCount}");
                     throw;
                 }
 
-                _log.LogWarning(0, ex, $"Failed to publish message {message.GetType().Name}. Retrying after attempt {attemptCount} of {Config.PublishFailureReAttempts}");
+                _log.LogWarning(0, ex, $"Failed to publish message {message.GetType()}. Retrying after attempt {attemptCount} of {Config.PublishFailureReAttempts}");
                 await Task.Delay(Config.PublishFailureBackoffMilliseconds * attemptCount, cancellationToken).ConfigureAwait(false);
                 await PublishAsync(publisher, message, attemptCount, cancellationToken).ConfigureAwait(false);
             }

--- a/JustSaying/JustSayingFluentlyLogging.cs
+++ b/JustSaying/JustSayingFluentlyLogging.cs
@@ -1,3 +1,4 @@
+using JustSaying.Messaging.MessageSerialisation;
 using Microsoft.Extensions.Logging;
 
 namespace JustSaying
@@ -5,5 +6,6 @@ namespace JustSaying
     public class JustSayingFluentlyLogging
     {
         public ILoggerFactory LoggerFactory { get; set; }
+        public IMessageSubjectProvider MessageSubjectProvider { get; set; }
     }
 }

--- a/JustSaying/Messaging/MessageHandling/ExactlyOnceHandler.cs
+++ b/JustSaying/Messaging/MessageHandling/ExactlyOnceHandler.cs
@@ -24,7 +24,7 @@ namespace JustSaying.Messaging.MessageHandling
 
         public async Task<bool> Handle(T message)
         {
-            var lockKey = $"{message.UniqueKey()}-{typeof(T).Name.ToLower()}-{_handlerName}";
+            var lockKey = $"{message.UniqueKey()}-{typeof(T).ToString().ToLower()}-{_handlerName}";
             var lockResponse = await _messageLock.TryAquireLockAsync(lockKey, TimeSpan.FromSeconds(_timeOut)).ConfigureAwait(false);
             if (!lockResponse.DoIHaveExclusiveLock)
             {

--- a/JustSaying/Messaging/MessageSerialisation/GenericMessageSubjectProvider.cs
+++ b/JustSaying/Messaging/MessageSerialisation/GenericMessageSubjectProvider.cs
@@ -23,7 +23,7 @@ namespace JustSaying.Messaging.MessageSerialisation
                 yield return inner;
             }
         }
-        public string GetTypeForSubject(Type messageType) =>
+        public string GetSubjectForType(Type messageType) =>
             string
                 .Join("_",
                     Flatten(messageType).Select(t => Regex.Replace(t.Name + "_" + t.Namespace, "\\W", "_")))

--- a/JustSaying/Messaging/MessageSerialisation/GenericMessageSubjectProvider.cs
+++ b/JustSaying/Messaging/MessageSerialisation/GenericMessageSubjectProvider.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using JustSaying.Extensions;
+
+namespace JustSaying.Messaging.MessageSerialisation
+{
+    /// <summary>
+    /// This implementation is suitable for generic types,
+    /// but using it will break compatibility with versions before IMessageSubjectProvider was introduced
+    /// </summary>
+    public class GenericMessageSubjectProvider : IMessageSubjectProvider
+    {
+        private const int MAX_SNS_SUBJECT_LENGTH = 100;
+
+        private static IEnumerable<Type> Flatten(Type type)
+        {
+            yield return type;
+            foreach (var inner in type.GetTypeInfo().GetGenericArguments().SelectMany(Flatten))
+            {
+                yield return inner;
+            }
+        }
+        public string GetTypeForSubject(Type messageType) =>
+            string
+                .Join("_",
+                    Flatten(messageType).Select(t => Regex.Replace(t.Name + "_" + t.Namespace, "\\W", "_")))
+                .TruncateTo(MAX_SNS_SUBJECT_LENGTH);
+    }
+}

--- a/JustSaying/Messaging/MessageSerialisation/IMessageSerialiser.cs
+++ b/JustSaying/Messaging/MessageSerialisation/IMessageSerialiser.cs
@@ -5,7 +5,7 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public interface IMessageSerialiser
     {
-        string GetMessageType(string sqsMessge);
+        string GetMessageSubject(string sqsMessge);
         Message Deserialise(string message, Type type);
 
         /// <summary>
@@ -13,11 +13,11 @@ namespace JustSaying.Messaging.MessageSerialisation
         /// </summary>
         /// <param name="message"></param>
         /// <param name="serializeForSnsPublishing">If set to false, then message will be wrapped in extra object with Subject and Message fields, e.g.:
-        /// new { Subject = message.GetType().Name, Message = serializedMessage };
+        /// new { Subject = subject, Message = serializedMessage };
         /// 
         /// AWS SNS service adds these automatically, so for publishing to topics don't add these properties
         /// </param>
         /// <returns></returns>
-        string Serialise(Message message, bool serializeForSnsPublishing);
+        string Serialise(Message message, bool serializeForSnsPublishing, string subject);
     }
 }

--- a/JustSaying/Messaging/MessageSerialisation/IMessageSubjectProvider.cs
+++ b/JustSaying/Messaging/MessageSerialisation/IMessageSubjectProvider.cs
@@ -4,6 +4,6 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public interface IMessageSubjectProvider
     {
-        string GetTypeForSubject(Type messageType);
+        string GetSubjectForType(Type messageType);
     }
 }

--- a/JustSaying/Messaging/MessageSerialisation/IMessageSubjectProvider.cs
+++ b/JustSaying/Messaging/MessageSerialisation/IMessageSubjectProvider.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace JustSaying.Messaging.MessageSerialisation
+{
+    public interface IMessageSubjectProvider
+    {
+        string GetTypeForSubject(Type messageType);
+    }
+}

--- a/JustSaying/Messaging/MessageSerialisation/MessageSerialisationRegister.cs
+++ b/JustSaying/Messaging/MessageSerialisation/MessageSerialisationRegister.cs
@@ -6,14 +6,20 @@ namespace JustSaying.Messaging.MessageSerialisation
 {
     public class MessageSerialisationRegister : IMessageSerialisationRegister
     {
-        private readonly Dictionary<string, TypeSerialiser> _map = new Dictionary<string, TypeSerialiser>();
+        private readonly IMessageSubjectProvider _messageSubjectProvider;
+        private readonly Dictionary<Type, TypeSerialiser> _map = new Dictionary<Type, TypeSerialiser>();
+
+        public MessageSerialisationRegister(IMessageSubjectProvider messageSubjectProvider)
+        {
+            _messageSubjectProvider = messageSubjectProvider;
+        }
 
         public void AddSerialiser<T>(IMessageSerialiser serialiser) where T : Message
         {
-            var keyname = typeof(T).Name;
-            if (!_map.ContainsKey(keyname))
+            var key = typeof(T);
+            if (!_map.ContainsKey(key))
             {
-                _map.Add(keyname, new TypeSerialiser(typeof(T), serialiser));
+                _map.Add(key, new TypeSerialiser(typeof(T), serialiser));
             }
         }
 
@@ -21,14 +27,14 @@ namespace JustSaying.Messaging.MessageSerialisation
         {
             foreach (var formatter in _map)
             {
-                var stringType = formatter.Value.Serialiser.GetMessageType(body);
-                if (string.IsNullOrWhiteSpace(stringType))
+                var messageSubject = formatter.Value.Serialiser.GetMessageSubject(body);
+                if (string.IsNullOrWhiteSpace(messageSubject))
                 {
                     continue;
                 }
 
                 var matchedType = formatter.Value.Type;
-                if (!string.Equals(matchedType.Name, stringType, StringComparison.CurrentCultureIgnoreCase))
+                if (!string.Equals(_messageSubjectProvider.GetTypeForSubject(matchedType), messageSubject, StringComparison.CurrentCultureIgnoreCase))
                 {
                     continue;
                 }
@@ -42,8 +48,9 @@ namespace JustSaying.Messaging.MessageSerialisation
 
         public string Serialise(Message message, bool serializeForSnsPublishing)
         {
-            var formatter = _map[message.GetType().Name];
-            return formatter.Serialiser.Serialise(message, serializeForSnsPublishing);
+            var messageType = message.GetType();
+            var formatter = _map[messageType];
+            return formatter.Serialiser.Serialise(message, serializeForSnsPublishing, _messageSubjectProvider.GetTypeForSubject(messageType));
         }
 
     }

--- a/JustSaying/Messaging/MessageSerialisation/MessageSerialisationRegister.cs
+++ b/JustSaying/Messaging/MessageSerialisation/MessageSerialisationRegister.cs
@@ -34,7 +34,7 @@ namespace JustSaying.Messaging.MessageSerialisation
                 }
 
                 var matchedType = formatter.Value.Type;
-                if (!string.Equals(_messageSubjectProvider.GetTypeForSubject(matchedType), messageSubject, StringComparison.CurrentCultureIgnoreCase))
+                if (!string.Equals(_messageSubjectProvider.GetSubjectForType(matchedType), messageSubject, StringComparison.CurrentCultureIgnoreCase))
                 {
                     continue;
                 }
@@ -50,7 +50,7 @@ namespace JustSaying.Messaging.MessageSerialisation
         {
             var messageType = message.GetType();
             var formatter = _map[messageType];
-            return formatter.Serialiser.Serialise(message, serializeForSnsPublishing, _messageSubjectProvider.GetTypeForSubject(messageType));
+            return formatter.Serialiser.Serialise(message, serializeForSnsPublishing, _messageSubjectProvider.GetSubjectForType(messageType));
         }
 
     }

--- a/JustSaying/Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
+++ b/JustSaying/Messaging/MessageSerialisation/NewtonsoftSerialiser.cs
@@ -26,7 +26,7 @@ namespace JustSaying.Messaging.MessageSerialisation
             return (Message)JsonConvert.DeserializeObject(messageBody, type, GetJsonSettings());
         }
 
-        public string Serialise(Message message, bool serializeForSnsPublishing)
+        public string Serialise(Message message, bool serializeForSnsPublishing, string subject)
         {
             var settings = GetJsonSettings();
 
@@ -40,7 +40,7 @@ namespace JustSaying.Messaging.MessageSerialisation
             }
 
             // for direct publishing to SQS, add Subject and Message properties manually
-            var context = new { Subject = message.GetType().Name, Message = msg };
+            var context = new { Subject = subject, Message = msg };
             return JsonConvert.SerializeObject(context);
         }
 
@@ -53,7 +53,7 @@ namespace JustSaying.Messaging.MessageSerialisation
                    };
         }
 
-        public string GetMessageType(string sqsMessge)
+        public string GetMessageSubject(string sqsMessge)
         {
             var body = JObject.Parse(sqsMessge);
 

--- a/JustSaying/Messaging/MessageSerialisation/NonGenericMessageSubjectProvider.cs
+++ b/JustSaying/Messaging/MessageSerialisation/NonGenericMessageSubjectProvider.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace JustSaying.Messaging.MessageSerialisation
+{
+    /// <summary>
+    /// This implementation is not suitable for generic types,
+    /// but replicates the behaviour of the system before IMessageSubjectProvider was introduced
+    /// </summary>
+    public class NonGenericMessageSubjectProvider : IMessageSubjectProvider
+    {
+        public string GetTypeForSubject(Type messageType) => messageType.Name;
+    }
+}

--- a/JustSaying/Messaging/MessageSerialisation/NonGenericMessageSubjectProvider.cs
+++ b/JustSaying/Messaging/MessageSerialisation/NonGenericMessageSubjectProvider.cs
@@ -8,6 +8,6 @@ namespace JustSaying.Messaging.MessageSerialisation
     /// </summary>
     public class NonGenericMessageSubjectProvider : IMessageSubjectProvider
     {
-        public string GetTypeForSubject(Type messageType) => messageType.Name;
+        public string GetSubjectForType(Type messageType) => messageType.Name;
     }
 }

--- a/JustSaying/Messaging/Monitoring/IMeasureHandlerExecutionTime.cs
+++ b/JustSaying/Messaging/Monitoring/IMeasureHandlerExecutionTime.cs
@@ -4,6 +4,6 @@ namespace JustSaying.Messaging.Monitoring
 {
     public interface IMeasureHandlerExecutionTime
     {
-        void HandlerExecutionTime(string typeName, string eventName, TimeSpan executionTime);
+        void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan executionTime);
     }
 }

--- a/JustSaying/Messaging/Monitoring/IMessageMonitor.cs
+++ b/JustSaying/Messaging/Monitoring/IMessageMonitor.cs
@@ -1,8 +1,10 @@
+using System;
+
 namespace JustSaying.Messaging.Monitoring
 {
     public interface IMessageMonitor
     {
-        void HandleException(string messageType);
+        void HandleException(Type messageType);
         void HandleTime(long handleTimeMs);
         void IssuePublishingMessage();
         void IncrementThrottlingStatistic();

--- a/JustSaying/Messaging/Monitoring/NullOpMessageMonitor.cs
+++ b/JustSaying/Messaging/Monitoring/NullOpMessageMonitor.cs
@@ -1,8 +1,10 @@
+using System;
+
 namespace JustSaying.Messaging.Monitoring
 {
     public class NullOpMessageMonitor : IMessageMonitor
     {
-        public void HandleException(string messageType) { }
+        public void HandleException(Type messageType) { }
 
         public void HandleTime(long handleTimeMs) { }
 

--- a/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
+++ b/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
@@ -23,10 +23,8 @@ namespace JustSaying.Messaging.Monitoring
 
             watch.Stop();
 
-            _monitoring.HandlerExecutionTime(TypeName(_inner), TypeName(message), watch.Elapsed);
+            _monitoring.HandlerExecutionTime(_inner.GetType(), message.GetType(), watch.Elapsed);
             return result;
         }
-
-        private static string TypeName(object obj) => obj.GetType().Name.ToLower();
     }
 }

--- a/JustSaying/MessagingConfig.cs
+++ b/JustSaying/MessagingConfig.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Models;
 
 namespace JustSaying
@@ -16,6 +17,7 @@ namespace JustSaying
             PublishFailureBackoffMilliseconds = JustSayingConstants.DEFAULT_PUBLISHER_RETRY_INTERVAL;
             AdditionalSubscriberAccounts = new List<string>();
             Regions = new List<string>();
+            MessageSubjectProvider = new NonGenericMessageSubjectProvider();
         }
 
         public int PublishFailureReAttempts { get; set; }
@@ -24,6 +26,7 @@ namespace JustSaying
         public IReadOnlyCollection<string> AdditionalSubscriberAccounts { get; set; }
         public IList<string> Regions { get; private set; }
         public Func<string> GetActiveRegion { get; set; }
+        public IMessageSubjectProvider MessageSubjectProvider { get; set; }
 
         public virtual void Validate()
         {
@@ -37,6 +40,9 @@ namespace JustSaying
             {
                 throw new ArgumentException($"Region {duplicateRegion.Key} was added multiple times");
             }
+
+            if (MessageSubjectProvider == null)
+                throw new ArgumentNullException("config.MessageSubjectProvider");
         }
     }
 }


### PR DESCRIPTION
Addresses lingering issues with generic message types discussed @ #278.

As mentioned there, the problem seems to lie with bits of code that stringify types using `Type.Name`, which loses information about the instance type's generic parameters. An added complication is that the Subject of SQS/SNS messages gets populated with this value;  changing that could break existing applications.

Here, I've attempted to remove all usages of `Type.Name` from the codebase in a way that won't break existing applications:

* For purely internal stuff, I've just replaced uses of `Type.Name` with something that preserves information about generic type parameters.

* For the message Subject, I've introduced an `IMessageSubjectProvider`. The default implementation preserves the current behaviour and compatibility, but has the existing problems with generics. An optional `GenericMessageSubjectProvider` breaks compatibility but supports generics (or users are free to supply their own impelmentation).