### PR TITLE
Naming of constants

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/WhenCreatingErrorQueue.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenCreatingErrorQueue.cs
@@ -19,7 +19,7 @@ namespace JustSaying.IntegrationTests.AwsTools
         {
             var queueConfig = new SqsBasicConfiguration
             {
-                ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MAXIMUM_RETENTION_PERIOD,
+                ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod,
                 ErrorQueueOptOut = true
             };
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -90,7 +90,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .ConfigureSubscriptionWith(cf =>
                 {
                     cf.MessageRetentionSeconds = 60;
-                    cf.VisibilityTimeoutSeconds = JustSayingConstants.DEFAULT_VISIBILITY_TIMEOUT;
+                    cf.VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
                     cf.InstancePosition = 1;
                 })
                 .WithMessageHandler(snsHandler)

--- a/JustSaying.UnitTests/AwsTools/SqsQueueConfiguration/Validation/WhenPublishEndpointIsNotProvided.cs
+++ b/JustSaying.UnitTests/AwsTools/SqsQueueConfiguration/Validation/WhenPublishEndpointIsNotProvided.cs
@@ -26,7 +26,7 @@ namespace JustSaying.UnitTests.AwsTools.SqsQueueConfiguration.Validation
 
         protected override SqsReadConfiguration CreateSystemUnderTest()
         {
-            return new SqsReadConfiguration(SubscriptionType.ToTopic) { MessageRetentionSeconds = JustSayingConstants.MINIMUM_RETENTION_PERIOD +1, Topic = "ATopic", PublishEndpoint = null };
+            return new SqsReadConfiguration(SubscriptionType.ToTopic) { MessageRetentionSeconds = JustSayingConstants.MinimumRetentionPeriod +1, Topic = "ATopic", PublishEndpoint = null };
         }
     }
 }

--- a/JustSaying.UnitTests/WhenPublishEndpointIsNotProvided.cs
+++ b/JustSaying.UnitTests/WhenPublishEndpointIsNotProvided.cs
@@ -25,6 +25,6 @@ namespace JustSaying.UnitTests
         }
 
         protected override SqsReadConfiguration CreateSystemUnderTest()
-            => new SqsReadConfiguration(SubscriptionType.ToTopic) { MessageRetentionSeconds = JustSayingConstants.MINIMUM_RETENTION_PERIOD +1, Topic = "ATopic", PublishEndpoint = null };
+            => new SqsReadConfiguration(SubscriptionType.ToTopic) { MessageRetentionSeconds = JustSayingConstants.MinimumRetentionPeriod +1, Topic = "ATopic", PublishEndpoint = null };
     }
 }

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -25,7 +25,7 @@ namespace JustSaying.AwsTools
             return new Dictionary<string, string>
             {
                 { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD , queueConfig.ErrorQueueRetentionPeriodSeconds.ToString(CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , JustSayingConstants.DEFAULT_VISIBILITY_TIMEOUT.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , JustSayingConstants.DefaultVisibilityTimeout.ToString(CultureInfo.InvariantCulture)},
             };
         }
 
@@ -42,7 +42,7 @@ namespace JustSaying.AwsTools
                 Attributes = new Dictionary<string, string>
                 {
                     {
-                        JustSayingConstants.ATTRIBUTE_RETENTION_PERIOD,
+                        JustSayingConstants.AttributeRetentionPeriod,
                         queueConfig.ErrorQueueRetentionPeriodSeconds.ToString(CultureInfo.InvariantCulture)
                     }
                 }

