### PR TITLE
Versioning Updates

### DIFF
--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -9,6 +9,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="StructureMap" Version="4.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="StructureMap" Version="4.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/JustSaying.Models.version.props
+++ b/JustSaying.Models.version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition=" '$(MSBuildProjectName)' == 'JustSaying.Models' ">
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.0.1</VersionPrefix>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -8,10 +8,10 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.5.0" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-51" />
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0-alpha4" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0-beta1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="Shouldly" Version="3.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
   </ItemGroup>
 </Project>

--- a/JustSaying.Tools/JustSaying.Tools.csproj
+++ b/JustSaying.Tools/JustSaying.Tools.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Magnum" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -9,6 +9,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 </Project>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -6,13 +6,13 @@
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
As-per the discussion in #396, this PR updates our versioning as thus:
  1. JustSaying now targets the minimum NuGet version required for compilation for it's dependencies, _except_ the AWS SDK, which I've just pinned to the same versions that we shipped `6.0.0` with.
  1. Updates the other projects to specify the _latest_ versions available for the transient dependencies from JustSaying.
  1. Updates some direct test dependencies to the latest relevant versions.
  1. Bumps the package version to `6.0.1` so we can ship these updates to NuGet.
