### PR TITLE
Turn public fields to properties or constants

### DIFF
--- a/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/JustSaying/AwsTools/JustSayingConstants.cs
@@ -14,58 +14,58 @@ namespace JustSaying.AwsTools
         /// <summary>
         /// Default visibility timeout for message in seconds
         /// </summary>
-        public static int DefaultVisibilityTimeout = 30;
+        public static int DefaultVisibilityTimeout => 30;
         
         /// <summary>
         /// Number of times a handler will retry a message until a message 
         /// is sent to error queue
         /// </summary>
-        public static int DefaultHandlerRetryCount = 5;
+        public static int DefaultHandlerRetryCount => 5;
 
         /// <summary>
         /// Number of times publisher will retry to publish a message if destination is down.
         /// </summary>
-        public static int DefaultPublisherRetryCount = 3;
+        public static int DefaultPublisherRetryCount => 3;
 
         /// <summary>
         /// Every time a publisher is not able to deliver a message, it will 
         /// wait {interval}*{attemptCount} miliseconds before retrying,
         /// </summary>
-        public static int DefaultPublisherRetryInterval = 100;//100 milliseconds
+        public static int DefaultPublisherRetryInterval => 100;//100 milliseconds
         
         /// <summary>
         /// Minimum message retention period on a queue.
         /// </summary>
-        public static int MinimumRetentionPeriod = 60;         //1 minute
+        public static int MinimumRetentionPeriod => 60;         //1 minute
 
         /// <summary>
         /// Default message retention period on a queue in seconds
         /// </summary>
-        public static int DefaultRetentionPeriod = 60 * 10;    //10 minutes
+        public static int DefaultRetentionPeriod => 60 * 10;    //10 minutes
 
         /// <summary>
         /// Maximum message retention period on a queue in seconds
         /// </summary>
-        public static int MaximumRetentionPeriod = 1209600;    //14 days
+        public static int MaximumRetentionPeriod => 1209600;    //14 days
         
         /// <summary>
         /// Minimum delay in message delivery for SQS i nseconds. This is also the default.
         /// </summary>
-        public static int MinimumDeliveryDelay = 0;
+        public static int MinimumDeliveryDelay => 0;
 
         /// <summary>
         /// Maximum message delivery delay for SQS in seconds
         /// </summary>
-        public static int MaximumDeliveryDelay = 900;          //15 minutes
+        public static int MaximumDeliveryDelay => 900;          //15 minutes
 
         /// <summary>
         /// Default ID of an AWS-managed customer master key (CMK) for Amazon SQS
         /// </summary>
-        public static string DefaultAttributeEncryptionKeyId = "alias/aws/sqs";
+        public static string DefaultAttributeEncryptionKeyId => "alias/aws/sqs";
 
         /// <summary>
         /// Default length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt/decrypt messages before calling AWS KMS again
         /// </summary>
-        public static string DefaultAttributeEncryptionKeyReusePeriodSecond = "300";  //5 minutes
+        public static string DefaultAttributeEncryptionKeyReusePeriodSecond => "300";  //5 minutes
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/MessageConstants.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/MessageConstants.cs
@@ -1,8 +1,8 @@
-﻿namespace JustSaying.Messaging.MessageProcessingStrategies
+namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public static class MessageConstants
     {
         public const int MaxAmazonMessageCap = 10;
-        public static int ParallelHandlerExecutionPerCore = 8;
+        public const int ParallelHandlerExecutionPerCore = 8;
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/MessageConstants.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/MessageConstants.cs
@@ -2,7 +2,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public static class MessageConstants
     {
-        public const int MaxAmazonMessageCap = 10;
-        public const int ParallelHandlerExecutionPerCore = 8;
+        public static int MaxAmazonMessageCap => 10;
+        public static int ParallelHandlerExecutionPerCore => 8;
     }
 }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Turn public fields to properties or constants. Some of them were writable desipite the name "constants"
This makes then read-only. This should be fine, but is a breaking change.


_Please include a reference to a GitHub issue if appropriate._

Analyser rules:

[CA1501: Do not declare visible instance fields](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1051-do-not-declare-visible-instance-fields) and [CA2211: Non-constant fields should not be visible](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca2211-non-constant-fields-should-not-be-visible?view=vs-2017)

#401 