--- a/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/JustSaying/AwsTools/JustSayingConstants.cs
@@ -2,70 +2,70 @@ namespace JustSaying.AwsTools
 {
     public static class JustSayingConstants
     {
-        public const string ATTRIBUTE_REDRIVE_POLICY = "RedrivePolicy";
-        public const string ATTRIBUTE_ARN = "QueueArn";
-        public const string ATTRIBUTE_RETENTION_PERIOD = "MessageRetentionPeriod";
-        public const string ATTRIBUTE_VISIBILITY_TIMEOUT = "VisibilityTimeout";
-        public const string ATTRIBUTE_DELIVERY_DELAY = "DelaySeconds";
-        public const string ATTRIBUTE_POLICY = "Policy";
-        public const string ATTRIBUTE_ENCRYPTION_KEY_ID = "KmsMasterKeyId";
-        public const string ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND_ID = "KmsDataKeyReusePeriodSeconds";
+        public const string AttributeRedrivePolicy = "RedrivePolicy";
+        public const string AttributeArn = "QueueArn";
+        public const string AttributeRetentionPeriod = "MessageRetentionPeriod";
+        public const string AttributeVisibilityTimeout = "VisibilityTimeout";
+        public const string AttributeDeliveryDelay = "DelaySeconds";
+        public const string AttributePolicy = "Policy";
+        public const string AttributeEncryptionKeyId = "KmsMasterKeyId";
+        public const string AttributeEncryptionKeyReusePeriodSecondId = "KmsDataKeyReusePeriodSeconds";
 
         /// <summary>
         /// Default visibility timeout for message in seconds
         /// </summary>
-        public static int DEFAULT_VISIBILITY_TIMEOUT = 30;
+        public static int DefaultVisibilityTimeout = 30;
         
         /// <summary>
         /// Number of times a handler will retry a message until a message 
         /// is sent to error queue
         /// </summary>
-        public static int DEFAULT_HANDLER_RETRY_COUNT = 5;
+        public static int DefaultHandlerRetryCount = 5;
 
         /// <summary>
         /// Number of times publisher will retry to publish a message if destination is down.
         /// </summary>
-        public static int DEFAULT_PUBLISHER_RETRY_COUNT = 3;
+        public static int DefaultPublisherRetryCount = 3;
 
         /// <summary>
         /// Every time a publisher is not able to deliver a message, it will 
         /// wait {interval}*{attemptCount} miliseconds before retrying,
         /// </summary>
-        public static int DEFAULT_PUBLISHER_RETRY_INTERVAL = 100;//100 milliseconds
+        public static int DefaultPublisherRetryInterval = 100;//100 milliseconds
         
         /// <summary>
         /// Minimum message retention period on a queue.
         /// </summary>
-        public static int MINIMUM_RETENTION_PERIOD = 60;         //1 minute
+        public static int MinimumRetentionPeriod = 60;         //1 minute
 
         /// <summary>
         /// Default message retention period on a queue in seconds
         /// </summary>
-        public static int DEFAULT_RETENTION_PERIOD = 60 * 10;    //10 minutes
+        public static int DefaultRetentionPeriod = 60 * 10;    //10 minutes
 
         /// <summary>
         /// Maximum message retention period on a queue in seconds
         /// </summary>
-        public static int MAXIMUM_RETENTION_PERIOD = 1209600;    //14 days
+        public static int MaximumRetentionPeriod = 1209600;    //14 days
         
         /// <summary>
         /// Minimum delay in message delivery for SQS i nseconds. This is also the default.
         /// </summary>
-        public static int MINIMUM_DELIVERY_DELAY = 0;
+        public static int MinimumDeliveryDelay = 0;
 
         /// <summary>
         /// Maximum message delivery delay for SQS in seconds
         /// </summary>
-        public static int MAXIMUM_DELIVERY_DELAY = 900;          //15 minutes
+        public static int MaximumDeliveryDelay = 900;          //15 minutes
 
         /// <summary>
-        /// Default ID of an AWS-managed cutomer master key (CMK) for Amazon SQS
+        /// Default ID of an AWS-managed customer master key (CMK) for Amazon SQS
         /// </summary>
-        public static string DEFAULT_ATTRIBUTE_ENCRYPTION_KEY_ID = "alias/aws/sqs";
+        public static string DefaultAttributeEncryptionKeyId = "alias/aws/sqs";
 
         /// <summary>
         /// Default length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt/decrypt messages before calling AWS KMS again
         /// </summary>
-        public static string DEFAULT_ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND = "300";  //5 minutes
+        public static string DefaultAttributeEncryptionKeyReusePeriodSecond = "300";  //5 minutes
     }
 }

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -52,14 +52,14 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var keys = new[]
                 {
-                    JustSayingConstants.ATTRIBUTE_ARN,
-                    JustSayingConstants.ATTRIBUTE_REDRIVE_POLICY,
-                    JustSayingConstants.ATTRIBUTE_POLICY,
-                    JustSayingConstants.ATTRIBUTE_RETENTION_PERIOD,
-                    JustSayingConstants.ATTRIBUTE_VISIBILITY_TIMEOUT,
-                    JustSayingConstants.ATTRIBUTE_DELIVERY_DELAY,
-                    JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_ID,
-                    JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND_ID
+                    JustSayingConstants.AttributeArn,
+                    JustSayingConstants.AttributeRedrivePolicy,
+                    JustSayingConstants.AttributePolicy,
+                    JustSayingConstants.AttributeRetentionPeriod,
+                    JustSayingConstants.AttributeVisibilityTimeout,
+                    JustSayingConstants.AttributeDeliveryDelay,
+                    JustSayingConstants.AttributeEncryptionKeyId,
+                    JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId
                 };
             var attributes = await GetAttrsAsync(keys).ConfigureAwait(false);
             Arn = attributes.QueueARN;
