### PR TITLE
Bump version to 7.0.0

### DIFF
--- a/JustSaying.Models.version.props
+++ b/JustSaying.Models.version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition=" '$(MSBuildProjectName)' == 'JustSaying.Models' ">
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>7.0.0</VersionPrefix>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-version: 0.0.{build}
+version: 7.0.{build}
 
 branches:
   only:

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>7.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
  * Bump the version to 7.0.0.
  * Set the initial version in AppVeyor to `7` rather than `0`, even if we do change it during the build (which breaks pending GitHub status check links once the build starts).
