### PR TITLE
ToLowerInvariant

### DIFF
--- a/JustSaying.UnitTests/Messaging/Monitoring/StopwatchHandlerTests.cs
+++ b/JustSaying.UnitTests/Messaging/Monitoring/StopwatchHandlerTests.cs
@@ -43,7 +43,7 @@ namespace JustSaying.UnitTests.Messaging.Monitoring
         public async Task WhenHandlerIsWrappedinStopWatch_MonitoringIsCalledWithCorrectTypes()
         {
             var handler = MockHandler();
-            var innnerHandlerName = handler.GetType().Name.ToLower();
+            var innnerHandlerName = handler.GetType().Name.ToLowerInvariant();
 
             var monitoring = Substitute.For<IMeasureHandlerExecutionTime>();
 

--- a/JustSaying.UnitTests/TypeExtensionTests.cs
+++ b/JustSaying.UnitTests/TypeExtensionTests.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests
         public void ToTopicName_GenericType_GivesLowercaseFullNameWithNonWordCharactersReplaced()
         {
             //Don't hardcode this, otherwise test will fail on assembly version upgrade
-            var assemblyNamePart = Regex.Replace(typeof(Bar<>).Assembly.FullName.ToLower(), @"\W", "_");
+            var assemblyNamePart = Regex.Replace(typeof(Bar<>).Assembly.FullName.ToLowerInvariant(), @"\W", "_");
             typeof(Bar<Foo>).ToTopicName()
                 .ShouldBe($"justsaying_unittests_typeextensiontests_bar_1__justsaying_unittests_typeextensiontests_foo__{assemblyNamePart}__");
         }

--- a/JustSaying/AwsTools/MessageHandling/MessageHandlerWrapper.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageHandlerWrapper.cs
@@ -43,7 +43,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 throw new Exception("IMessageLock is null. You need to specify an implementation for IMessageLock.");
             }
 
-            var handlerName = handlerType.FullName.ToLower();
+            var handlerName = handlerType.FullName.ToLowerInvariant();
             return new ExactlyOnceHandler<T>(handler, _messageLock, exactlyOnceMetadata.GetTimeOut(), handlerName);
         }
 

--- a/JustSaying/DefaultNamingStrategy.cs
+++ b/JustSaying/DefaultNamingStrategy.cs
@@ -13,11 +13,11 @@ namespace JustSaying
     /// </summary>
     class DefaultNamingStrategy : INamingStrategy
     {
-        public string GetTopicName(string topicName, Type messageType) => messageType.ToTopicName().ToLower();
+        public string GetTopicName(string topicName, Type messageType) => messageType.ToTopicName().ToLowerInvariant();
 
         public string GetQueueName(SqsReadConfiguration sqsConfig, Type messageType)
             => string.IsNullOrWhiteSpace(sqsConfig.BaseQueueName)
-                ? messageType.ToTopicName().ToLower()
-                : sqsConfig.BaseQueueName.ToLower();
+                ? messageType.ToTopicName().ToLowerInvariant()
+                : sqsConfig.BaseQueueName.ToLowerInvariant();
     }
 }

--- a/JustSaying/Extensions/TypeExtensions.cs
+++ b/JustSaying/Extensions/TypeExtensions.cs
@@ -11,8 +11,8 @@ namespace JustSaying.Extensions
         public static string ToTopicName(this Type type)
         {
             var name = type.GetTypeInfo().IsGenericType
-                ? Regex.Replace(type.FullName, "\\W", "_").ToLower()
-                : type.Name.ToLower();
+                ? Regex.Replace(type.FullName, "\\W", "_").ToLowerInvariant()
+                : type.Name.ToLowerInvariant();
 
             return name.TruncateTo(MAX_TOPIC_NAME_LENGTH);
         }

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -221,7 +221,7 @@ namespace JustSaying
         {
             _subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic)
             {
-                BaseTopicName = (topicName ?? string.Empty).ToLower()
+                BaseTopicName = (topicName ?? string.Empty).ToLowerInvariant()
             };
             return this;
         }

--- a/JustSaying/Messaging/MessageHandling/ExactlyOnceHandler.cs
+++ b/JustSaying/Messaging/MessageHandling/ExactlyOnceHandler.cs
@@ -24,7 +24,7 @@ namespace JustSaying.Messaging.MessageHandling
 
         public async Task<bool> Handle(T message)
         {
-            var lockKey = $"{message.UniqueKey()}-{typeof(T).ToString().ToLower()}-{_handlerName}";
+            var lockKey = $"{message.UniqueKey()}-{typeof(T).ToString().ToLowerInvariant()}-{_handlerName}";
             var lockResponse = await _messageLock.TryAquireLockAsync(lockKey, TimeSpan.FromSeconds(_timeOut)).ConfigureAwait(false);
             if (!lockResponse.DoIHaveExclusiveLock)
             {


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

use `ToLowerInvariant()` not `ToLower()` throughout.
This should be a compatible change in almost all cases, whereas using `ToUpperInvariant()` as some guidance suggests, could introduce tricky breakages.

_Please include a reference to a GitHub issue if appropriate._

Work towards using code analysers
