### PR TITLE
[DNM] Proof-of-Concept HttpClientFactory integration

### DIFF
--- a/JustSaying.Extensions/AmazonServiceClientExtensions.cs
+++ b/JustSaying.Extensions/AmazonServiceClientExtensions.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+using System.Net.Http;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.Extensions
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class AmazonServiceClientExtensions
+    {
+        internal static void ConfigureHttpHandler<T>(this T client, RuntimePipeline pipeline)
+            where T : AmazonServiceClient
+        {
+            string name = client.GetType().Name;
+
+            var services = new ServiceCollection();
+
+            services
+                .AddHttpClient()
+                .AddAwsHttpClient(name, client.Config);
+
+            var serviceProvider = services.BuildServiceProvider();
+            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+            var httpRequestFactory = new CustomHttpRequestFactory(name, client.Config, httpClientFactory);
+            var httpHandler = new HttpHandler<HttpContent>(httpRequestFactory, client);
+
+            pipeline.ReplaceHandler<HttpHandler<HttpContent>>(httpHandler);
+        }
+    }
+}

--- a/JustSaying.Extensions/AwsServiceCollectionExtensions.cs
+++ b/JustSaying.Extensions/AwsServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel;
+using System.Net;
+using System.Net.Http;
+using Amazon.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JustSaying.Extensions
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class AwsServiceCollectionExtensions
+    {
+        internal static IHttpClientBuilder AddAwsHttpClient(this IServiceCollection services, string name, IClientConfig clientConfig)
+        {
+            // Based on https://github.com/aws/aws-sdk-net/blob/b691e46e57a3e24477e6a5fa2e849da44db7002f/sdk/src/Core/Amazon.Runtime/Pipeline/HttpHandler/_mobile/HttpRequestMessageFactory.cs#L164-L202
+            return services
+                .AddHttpClient(name)
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                {
+                    var handler = new HttpClientHandler()
+                    {
+                        AllowAutoRedirect = clientConfig.AllowAutoRedirect,
+                        AutomaticDecompression = DecompressionMethods.None,
+                    };
+
+                    if (clientConfig.MaxConnectionsPerServer.HasValue)
+                    {
+                        handler.MaxConnectionsPerServer = clientConfig.MaxConnectionsPerServer.Value;
+                    }
+
+                    IWebProxy proxy = clientConfig.GetWebProxy();
+
+                    if (proxy != null)
+                    {
+                        handler.Proxy = proxy;
+                    }
+
+                    if (handler.Proxy != null && clientConfig.ProxyCredentials != null)
+                    {
+                        handler.Proxy.Credentials = clientConfig.ProxyCredentials;
+                    }
+
+                    return handler;
+                })
+                .ConfigureHttpClient((httpClient) =>
+                {
+                    if (clientConfig.Timeout.HasValue)
+                    {
+                        httpClient.Timeout = clientConfig.Timeout.Value;
+                    }
+                });
+        }
+    }
+}

--- a/JustSaying.Extensions/CustomAmazonSQSClient.cs
+++ b/JustSaying.Extensions/CustomAmazonSQSClient.cs
@@ -1,0 +1,21 @@
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.SQS;
+
+namespace JustSaying.Extensions
+{
+    internal sealed class CustomAmazonSQSClient : AmazonSQSClient
+    {
+        internal CustomAmazonSQSClient(AWSCredentials credentials, RegionEndpoint region)
+            : base(credentials, region)
+        {
+        }
+
+        protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
+        {
+            this.ConfigureHttpHandler(pipeline);
+            base.CustomizeRuntimePipeline(pipeline);
+        }
+    }
+}

--- a/JustSaying.Extensions/CustomAmazonSimpleNotificationServiceClient.cs
+++ b/JustSaying.Extensions/CustomAmazonSimpleNotificationServiceClient.cs
@@ -1,0 +1,21 @@
+using Amazon;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.SimpleNotificationService;
+
+namespace JustSaying.Extensions
+{
+    internal sealed class CustomAmazonSimpleNotificationServiceClient : AmazonSimpleNotificationServiceClient
+    {
+        internal CustomAmazonSimpleNotificationServiceClient(AWSCredentials credentials, RegionEndpoint region)
+            : base(credentials, region)
+        {
+        }
+
+        protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
+        {
+            this.ConfigureHttpHandler(pipeline);
+            base.CustomizeRuntimePipeline(pipeline);
+        }
+    }
+}

