### PR TITLE
QueueUrl as Uri not string

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/BasicHandlingThrottlingTest.cs
+++ b/JustSaying.IntegrationTests/AwsTools/BasicHandlingThrottlingTest.cs
@@ -81,7 +81,7 @@ namespace JustSaying.IntegrationTests.AwsTools
                     entriesAdded++;
                 }
 
-                await client.SendMessageBatchAsync(queue.Url.ToString(), entries);
+                await client.SendMessageBatchAsync(queue.Uri.ToString(), entries);
             }
             while (entriesAdded < throttleMessageCount);
 

--- a/JustSaying.IntegrationTests/AwsTools/BasicHandlingThrottlingTest.cs
+++ b/JustSaying.IntegrationTests/AwsTools/BasicHandlingThrottlingTest.cs
@@ -81,7 +81,7 @@ namespace JustSaying.IntegrationTests.AwsTools
                     entriesAdded++;
                 }
 
-                await client.SendMessageBatchAsync(queue.Url, entries);
+                await client.SendMessageBatchAsync(queue.Url.ToString(), entries);
             }
             while (entriesAdded < throttleMessageCount);
 

--- a/JustSaying.IntegrationTests/AwsTools/BasicHandlingThrottlingTest.cs
+++ b/JustSaying.IntegrationTests/AwsTools/BasicHandlingThrottlingTest.cs
@@ -81,7 +81,7 @@ namespace JustSaying.IntegrationTests.AwsTools
                     entriesAdded++;
                 }
 
-                await client.SendMessageBatchAsync(queue.Uri.ToString(), entries);
+                await client.SendMessageBatchAsync(queue.Uri.AbsoluteUri, entries);
             }
             while (entriesAdded < throttleMessageCount);
 

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -19,7 +19,7 @@ namespace JustSaying.Models
         public string Tenant { get; set; }
         public string Conversation { get; set; }
         public string ReceiptHandle { get; set; }
-        public Uri QueueUrl { get; set; }
+        public Uri QueueUri { get; set; }
         public int? DelaySeconds { get; set; }
         public IDictionary<string, MessageAttributeValue> MessageAttributes { get; set; }
 

--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -19,7 +19,7 @@ namespace JustSaying.Models
         public string Tenant { get; set; }
         public string Conversation { get; set; }
         public string ReceiptHandle { get; set; }
-        public string QueueUrl { get; set; }
+        public Uri QueueUrl { get; set; }
         public int? DelaySeconds { get; set; }
         public IDictionary<string, MessageAttributeValue> MessageAttributes { get; set; }
 

