### PR TITLE
Microsoft.Extensions.Logging.Abstractions dependency version downgrade

### DIFF
--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes the dependency on Microsoft.Extensions.Logging.Abstractions for the netstandard2.0 target from >= 2.1.1 to >= 2.0.0.

This is useful because the Microsoft.AspNetCore.App metapackages have dependencies on specific versions of Microsoft.Extensions.Logging.Abstractions. So as things stand, if you're targeting, say, Microsoft.AspNetCore.App 2.1.0 and JustSaying, you'll get errors unless you explicitly reference Microsoft.Extensions.Logging.Abstractions 2.1.1, and even then you'll get a warning.

I assume that JustSaying isn't actually depending on anything in 2.1.1, because the net461 target uses 1.1.2?