### PR TITLE
Add BaseTopicName to SnsWriteConfiguration

### DIFF
--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -84,11 +84,15 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                     c.PublishFailureBackoffMilliseconds = _config.PublishFailureBackoffMilliseconds;
                     c.PublishFailureReAttempts = _config.PublishFailureReAttempts;
                 })
-                .WithSnsMessagePublisher<SimpleMessage>()
+                .WithSnsMessagePublisher<SimpleMessage>(cf =>
+                {
+                    cf.BaseTopicName = "this-is-my-topic";
+                })
                 .WithSqsTopicSubscriber()
                 .IntoQueue(TestFixture.UniqueName)
                 .ConfigureSubscriptionWith(cf =>
                 {
+                    cf.BaseTopicName = "this-is-my-topic";
                     cf.MessageRetentionSeconds = 60;
                     cf.VisibilityTimeoutSeconds = JustSayingConstants.DEFAULT_VISIBILITY_TIMEOUT;
                     cf.InstancePosition = 1;

--- a/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JustSaying.Models;
 
 namespace JustSaying.AwsTools.QueueCreation
@@ -10,5 +10,6 @@ namespace JustSaying.AwsTools.QueueCreation
         /// </summary>
         /// <returns>Boolean indicating whether the exception has been handled</returns>
         public Func<Exception, Message, bool> HandleException { get; set; }
+        public string BaseTopicName { get; set; }
     }
 }

--- a/JustSaying/DefaultNamingStrategy.cs
+++ b/JustSaying/DefaultNamingStrategy.cs
@@ -5,7 +5,7 @@ using JustSaying.Extensions;
 namespace JustSaying
 {
     /// <summary>
-    /// A default namign strategy for JustSaying bus.
+    /// A default naming strategy for JustSaying bus.
     /// Topic names are defaulted to message type name, lowercase (one topic per message type).
     /// Queue name is default to queue name.
     /// 
@@ -13,7 +13,10 @@ namespace JustSaying
     /// </summary>
     class DefaultNamingStrategy : INamingStrategy
     {
-        public string GetTopicName(string topicName, Type messageType) => messageType.ToTopicName().ToLower();
+        public string GetTopicName(string baseTopicName, Type messageType)
+            => string.IsNullOrEmpty(baseTopicName)
+                ? messageType.ToTopicName().ToLower()
+                : baseTopicName;
 
         public string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType)
             => string.IsNullOrWhiteSpace(sqsConfig.BaseQueueName)

--- a/JustSaying/INamingStrategy.cs
+++ b/JustSaying/INamingStrategy.cs
@@ -5,7 +5,7 @@ namespace JustSaying
 {
     public interface INamingStrategy
     {
-        string GetTopicName(string topicName, Type messageType);
+        string GetTopicName(string baseTopicName, Type messageType);
         string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType);
     }
 }

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -75,12 +75,11 @@ namespace JustSaying
             var snsWriteConfig = new SnsWriteConfiguration();
             configBuilder?.Invoke(snsWriteConfig);
 
-            _subscriptionConfig.Topic = typeof(T).ToTopicName();
             var namingStrategy = GetNamingStrategy();
 
             Bus.SerialisationRegister.AddSerialiser<T>(_serialisationFactory.GetSerialiser<T>());
 
-            var topicName = namingStrategy.GetTopicName(_subscriptionConfig.BaseTopicName, typeof(T));
+            var topicName = namingStrategy.GetTopicName(snsWriteConfig.BaseTopicName, typeof(T));
             foreach (var region in Bus.Config.Regions)
             {
                 // TODO pass region down into topic creation for when we have foreign topics so we can generate the arn
@@ -101,7 +100,7 @@ namespace JustSaying
                 Bus.AddMessagePublisher<T>(eventPublisher, region);
             }
 
-            _log.LogInformation($"Created SNS topic publisher - Topic: {_subscriptionConfig.Topic}");
+            _log.LogInformation($"Created SNS topic publisher - Topic: {typeof(T).ToTopicName()}");
 
             return this;
         }


### PR DESCRIPTION
Currently the `BaseTopicName` is taken from the `_subscriptionConfig` when registering an SNS publisher which means you have to perform some fluent API gymnastics to set it correctly, such as;
```
CreateMeABus
    .WithLogging(NullLoggerFactory.Instance)
    .InRegion("eu-west-1")
    .WithSqsTopicSubscriber()
    .IntoQueue("queue")
    .ConfigureSubscriptionWith(cfg =>
    {
        cfg.BaseTopicName = "lardy-dah";
    })
    .WithMessageHandler(new FakeMessageHandler())
    .WithSnsMessagePublisher<FakeMessage>();
```

This proposed change allows you to do this;
```
CreateMeABus
    .WithLogging(NullLoggerFactory.Instance)
    .InRegion("eu-west-1")
    .WithSnsMessagePublisher<FakeMessage>(cfg =>
    {
        cfg.BaseTopicName = "lardy-dah";
    });
```