### PR TITLE
[WIP] Add BaseTopicName to SnsWriteConfiguration

### DIFF
--- a/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JustSaying.Models;
 
 namespace JustSaying.AwsTools.QueueCreation
@@ -10,5 +10,6 @@ namespace JustSaying.AwsTools.QueueCreation
         /// </summary>
         /// <returns>Boolean indicating whether the exception has been handled</returns>
         public Func<Exception, Message, bool> HandleException { get; set; }
+        public string BaseTopicName { get; set; }
     }
 }

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -75,12 +75,11 @@ namespace JustSaying
             var snsWriteConfig = new SnsWriteConfiguration();
             configBuilder?.Invoke(snsWriteConfig);
 
-            _subscriptionConfig.Topic = typeof(T).ToTopicName();
             var namingStrategy = GetNamingStrategy();
 
             Bus.SerialisationRegister.AddSerialiser<T>(_serialisationFactory.GetSerialiser<T>());
 
-            var topicName = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, typeof(T));
+            var topicName = namingStrategy.GetTopicName(snsWriteConfig.BaseTopicName, typeof(T));
             foreach (var region in Bus.Config.Regions)
             {
                 // TODO pass region down into topic creation for when we have foreign topics so we can generate the arn
@@ -101,7 +100,7 @@ namespace JustSaying
                 Bus.AddMessagePublisher<T>(eventPublisher, region);
             }
 
-            _log.LogInformation($"Created SNS topic publisher - Topic: {_subscriptionConfig.Topic}");
+            _log.LogInformation($"Created SNS topic publisher - Topic: {typeof(T).ToTopicName()}");
 
             return this;
         }


### PR DESCRIPTION
Currently the `BaseTopicName` is taken from the `_subscriptionConfig` when registering an SNS publisher which means you have to some fluent API gymnastics to get it to be set correctly, such as;
```
CreateMeABus
    .WithLogging(NullLoggerFactory.Instance)
    .InRegion("eu-west-1")
    .WithSqsTopicSubscriber()
    .IntoQueue("queue")
    .ConfigureSubscriptionWith(cfg =>
    {
        cfg.BaseTopicName = "lardy-dah";
    })
    .WithMessageHandler(new FakeMessageHandler())
    .WithSnsMessagePublisher<FakeMessage>();
```

This proposed change allows you to do this;
```
CreateMeABus
    .WithLogging(NullLoggerFactory.Instance)
    .InRegion("eu-west-1")
    .WithSnsMessagePublisher<FakeMessage>(cfg =>
    {
        cfg.BaseTopicName = "lardy-dah";
    });
```