@@ -87,19 +87,19 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var attributes = new Dictionary<string, string>
                 {
-                    {JustSayingConstants.ATTRIBUTE_RETENTION_PERIOD, queueConfig.MessageRetentionSeconds.ToString(CultureInfo.InvariantCulture) },
-                    {JustSayingConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture) },
-                    {JustSayingConstants.ATTRIBUTE_DELIVERY_DELAY, queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture) }
+                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetentionSeconds.ToString(CultureInfo.InvariantCulture) },
+                    {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture) },
+                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture) }
                 };
                 if (queueConfig.ServerSideEncryption != null)
                 {
-                    attributes.Add(JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_ID, queueConfig.ServerSideEncryption.KmsMasterKeyId);
-                    attributes.Add(JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND_ID, queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds);
+                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyId, queueConfig.ServerSideEncryption.KmsMasterKeyId);
+                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId, queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds);
                 }
 
                 if (queueConfig.ServerSideEncryption == null)
                 {
-                    attributes.Add(JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_ID, string.Empty);
+                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyId, string.Empty);
                 }
                 var request = new SetQueueAttributesRequest
                 {
@@ -145,23 +145,23 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private RedrivePolicy ExtractRedrivePolicyFromQueueAttributes(Dictionary<string, string> queueAttributes)
         {
-            if (!queueAttributes.ContainsKey(JustSayingConstants.ATTRIBUTE_REDRIVE_POLICY))
+            if (!queueAttributes.ContainsKey(JustSayingConstants.AttributeRedrivePolicy))
             {
                 return null;
             }
-            return RedrivePolicy.ConvertFromString(queueAttributes[JustSayingConstants.ATTRIBUTE_REDRIVE_POLICY]);
+            return RedrivePolicy.ConvertFromString(queueAttributes[JustSayingConstants.AttributeRedrivePolicy]);
         }
 
         private ServerSideEncryption ExtractServerSideEncryptionFromQueueAttributes(Dictionary<string, string> queueAttributes)
         {
-            if (!queueAttributes.ContainsKey(JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_ID))
+            if (!queueAttributes.ContainsKey(JustSayingConstants.AttributeEncryptionKeyId))
             {
                 return null;
             }
             return new ServerSideEncryption
             {
-                KmsMasterKeyId = queueAttributes[JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_ID],
-                KmsDataKeyReusePeriodSeconds = queueAttributes[JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND_ID]
+                KmsMasterKeyId = queueAttributes[JustSayingConstants.AttributeEncryptionKeyId],
+                KmsDataKeyReusePeriodSeconds = queueAttributes[JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId]
             };
         }
     }

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -61,7 +61,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     QueueUrl = Url,
                     Attributes = new Dictionary<string, string>
                         {
-                            {JustSayingConstants.ATTRIBUTE_REDRIVE_POLICY, requestedRedrivePolicy.ToString()}
+                            {JustSayingConstants.AttributeRedrivePolicy, requestedRedrivePolicy.ToString()}
                         }
                 };
 
