### PR TITLE
Update AWSSDK packages

### DIFF
--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -9,13 +9,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.4.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-36" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="StructureMap" Version="4.6.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.4.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.10.3" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.11" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-36" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -7,9 +7,9 @@
     <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.10.3" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.11" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NLog" Version="4.5.5" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -7,10 +7,6 @@
     <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NLog" Version="4.5.5" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />

--- a/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/JustSaying.Tools/JustSaying.Tools.csproj
@@ -11,7 +11,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Magnum" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />  </ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/JustSaying.Tools/JustSaying.Tools.csproj
@@ -10,12 +10,8 @@
     <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="Magnum" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/JustSaying.Tools/JustSaying.Tools.csproj
@@ -10,8 +10,8 @@
     <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.10.3" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="Magnum" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.4.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.10.3" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.11" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-36" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -10,13 +10,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.4.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-36" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -6,9 +6,9 @@
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.10.3" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.0.11" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -6,9 +6,9 @@
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.24.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.10" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Update AWSSDK nuget packages.

With the new tree-structured package model, the `AWSSDK.*` nuget packages will be implicit dependencies of the app consuming `JustSaying` meaning that they are often consumed at the _lowest_ version specified here, and never updated. 

So update them here in order to get a current version to consumers of `JustSaying`.

* Use a floating version `3.3.*` in `JustSaying.csproj`
* Projects that reference `JustSaying.csproj` do not need to mention these `AWSSDK` packages again, they are pulled in from there, via this tree of dependencies. In fact, mentioning them again is nothing but an opportunity for things to get out of sync, so avoid it. Same with `Newtonsoft.Json`.