### PR TITLE
Remove filter policies from queues if no policy is specified

### DIFF
--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -17,6 +17,8 @@ namespace JustSaying.AwsTools.QueueCreation
         private readonly IRegionResourceCache<SqsQueueByName> _queueCache = new RegionResourceCache<SqsQueueByName>();
         private readonly ILogger _log;
 
+        private const string EmptyFilterPolicy = "{}";
+
         public AmazonQueueCreator(IAwsClientFactoryProxy awsClientFactory, ILoggerFactory loggerFactory)
         {
             _awsClientFactory = awsClientFactory;
@@ -78,10 +80,8 @@ namespace JustSaying.AwsTools.QueueCreation
         {
             var subscriptionArn = await amazonSimpleNotificationService.SubscribeQueueAsync(topicArn, amazonSQS, queueUrl).ConfigureAwait(false);
 
-            if (!string.IsNullOrEmpty(filterPolicy))
-            {
-                await amazonSimpleNotificationService.SetSubscriptionAttributesAsync(subscriptionArn, "FilterPolicy", filterPolicy).ConfigureAwait(false);
-            }
+            var actualFilterPolicy = string.IsNullOrWhiteSpace(filterPolicy) ? EmptyFilterPolicy : filterPolicy;
+            await amazonSimpleNotificationService.SetSubscriptionAttributesAsync(subscriptionArn, "FilterPolicy", actualFilterPolicy).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

While testing SQS filtering, I found that if you create a subscription with a filter policy but then remove the policy in code, it will re-use the existing queue without removing the filter policy.

This change will send an empty filter policy if no policy is specified, overwriting any policy which was present on an pre-existing queue. (Follows guidance for removing policies from here: https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html)

_Please include a reference to a GitHub issue if appropriate._