@@ -120,13 +120,13 @@ namespace JustSaying.AwsTools.MessageHandling
             };
             if (NeedErrorQueue(queueConfig))
             {
-                policy.Add(JustSayingConstants.ATTRIBUTE_REDRIVE_POLICY, new RedrivePolicy(_retryCountBeforeSendingToErrorQueue, ErrorQueue.Arn).ToString());
+                policy.Add(JustSayingConstants.AttributeRedrivePolicy, new RedrivePolicy(_retryCountBeforeSendingToErrorQueue, ErrorQueue.Arn).ToString());
             }
 
             if (queueConfig.ServerSideEncryption != null)
             {
-                policy.Add(JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_ID, queueConfig.ServerSideEncryption.KmsMasterKeyId);
-                policy.Add(JustSayingConstants.ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND_ID, queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds);
+                policy.Add(JustSayingConstants.AttributeEncryptionKeyId, queueConfig.ServerSideEncryption.KmsMasterKeyId);
+                policy.Add(JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId, queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds);
             }
 
             return policy;

--- a/JustSaying/AwsTools/QueueCreation/ServerSideEncryption.cs
+++ b/JustSaying/AwsTools/QueueCreation/ServerSideEncryption.cs
@@ -6,8 +6,8 @@ namespace JustSaying.AwsTools.QueueCreation
     {
         public ServerSideEncryption()
         {
-            KmsMasterKeyId = JustSayingConstants.DEFAULT_ATTRIBUTE_ENCRYPTION_KEY_ID;
-            KmsDataKeyReusePeriodSeconds = JustSayingConstants.DEFAULT_ATTRIBUTE_ENCRYPTION_KEY_REUSE_PERIOD_SECOND;
+            KmsMasterKeyId = JustSayingConstants.DefaultAttributeEncryptionKeyId;
+            KmsDataKeyReusePeriodSeconds = JustSayingConstants.DefaultAttributeEncryptionKeyReusePeriodSecond;
         }
             
         [JsonProperty(PropertyName = "kmsMasterKeyId")]

--- a/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -12,34 +12,34 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public SqsBasicConfiguration()
         {
-            MessageRetentionSeconds = JustSayingConstants.DEFAULT_RETENTION_PERIOD;
-            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MAXIMUM_RETENTION_PERIOD;
-            VisibilityTimeoutSeconds = JustSayingConstants.DEFAULT_VISIBILITY_TIMEOUT;
-            RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DEFAULT_HANDLER_RETRY_COUNT;
-            DeliveryDelaySeconds = JustSayingConstants.MINIMUM_DELIVERY_DELAY;
+            MessageRetentionSeconds = JustSayingConstants.DefaultRetentionPeriod;
+            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod;
+            VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+            RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
+            DeliveryDelaySeconds = JustSayingConstants.MinimumDeliveryDelay;
         }
 
         public virtual void Validate()
         {
-            if (MessageRetentionSeconds < JustSayingConstants.MINIMUM_RETENTION_PERIOD ||
-                MessageRetentionSeconds > JustSayingConstants.MAXIMUM_RETENTION_PERIOD)
+            if (MessageRetentionSeconds < JustSayingConstants.MinimumRetentionPeriod ||
+                MessageRetentionSeconds > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. MessageRetentionSeconds must be between {JustSayingConstants.MINIMUM_RETENTION_PERIOD} and {JustSayingConstants.MAXIMUM_RETENTION_PERIOD}.");
+                    $"Invalid configuration. MessageRetentionSeconds must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
-            if (ErrorQueueRetentionPeriodSeconds < JustSayingConstants.MINIMUM_RETENTION_PERIOD ||
-                ErrorQueueRetentionPeriodSeconds > JustSayingConstants.MAXIMUM_RETENTION_PERIOD)
+            if (ErrorQueueRetentionPeriodSeconds < JustSayingConstants.MinimumRetentionPeriod ||
+                ErrorQueueRetentionPeriodSeconds > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. ErrorQueueRetentionPeriodSeconds must be between {JustSayingConstants.MINIMUM_RETENTION_PERIOD} and {JustSayingConstants.MAXIMUM_RETENTION_PERIOD}.");
+                    $"Invalid configuration. ErrorQueueRetentionPeriodSeconds must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
-            if (DeliveryDelaySeconds < JustSayingConstants.MINIMUM_DELIVERY_DELAY ||
-                DeliveryDelaySeconds > JustSayingConstants.MAXIMUM_DELIVERY_DELAY)
+            if (DeliveryDelaySeconds < JustSayingConstants.MinimumDeliveryDelay ||
+                DeliveryDelaySeconds > JustSayingConstants.MaximumDeliveryDelay)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. DeliveryDelaySeconds must be between {JustSayingConstants.MINIMUM_DELIVERY_DELAY} and {JustSayingConstants.MAXIMUM_DELIVERY_DELAY}.");
+                    $"Invalid configuration. DeliveryDelaySeconds must be between {JustSayingConstants.MinimumDeliveryDelay} and {JustSayingConstants.MaximumDeliveryDelay}.");
             }
         }
     }

