### PR TITLE
Remove code coverage upload

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,6 @@ install:
 build_script:
   - ps: .\Build.ps1
 
-after_build:
-    - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
-    - pip install codecov
-    - codecov -f "artifacts\code-coverage.xml"
-
 nuget:
   disable_publish_on_pr: true
 


### PR DESCRIPTION
Fixes #393 by removing the step to upload a non-existent code coverage report to `codecov.io`.
