### PR TITLE
Use interface not array on MessageAttributeValue data

### DIFF
--- a/JustSaying.Models/MessageAttributeValue.cs
+++ b/JustSaying.Models/MessageAttributeValue.cs
@@ -4,7 +4,6 @@
 
 
 using System.Collections.Generic;
-using System.IO;
 
 
 namespace JustSaying.Models

--- a/JustSaying.Models/MessageAttributeValue.cs
+++ b/JustSaying.Models/MessageAttributeValue.cs
@@ -3,6 +3,7 @@
  */
 
 
+using System.Collections.Generic;
 using System.IO;
 
 
@@ -31,7 +32,7 @@ namespace JustSaying.Models
         /// data, or images.
         /// </para>
         /// </summary>
-        public byte[] BinaryValue { get; set; }
+        public IEnumerable<byte> BinaryValue { get; set; }
 
         /// <summary>
         /// Gets and sets the property StringValue. 

--- a/JustSaying.Models/MessageAttributeValue.cs
+++ b/JustSaying.Models/MessageAttributeValue.cs
@@ -32,7 +32,7 @@ namespace JustSaying.Models
         /// data, or images.
         /// </para>
         /// </summary>
-        public IEnumerable<byte> BinaryValue { get; set; }
+        public IReadOnlyCollection<byte> BinaryValue { get; set; }
 
         /// <summary>
         /// Gets and sets the property StringValue. 

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -83,12 +83,18 @@ namespace JustSaying.AwsTools.MessageHandling
                 source =>
                 {
                     if (source.Value == null)
+                    {
                         return null;
+                    }
+
+                    var binaryValueStream = source.Value.BinaryValue != null
+                        ? new MemoryStream(source.Value.BinaryValue.ToArray(), false)
+                        : null;
 
                     return new MessageAttributeValue
                     {
                         StringValue = source.Value.StringValue,
-                        BinaryValue = source.Value.BinaryValue != null ? new MemoryStream(source.Value.BinaryValue, false) : null,
+                        BinaryValue = binaryValueStream,
                         DataType = source.Value.DataType
                     };
                 });


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

In line with [CA1819: Properties should not return arrays](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1819-properties-should-not-return-arrays?view=vs-2017)
We use IEnumerable instead, which is both more widely compatible (e.g is implemented by lists) and less abusable as it's read-only

And convert it to array just before sending.

_Please include a reference to a GitHub issue if appropriate._

#401 