--- a/JustSaying.Tools/Commands/MoveCommand.cs
+++ b/JustSaying.Tools/Commands/MoveCommand.cs
@@ -44,13 +44,13 @@ namespace JustSaying.Tools.Commands
 
             var sendResponse = destinationQueue.Client.SendMessageBatch(new SendMessageBatchRequest
             {
-                QueueUrl = destinationQueue.Uri.ToString(),
+                QueueUrl = destinationQueue.Uri.AbsoluteUri,
                 Entries = messages.Select(x => new SendMessageBatchRequestEntry { Id = x.MessageId, MessageBody = x.Body }).ToList()
             });
 
             sourceQueue.Client.DeleteMessageBatch(new DeleteMessageBatchRequest
             {
-                QueueUrl = sourceQueue.Uri.ToString(),
+                QueueUrl = sourceQueue.Uri.AbsoluteUri,
                 Entries = sendResponse.Successful.Select(x => new DeleteMessageBatchRequestEntry
                 {
                     Id = x.Id,
@@ -79,7 +79,7 @@ namespace JustSaying.Tools.Commands
             {
                 receiveResponse = sourceQueue.Client.ReceiveMessage(new ReceiveMessageRequest
                 {
-                    QueueUrl = sourceQueue.Uri.ToString(),
+                    QueueUrl = sourceQueue.Uri.AbsoluteUri,
                     MaxNumberOfMessages = Count
                 });
                 messages.AddRange(receiveResponse.Messages);

--- a/JustSaying.Tools/Commands/MoveCommand.cs
+++ b/JustSaying.Tools/Commands/MoveCommand.cs
@@ -33,8 +33,8 @@ namespace JustSaying.Tools.Commands
 
             var config = new AmazonSQSConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(Region) };
             var client = new DefaultAwsClientFactory().GetSqsClient(config.RegionEndpoint);
-            var sourceQueue = new SqsQueueByName(config.RegionEndpoint, SourceQueueName, client, JustSayingConstants.DEFAULT_HANDLER_RETRY_COUNT, loggerFactory);
-            var destinationQueue = new SqsQueueByName(config.RegionEndpoint, DestinationQueueName, client, JustSayingConstants.DEFAULT_HANDLER_RETRY_COUNT, loggerFactory);
+            var sourceQueue = new SqsQueueByName(config.RegionEndpoint, SourceQueueName, client, JustSayingConstants.DefaultHandlerRetryCount, loggerFactory);
+            var destinationQueue = new SqsQueueByName(config.RegionEndpoint, DestinationQueueName, client, JustSayingConstants.DefaultHandlerRetryCount, loggerFactory);
 
             EnsureQueueExistsAsync(sourceQueue).GetAwaiter().GetResult();
             EnsureQueueExistsAsync(destinationQueue).GetAwaiter().GetResult();
@@ -44,13 +44,13 @@ namespace JustSaying.Tools.Commands
 
             var sendResponse = destinationQueue.Client.SendMessageBatch(new SendMessageBatchRequest
             {
-                QueueUrl = destinationQueue.Url,
+                QueueUrl = destinationQueue.Url.ToString(),
                 Entries = messages.Select(x => new SendMessageBatchRequestEntry { Id = x.MessageId, MessageBody = x.Body }).ToList()
             });
 
             sourceQueue.Client.DeleteMessageBatch(new DeleteMessageBatchRequest
             {
-                QueueUrl = sourceQueue.Url,
+                QueueUrl = sourceQueue.Url.ToString(),
                 Entries = sendResponse.Successful.Select(x => new DeleteMessageBatchRequestEntry
                 {
                     Id = x.Id,
@@ -79,7 +79,7 @@ namespace JustSaying.Tools.Commands
             {
                 receiveResponse = sourceQueue.Client.ReceiveMessage(new ReceiveMessageRequest
                 {
-                    QueueUrl = sourceQueue.Url,
+                    QueueUrl = sourceQueue.Url.ToString(),
                     MaxNumberOfMessages = Count,
                 });
                 messages.AddRange(receiveResponse.Messages);

--- a/JustSaying.Tools/Commands/MoveCommand.cs
+++ b/JustSaying.Tools/Commands/MoveCommand.cs
@@ -80,7 +80,7 @@ namespace JustSaying.Tools.Commands
                 receiveResponse = sourceQueue.Client.ReceiveMessage(new ReceiveMessageRequest
                 {
                     QueueUrl = sourceQueue.Url.ToString(),
-                    MaxNumberOfMessages = Count,
+                    MaxNumberOfMessages = Count
                 });
                 messages.AddRange(receiveResponse.Messages);
             } while (messages.Count < Count && receiveResponse.Messages.Any());

--- a/JustSaying.Tools/Commands/MoveCommand.cs
+++ b/JustSaying.Tools/Commands/MoveCommand.cs
@@ -44,13 +44,13 @@ namespace JustSaying.Tools.Commands
 
             var sendResponse = destinationQueue.Client.SendMessageBatch(new SendMessageBatchRequest
             {
-                QueueUrl = destinationQueue.Url.ToString(),
+                QueueUrl = destinationQueue.Uri.ToString(),
                 Entries = messages.Select(x => new SendMessageBatchRequestEntry { Id = x.MessageId, MessageBody = x.Body }).ToList()
             });
 
             sourceQueue.Client.DeleteMessageBatch(new DeleteMessageBatchRequest
             {
-                QueueUrl = sourceQueue.Url.ToString(),
+                QueueUrl = sourceQueue.Uri.ToString(),
                 Entries = sendResponse.Successful.Select(x => new DeleteMessageBatchRequestEntry
                 {
                     Id = x.Id,
@@ -79,7 +79,7 @@ namespace JustSaying.Tools.Commands
             {
                 receiveResponse = sourceQueue.Client.ReceiveMessage(new ReceiveMessageRequest
                 {
-                    QueueUrl = sourceQueue.Url.ToString(),
+                    QueueUrl = sourceQueue.Uri.ToString(),
                     MaxNumberOfMessages = Count
                 });
                 messages.AddRange(receiveResponse.Messages);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -21,9 +21,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
 {
     public class DummySqsQueue : SqsQueueBase
     {
-        public DummySqsQueue(Uri url, IAmazonSQS client) : base(RegionEndpoint.EUWest1, client)
+        public DummySqsQueue(Uri uri, IAmazonSQS client) : base(RegionEndpoint.EUWest1, client)
         {
-            Url = url;
+            Uri = uri;
         }
 
         public override Task<bool> ExistsAsync() => Task.FromResult(true);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -21,7 +21,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
 {
     public class DummySqsQueue : SqsQueueBase
     {
-        public DummySqsQueue(string url, IAmazonSQS client) : base(RegionEndpoint.EUWest1, client)
+        public DummySqsQueue(Uri url, IAmazonSQS client) : base(RegionEndpoint.EUWest1, client)
         {
             Url = url;
         }
@@ -57,7 +57,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             };
 
             _loggerFactory.CreateLogger(Arg.Any<string>()).Returns(_logger);
-            _queue = new DummySqsQueue(ExpectedQueueUrl, _amazonSqsClient);
+            _queue = new DummySqsQueue(new Uri(ExpectedQueueUrl), _amazonSqsClient);
             _serialisationRegister.DeserializeMessage(Arg.Any<string>()).Returns(_typedMessage);
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -31,7 +31,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
     
     public class WhenDispatchingMessage : XAsyncBehaviourTest<MessageDispatcher>
     {
-        private const string ExpectedQueueUrl = "http://queueurl";
+        private const string ExpectedQueueUrl = "http://testurl.com/queue";
         
         private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
         private readonly IMessageMonitor _messageMonitor = Substitute.For<IMessageMonitor>();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingQueueByName.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingQueueByName.cs
@@ -25,7 +25,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
                 .Returns(x =>
                 {
                     if (x.Arg<string>() == "some-queue-name")
-                        return new GetQueueUrlResponse {QueueUrl = "some-queue-name"};
+                        return new GetQueueUrlResponse
+                        {
+                            QueueUrl = "https://testqueues.com/some-queue-name"
+                        };
                     throw new QueueDoesNotExistException("some-queue-name not found");
                 });
             _client.GetQueueAttributesAsync(Arg.Any<GetQueueAttributesRequest>())

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingDelayedMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingDelayedMessage.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
     {
         private readonly IMessageSerialisationRegister _serialisationRegister = Substitute.For<IMessageSerialisationRegister>();
         private readonly IAmazonSQS _sqs = Substitute.For<IAmazonSQS>();
-        private const string Url = "https://blablabla/" + QueueName;
+        private const string Url = "https://testurl.com/" + QueueName;
         private readonly DelayedMessage _message = new DelayedMessage(delaySeconds: 1);
         private const string QueueName = "queuename";
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public abstract class BaseQueuePollingTest : XAsyncBehaviourTest<JustSaying.AwsTools.MessageHandling.SqsNotificationListener>
     {
-        protected const string QueueUrl = "url";
+        protected const string QueueUrl = "http://url.com";
         protected IAmazonSQS Sqs;
         protected SimpleMessage DeserialisedMessage;
         protected const string MessageBody = "object";
@@ -33,7 +33,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
         protected override JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
         {
-            var queue = new SqsQueueByUrl(RegionEndpoint.EUWest1, QueueUrl, Sqs);
+            var queue = new SqsQueueByUrl(RegionEndpoint.EUWest1, new Uri(QueueUrl), Sqs);
             return new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(queue, SerialisationRegister, Monitor, LoggerFactory, null, MessageLock);
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public abstract class BaseQueuePollingTest : XAsyncBehaviourTest<JustSaying.AwsTools.MessageHandling.SqsNotificationListener>
     {
-        protected const string QueueUrl = "http://url.com";
+        protected const string QueueUrl = "http://testurl.com/queue";
         protected IAmazonSQS Sqs;
         protected SimpleMessage DeserialisedMessage;
         protected const string MessageBody = "object";
@@ -71,7 +71,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
             SystemUnderTest.StopListening();
 
-            doneOk.ShouldBeTrue("Timout occured before done signal");
+            doneOk.ShouldBeTrue("Timeout occured before done signal");
         }
 
         protected ReceiveMessageResponse GenerateResponseMessage(string messageType, Guid messageId)

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         protected override JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
         {
             return new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(
-                new SqsQueueByUrl(RegionEndpoint.EUWest1, "", _sqs), 
+                new SqsQueueByUrl(RegionEndpoint.EUWest1, new Uri("http://foo.com"), _sqs), 
                 _serialisationRegister, 
                 Substitute.For<IMessageMonitor>(),
                 Substitute.For<ILoggerFactory>());

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +23,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         protected override JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
         {
             return new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(
-                new SqsQueueByUrl(RegionEndpoint.EUWest1, "", _sqs),
+                new SqsQueueByUrl(RegionEndpoint.EUWest1, new Uri("http://foo.com"), _sqs),
                 null,
                 Substitute.For<IMessageMonitor>(),
                 Substitute.For<ILoggerFactory>());

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -38,7 +38,7 @@ namespace JustSaying.AwsTools
 
             var request = new SetQueueAttributesRequest
             {
-                QueueUrl = Url,
+                QueueUrl = Url.ToString(),
                 Attributes = new Dictionary<string, string>
                 {
                     {

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -38,7 +38,7 @@ namespace JustSaying.AwsTools
 
             var request = new SetQueueAttributesRequest
             {
-                QueueUrl = Uri.ToString(),
+                QueueUrl = Uri.AbsoluteUri,
                 Attributes = new Dictionary<string, string>
                 {
                     {

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -38,7 +38,7 @@ namespace JustSaying.AwsTools
 
             var request = new SetQueueAttributesRequest
             {
-                QueueUrl = Url.ToString(),
+                QueueUrl = Uri.ToString(),
                 Attributes = new Dictionary<string, string>
                 {
                     {

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -126,7 +126,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var deleteRequest = new DeleteMessageRequest
             {
-                QueueUrl = _queue.Uri.ToString(),
+                QueueUrl = _queue.Uri.AbsoluteUri,
                 ReceiptHandle = receiptHandle
             };
 
@@ -143,7 +143,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     var visibilityRequest = new ChangeMessageVisibilityRequest
                     {
-                        QueueUrl = _queue.Uri.ToString(),
+                        QueueUrl = _queue.Uri.AbsoluteUri,
                         ReceiptHandle = receiptHandle,
                         VisibilityTimeout = visibilityTimeoutSeconds
                     };

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -70,7 +70,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 if (typedMessage != null)
                 {
                     typedMessage.ReceiptHandle = message.ReceiptHandle;
-                    typedMessage.QueueUri = _queue.Url;
+                    typedMessage.QueueUri = _queue.Uri;
                     handlingSucceeded = await CallMessageHandler(typedMessage).ConfigureAwait(false);
                 }
 
@@ -126,7 +126,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var deleteRequest = new DeleteMessageRequest
             {
-                QueueUrl = _queue.Url.ToString(),
+                QueueUrl = _queue.Uri.ToString(),
                 ReceiptHandle = receiptHandle
             };
 
@@ -143,7 +143,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     var visibilityRequest = new ChangeMessageVisibilityRequest
                     {
-                        QueueUrl = _queue.Url.ToString(),
+                        QueueUrl = _queue.Uri.ToString(),
                         ReceiptHandle = receiptHandle,
                         VisibilityTimeout = visibilityTimeoutSeconds
                     };

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -126,7 +126,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var deleteRequest = new DeleteMessageRequest
             {
-                QueueUrl = _queue.Url,
+                QueueUrl = _queue.Url.ToString(),
                 ReceiptHandle = receiptHandle
             };
 
@@ -143,7 +143,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     var visibilityRequest = new ChangeMessageVisibilityRequest
                     {
-                        QueueUrl = _queue.Url,
+                        QueueUrl = _queue.Url.ToString(),
                         ReceiptHandle = receiptHandle,
                         VisibilityTimeout = visibilityTimeoutSeconds
                     };

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -70,7 +70,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 if (typedMessage != null)
                 {
                     typedMessage.ReceiptHandle = message.ReceiptHandle;
-                    typedMessage.QueueUrl = _queue.Url;
+                    typedMessage.QueueUri = _queue.Url;
                     handlingSucceeded = await CallMessageHandler(typedMessage).ConfigureAwait(false);
                 }
 

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -204,7 +204,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             var request = new ReceiveMessageRequest
             {
-                QueueUrl = _queue.Url.ToString(),
+                QueueUrl = _queue.Uri.ToString(),
                 MaxNumberOfMessages = numberOfMessagesToReadFromSqs,
                 WaitTimeSeconds = 20,
                 AttributeNames = _requestMessageAttributeNames

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -204,7 +204,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             var request = new ReceiveMessageRequest
             {
-                QueueUrl = _queue.Uri.ToString(),
+                QueueUrl = _queue.Uri.AbsoluteUri,
                 MaxNumberOfMessages = numberOfMessagesToReadFromSqs,
                 WaitTimeSeconds = 20,
                 AttributeNames = _requestMessageAttributeNames

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -204,7 +204,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             var request = new ReceiveMessageRequest
             {
-                QueueUrl = _queue.Url,
+                QueueUrl = _queue.Url.ToString(),
                 MaxNumberOfMessages = numberOfMessagesToReadFromSqs,
                 WaitTimeSeconds = 20,
                 AttributeNames = _requestMessageAttributeNames

--- a/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
@@ -15,7 +15,7 @@ namespace JustSaying.AwsTools.MessageHandling
             _policy = policy;
         }
 
-        public static async Task SaveAsync(string sourceArn, string queueArn, Uri queueUrl, IAmazonSQS client)
+        public static async Task SaveAsync(string sourceArn, string queueArn, Uri queueUri, IAmazonSQS client)
         {
             var topicArnWildcard = CreateTopicArnWildcard(sourceArn);
             ActionIdentifier[] actions = { SQSActionIdentifiers.SendMessage };
@@ -28,7 +28,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     .WithActionIdentifiers(actions));
             var setQueueAttributesRequest = new SetQueueAttributesRequest
             {
-                QueueUrl = queueUrl.ToString(),
+                QueueUrl = queueUri.ToString(),
                 Attributes = { ["Policy"] = sqsPolicy.ToJson() }
             };
 

--- a/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
@@ -15,7 +15,7 @@ namespace JustSaying.AwsTools.MessageHandling
             _policy = policy;
         }
 
-        public static async Task SaveAsync(string sourceArn, string queueArn, string queueUrl, IAmazonSQS client)
+        public static async Task SaveAsync(string sourceArn, string queueArn, Uri queueUrl, IAmazonSQS client)
         {
             var topicArnWildcard = CreateTopicArnWildcard(sourceArn);
             ActionIdentifier[] actions = { SQSActionIdentifiers.SendMessage };
@@ -28,7 +28,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     .WithActionIdentifiers(actions));
             var setQueueAttributesRequest = new SetQueueAttributesRequest
             {
-                QueueUrl = queueUrl,
+                QueueUrl = queueUrl.ToString(),
                 Attributes = { ["Policy"] = sqsPolicy.ToJson() }
             };
 

--- a/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
@@ -28,8 +28,11 @@ namespace JustSaying.AwsTools.MessageHandling
                     .WithActionIdentifiers(actions));
             var setQueueAttributesRequest = new SetQueueAttributesRequest
             {
-                QueueUrl = queueUri.ToString(),
-                Attributes = { ["Policy"] = sqsPolicy.ToJson() }
+                QueueUrl = queueUri.AbsoluteUri,
+                Attributes =
+                {
+                    ["Policy"] = sqsPolicy.ToJson()
+                }
             };
 
             await client.SetQueueAttributesAsync(setQueueAttributesRequest).ConfigureAwait(false);

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
@@ -53,7 +53,7 @@ namespace JustSaying.AwsTools.MessageHandling
             var request = new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                QueueUrl = Url
+                QueueUrl = Url.ToString()
             };
 
             if (message.DelaySeconds.HasValue)

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -43,7 +43,7 @@ namespace JustSaying.AwsTools.MessageHandling
             catch (Exception ex)
             {
                 throw new PublishException(
-                    $"Failed to publish message to SQS. QueueUrl: {request.QueueUrl} MessageBody: {request.MessageBody}",
+                    $"Failed to publish message to SQS. QueueUri: {request.QueueUrl} MessageBody: {request.MessageBody}",
                     ex);
             }
         }

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -53,7 +53,7 @@ namespace JustSaying.AwsTools.MessageHandling
             var request = new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                QueueUrl = Url.ToString()
+                QueueUrl = Uri.ToString()
             };
 
             if (message.DelaySeconds.HasValue)

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -53,7 +53,7 @@ namespace JustSaying.AwsTools.MessageHandling
             var request = new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                QueueUrl = Uri.ToString()
+                QueueUrl = Uri?.ToString()
             };
 
             if (message.DelaySeconds.HasValue)

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -43,7 +43,7 @@ namespace JustSaying.AwsTools.MessageHandling
             catch (Exception ex)
             {
                 throw new PublishException(
-                    $"Failed to publish message to SQS. QueueUri: {request.QueueUrl} MessageBody: {request.MessageBody}",
+                    $"Failed to publish message to SQS. {nameof(request.QueueUrl)}: {request.QueueUrl},{nameof(request.MessageBody)}: {request.MessageBody}",
                     ex);
             }
         }

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -53,7 +53,7 @@ namespace JustSaying.AwsTools.MessageHandling
             var request = new SendMessageRequest
             {
                 MessageBody = GetMessageInContext(message),
-                QueueUrl = Uri?.ToString()
+                QueueUrl = Uri?.AbsoluteUri
             };
 
             if (message.DelaySeconds.HasValue)

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
@@ -12,7 +13,7 @@ namespace JustSaying.AwsTools.MessageHandling
     public abstract class SqsQueueBase
     {
         public string Arn { get; protected set; }
-        public string Url { get; protected set; }
+        public Uri Url { get; protected set; }
         public IAmazonSQS Client { get; private set; }
         public string QueueName { get; protected set; }
         public RegionEndpoint Region { get; protected set; }
@@ -41,7 +42,11 @@ namespace JustSaying.AwsTools.MessageHandling
             var exists = await ExistsAsync().ConfigureAwait(false);
             if (exists)
             {
-                await Client.DeleteQueueAsync(new DeleteQueueRequest { QueueUrl = Url }).ConfigureAwait(false);
+                var request = new DeleteQueueRequest
+                    {
+                        QueueUrl = Url.ToString()
+                    };
+                await Client.DeleteQueueAsync(request).ConfigureAwait(false);
 
                 Arn = null;
                 Url = null;
@@ -73,10 +78,11 @@ namespace JustSaying.AwsTools.MessageHandling
 
         protected async Task<GetQueueAttributesResponse> GetAttrsAsync(IEnumerable<string> attrKeys)
         {
-            var request = new GetQueueAttributesRequest {
-                QueueUrl = Url,
-                AttributeNames = new List<string>(attrKeys)
-            };
+            var request = new GetQueueAttributesRequest
+                {
+                    QueueUrl = Url.ToString(),
+                    AttributeNames = new List<string>(attrKeys)
+                };
 
             return await Client.GetQueueAttributesAsync(request).ConfigureAwait(false);
         }
@@ -103,7 +109,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
                 var request = new SetQueueAttributesRequest
                 {
-                    QueueUrl = Url,
+                    QueueUrl = Url.ToString(),
                     Attributes = attributes
                 };
 

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -13,7 +13,7 @@ namespace JustSaying.AwsTools.MessageHandling
     public abstract class SqsQueueBase
     {
         public string Arn { get; protected set; }
-        public Uri Url { get; protected set; }
+        public Uri Uri { get; protected set; }
         public IAmazonSQS Client { get; private set; }
         public string QueueName { get; protected set; }
         public RegionEndpoint Region { get; protected set; }
@@ -37,19 +37,19 @@ namespace JustSaying.AwsTools.MessageHandling
         public virtual async Task DeleteAsync()
         {
             Arn = null;
-            Url = null;
+            Uri = null;
 
             var exists = await ExistsAsync().ConfigureAwait(false);
             if (exists)
             {
                 var request = new DeleteQueueRequest
                     {
-                        QueueUrl = Url.ToString()
+                        QueueUrl = Uri.ToString()
                     };
                 await Client.DeleteQueueAsync(request).ConfigureAwait(false);
 
                 Arn = null;
-                Url = null;
+                Uri = null;
             }
         }
 
@@ -80,7 +80,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var request = new GetQueueAttributesRequest
                 {
-                    QueueUrl = Url.ToString(),
+                    QueueUrl = Uri.ToString(),
                     AttributeNames = new List<string>(attrKeys)
                 };
 
@@ -109,7 +109,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
                 var request = new SetQueueAttributesRequest
                 {
-                    QueueUrl = Url.ToString(),
+                    QueueUrl = Uri.ToString(),
                     Attributes = attributes
                 };
 

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -44,8 +44,8 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var request = new DeleteQueueRequest
                     {
-                        QueueUrl = Uri.ToString()
-                    };
+                        QueueUrl = Uri.AbsoluteUri
+                };
                 await Client.DeleteQueueAsync(request).ConfigureAwait(false);
 
                 Arn = null;
@@ -80,7 +80,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var request = new GetQueueAttributesRequest
                 {
-                    QueueUrl = Uri.ToString(),
+                    QueueUrl = Uri.AbsoluteUri,
                     AttributeNames = new List<string>(attrKeys)
                 };
 
@@ -109,7 +109,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
                 var request = new SetQueueAttributesRequest
                 {
-                    QueueUrl = Uri.ToString(),
+                    QueueUrl = Uri.AbsoluteUri,
                     Attributes = attributes
                 };
 

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -58,7 +58,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var request = new SetQueueAttributesRequest
                 {
-                    QueueUrl = Url,
+                    QueueUrl = Url.ToString(),
                     Attributes = new Dictionary<string, string>
                         {
                             {JustSayingConstants.AttributeRedrivePolicy, requestedRedrivePolicy.ToString()}

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -58,7 +58,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var request = new SetQueueAttributesRequest
                 {
-                    QueueUrl = Uri.ToString(),
+                    QueueUrl = Uri.AbsoluteUri,
                     Attributes = new Dictionary<string, string>
                         {
                             {JustSayingConstants.AttributeRedrivePolicy, requestedRedrivePolicy.ToString()}

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -58,7 +58,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var request = new SetQueueAttributesRequest
                 {
-                    QueueUrl = Url.ToString(),
+                    QueueUrl = Uri.ToString(),
                     Attributes = new Dictionary<string, string>
                         {
                             {JustSayingConstants.AttributeRedrivePolicy, requestedRedrivePolicy.ToString()}

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
@@ -43,7 +43,8 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 return false;
             }
-            Url = result.QueueUrl;
+
+            Url = new Uri(result.QueueUrl);
 
             await SetQueuePropertiesAsync().ConfigureAwait(false);
             return true;

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
@@ -44,7 +44,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 return false;
             }
 
-            Url = new Uri(result.QueueUrl);
+            Uri = new Uri(result.QueueUrl);
 
             await SetQueuePropertiesAsync().ConfigureAwait(false);
             return true;
@@ -62,7 +62,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 if (!string.IsNullOrWhiteSpace(queueResponse?.QueueUrl))
                 {
-                    Url = new Uri(queueResponse.QueueUrl);
+                    Uri = new Uri(queueResponse.QueueUrl);
                     await Client.SetQueueAttributesAsync(queueResponse.QueueUrl, GetCreateQueueAttributes(queueConfig)).ConfigureAwait(false);
                     await SetQueuePropertiesAsync().ConfigureAwait(false);
 

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
@@ -61,7 +61,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 if (!string.IsNullOrWhiteSpace(queueResponse?.QueueUrl))
                 {
-                    Url = queueResponse.QueueUrl;
+                    Url = new Uri(queueResponse.QueueUrl);
                     await Client.SetQueueAttributesAsync(queueResponse.QueueUrl, GetCreateQueueAttributes(queueConfig)).ConfigureAwait(false);
                     await SetQueuePropertiesAsync().ConfigureAwait(false);
 

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByUrl.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByUrl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon;
@@ -8,7 +9,7 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     public class SqsQueueByUrl : SqsQueueBase
     {
-        public SqsQueueByUrl(RegionEndpoint region, string queueUrl, IAmazonSQS client)
+        public SqsQueueByUrl(RegionEndpoint region, Uri queueUrl, IAmazonSQS client)
             : base(region, client)
         {
             Url = queueUrl;
@@ -18,7 +19,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var result = await Client.ListQueuesAsync(new ListQueuesRequest()).ConfigureAwait(false);
 
-            if (result.QueueUrls.Any(x => x == Url))
+            if (result.QueueUrls.Any(x => x == Url.ToString()))
             {
                 await SetQueuePropertiesAsync().ConfigureAwait(false);
                 // Need to set the prefix yet!

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByUrl.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByUrl.cs
@@ -9,17 +9,17 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     public class SqsQueueByUrl : SqsQueueBase
     {
-        public SqsQueueByUrl(RegionEndpoint region, Uri queueUrl, IAmazonSQS client)
+        public SqsQueueByUrl(RegionEndpoint region, Uri queueUri, IAmazonSQS client)
             : base(region, client)
         {
-            Url = queueUrl;
+            Uri = queueUri;
         }
 
         public override async Task<bool> ExistsAsync()
         {
             var result = await Client.ListQueuesAsync(new ListQueuesRequest()).ConfigureAwait(false);
 
-            if (result.QueueUrls.Any(x => x == Url.ToString()))
+            if (result.QueueUrls.Any(x => x == Uri.ToString()))
             {
                 await SetQueuePropertiesAsync().ConfigureAwait(false);
                 // Need to set the prefix yet!

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByUrl.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByUrl.cs
@@ -19,7 +19,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var result = await Client.ListQueuesAsync(new ListQueuesRequest()).ConfigureAwait(false);
 
-            if (result.QueueUrls.Any(x => x == Uri.ToString()))
+            if (result.QueueUrls.Any(x => x == Uri.AbsoluteUri))
             {
                 await SetQueuePropertiesAsync().ConfigureAwait(false);
                 // Need to set the prefix yet!

--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -79,7 +79,7 @@ namespace JustSaying.AwsTools.QueueCreation
             IAmazonSimpleNotificationService amazonSimpleNotificationService,
             string topicArn, IAmazonSQS amazonSQS, Uri queueUrl, string filterPolicy)
         {
-            var subscriptionArn = await amazonSimpleNotificationService.SubscribeQueueAsync(topicArn, amazonSQS, queueUrl.ToString())
+            var subscriptionArn = await amazonSimpleNotificationService.SubscribeQueueAsync(topicArn, amazonSQS, queueUrl.AbsoluteUri)
                 .ConfigureAwait(false);
 
             var actualFilterPolicy = string.IsNullOrWhiteSpace(filterPolicy) ? EmptyFilterPolicy : filterPolicy;

--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.SimpleNotificationService;
@@ -76,9 +75,12 @@ namespace JustSaying.AwsTools.QueueCreation
             return queue;
         }
 
-        async Task SubscribeQueueAndApplyFilterPolicyAsync(IAmazonSimpleNotificationService amazonSimpleNotificationService, string topicArn, IAmazonSQS amazonSQS, string queueUrl, string filterPolicy)
+        async Task SubscribeQueueAndApplyFilterPolicyAsync(
+            IAmazonSimpleNotificationService amazonSimpleNotificationService,
+            string topicArn, IAmazonSQS amazonSQS, Uri queueUrl, string filterPolicy)
         {
-            var subscriptionArn = await amazonSimpleNotificationService.SubscribeQueueAsync(topicArn, amazonSQS, queueUrl).ConfigureAwait(false);
+            var subscriptionArn = await amazonSimpleNotificationService.SubscribeQueueAsync(topicArn, amazonSQS, queueUrl.ToString())
+                .ConfigureAwait(false);
 
             var actualFilterPolicy = string.IsNullOrWhiteSpace(filterPolicy) ? EmptyFilterPolicy : filterPolicy;
             await amazonSimpleNotificationService.SetSubscriptionAttributesAsync(subscriptionArn, "FilterPolicy", actualFilterPolicy).ConfigureAwait(false);

--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -38,7 +38,7 @@ namespace JustSaying.AwsTools.QueueCreation
                 var arnProvider = new ForeignTopicArnProvider(regionEndpoint, queueConfig.TopicSourceAccount, queueConfig.PublishEndpoint);
 
                 var topicArn = await arnProvider.GetArnAsync().ConfigureAwait(false);
-                await SubscribeQueueAndApplyFilterPolicyAsync(snsClient, topicArn, sqsClient, queue.Url, queueConfig.FilterPolicy).ConfigureAwait(false);
+                await SubscribeQueueAndApplyFilterPolicyAsync(snsClient, topicArn, sqsClient, queue.Uri, queueConfig.FilterPolicy).ConfigureAwait(false);
                 
             }
             else
@@ -46,9 +46,9 @@ namespace JustSaying.AwsTools.QueueCreation
                 var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint, snsClient, serialisationRegister, _loggerFactory, messageSubjectProvider);
                 await eventTopic.CreateAsync().ConfigureAwait(false);
 
-                await SubscribeQueueAndApplyFilterPolicyAsync(snsClient, eventTopic.Arn, sqsClient, queue.Url, queueConfig.FilterPolicy).ConfigureAwait(false);
+                await SubscribeQueueAndApplyFilterPolicyAsync(snsClient, eventTopic.Arn, sqsClient, queue.Uri, queueConfig.FilterPolicy).ConfigureAwait(false);
 
-                await SqsPolicy.SaveAsync(eventTopic.Arn, queue.Arn, queue.Url, sqsClient).ConfigureAwait(false);
+                await SqsPolicy.SaveAsync(eventTopic.Arn, queue.Arn, queue.Uri, sqsClient).ConfigureAwait(false);
             }
 
             return queue;


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

`QueueUrl` should be strongly typed as `Uri` not string
In line with [CA1056: URI properties should not be strings](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1056-uri-properties-should-not-be-strings?view=vs-2017).

_Please include a reference to a GitHub issue if appropriate._

#401 