--- a/JustSaying.Extensions/CustomHttpRequestFactory.cs
+++ b/JustSaying.Extensions/CustomHttpRequestFactory.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net.Http;
+using Amazon.Runtime;
+
+namespace JustSaying.Extensions
+{
+    internal sealed class CustomHttpRequestFactory : IHttpRequestFactory<HttpContent>
+    {
+        public CustomHttpRequestFactory(string name, IClientConfig config, IHttpClientFactory factory)
+        {
+            Name = name;
+            Config = config;
+            Factory = factory;
+        }
+
+        private IClientConfig Config { get; }
+
+        private IHttpClientFactory Factory { get; }
+
+        private string Name { get; }
+
+        public IHttpRequest<HttpContent> CreateHttpRequest(Uri requestUri)
+        {
+            var httpClient = Factory.CreateClient(Name);
+            return new HttpWebRequestMessage(httpClient, requestUri, Config);
+        }
+
+        public void Dispose()
+        {
+            // Nothing to do
+        }
+    }
+}

--- a/JustSaying.Extensions/HttpClientFactoryAwsClientFactory.cs
+++ b/JustSaying.Extensions/HttpClientFactoryAwsClientFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+using JustSaying.AwsTools;
+
+namespace JustSaying.Extensions
+{
+    public sealed class HttpClientFactoryAwsClientFactory : IAwsClientFactory
+    {
+        public HttpClientFactoryAwsClientFactory()
+            : this(FallbackCredentialsFactory.GetCredentials())
+        {
+        }
+
+        public HttpClientFactoryAwsClientFactory(AWSCredentials credentials)
+        {
+            Credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+        }
+
+        private AWSCredentials Credentials { get; }
+
+        public IAmazonSimpleNotificationService GetSnsClient(RegionEndpoint region)
+            => new CustomAmazonSimpleNotificationServiceClient(Credentials, region);
+
+        public IAmazonSQS GetSqsClient(RegionEndpoint region)
+            => new CustomAmazonSQSClient(Credentials, region);
+    }
+}

--- a/JustSaying.Extensions/JustSaying.Extensions.csproj
+++ b/JustSaying.Extensions/JustSaying.Extensions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
+  </ItemGroup>
+</Project>

--- a/JustSaying.UnitTests/HttpClientFactoryTests.cs
+++ b/JustSaying.UnitTests/HttpClientFactoryTests.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Amazon;
+using JustSaying.Extensions;
+using Xunit;
+
+namespace JustSaying.UnitTests
+{
+    public static class HttpClientFactoryTests
+    {
+        [Fact]
+        public static async Task Create_SNS_Client_Using_HttpClientFactory()
+        {
+            // Arrange
+            var factory = new HttpClientFactoryAwsClientFactory();
+
+            // Act
+            using (var client = factory.GetSnsClient(RegionEndpoint.EUWest1))
+            {
+                // Assert (no throw)
+                await client.ListTopicsAsync();
+            }
+        }
+
+        [Fact]
+        public static async Task Create_SQS_Client_Using_HttpClientFactory()
+        {
+            // Arrange
+            var factory = new HttpClientFactoryAwsClientFactory();
+
+            // Act
+            using (var client = factory.GetSqsClient(RegionEndpoint.EUWest1))
+            {
+                // Assert (no throw)
+                await client.ListQueuesAsync("*");
+            }
+        }
+    }
+}

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -6,6 +6,7 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\JustSaying.Extensions\JustSaying.Extensions.csproj" />
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/JustSaying.sln
+++ b/JustSaying.sln
@@ -49,6 +49,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustSaying.Extensions", "JustSaying.Extensions\JustSaying.Extensions.csproj", "{97F5CFB0-E92B-4783-8A5E-46723D356CD8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{F7B166C4-B4B8-4B99-9038-63E964D2CABB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7B166C4-B4B8-4B99-9038-63E964D2CABB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7B166C4-B4B8-4B99-9038-63E964D2CABB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97F5CFB0-E92B-4783-8A5E-46723D356CD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97F5CFB0-E92B-4783-8A5E-46723D356CD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97F5CFB0-E92B-4783-8A5E-46723D356CD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97F5CFB0-E92B-4783-8A5E-46723D356CD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A proof-of-concept of integrating HttpClientFactory into JustSaying.

This isn't intended to be merged, it's just an easy way to make it easy to share for review and consideration.

It's all very unextensible and what-have-you in this form, but there's enough here to show the concept of how we could hook newer .NET Core 2.1 concepts into the AWS SDK and JustSaying without having to touch the SDK itself.

The same concept could be used with the Dynamo and S3 clients as well.