--- a/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
@@ -10,10 +10,10 @@ namespace JustSaying.AwsTools.QueueCreation
         public SqsReadConfiguration(SubscriptionType subscriptionType)
         {
             SubscriptionType = subscriptionType;
-            MessageRetentionSeconds = JustSayingConstants.DEFAULT_RETENTION_PERIOD;
-            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MAXIMUM_RETENTION_PERIOD;
-            VisibilityTimeoutSeconds = JustSayingConstants.DEFAULT_VISIBILITY_TIMEOUT;
-            RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DEFAULT_HANDLER_RETRY_COUNT;
+            MessageRetentionSeconds = JustSayingConstants.DefaultRetentionPeriod;
+            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod;
+            VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+            RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
         }
 
         public SubscriptionType SubscriptionType { get; private set; }

--- a/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
@@ -4,10 +4,10 @@ namespace JustSaying.AwsTools.QueueCreation
     {
         public SqsWriteConfiguration()
         {
-            MessageRetentionSeconds = JustSayingConstants.DEFAULT_RETENTION_PERIOD;
-            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MAXIMUM_RETENTION_PERIOD;
-            VisibilityTimeoutSeconds = JustSayingConstants.DEFAULT_VISIBILITY_TIMEOUT;
-            RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DEFAULT_HANDLER_RETRY_COUNT;
+            MessageRetentionSeconds = JustSayingConstants.DefaultRetentionPeriod;
+            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod;
+            VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+            RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
         }
 
         public string QueueName { get; set; }

--- a/JustSaying/MessagingConfig.cs
+++ b/JustSaying/MessagingConfig.cs
@@ -13,8 +13,8 @@ namespace JustSaying
     {
         public MessagingConfig()
         {
-            PublishFailureReAttempts = JustSayingConstants.DEFAULT_PUBLISHER_RETRY_COUNT;
-            PublishFailureBackoffMilliseconds = JustSayingConstants.DEFAULT_PUBLISHER_RETRY_INTERVAL;
+            PublishFailureReAttempts = JustSayingConstants.DefaultPublisherRetryCount;
+            PublishFailureBackoffMilliseconds = JustSayingConstants.DefaultPublisherRetryInterval;
             AdditionalSubscriberAccounts = new List<string>();
             Regions = new List<string>();
             MessageSubjectProvider = new NonGenericMessageSubjectProvider();


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Naming in `JustSayingConstants` as per code analysers rule [ca1707](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1707-identifiers-should-not-contain-underscores?view=vs-2017)
Change `SCREAMING_SNAKE_CASE` to `CamelCase`.

This is a breaking change.
I am doing this on it's own as it touches a few files.
NB: some of these constants can vary. What to do with them is a separate issue.

_Please include a reference to a GitHub issue if appropriate._

#401 