### PR TITLE
Fix CA2208 in MessagingConfig

### DIFF
--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenConfigIsValid.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenConfigIsValid.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
+{
+    public class WhenConfigIsValid : JustSayingFluentlyTestBase
+    {
+        protected override JustSaying.JustSayingFluently CreateSystemUnderTest()
+        {
+            return null;
+        }
+
+        protected override void Given()
+        {
+            RecordAnyExceptionsThrown();
+        }
+
+        protected override Task When()
+        {
+            CreateMeABus
+                .WithLogging(new LoggerFactory())
+                .InRegion("eu-west-1")
+                .ConfigurePublisherWith(configuration => { });
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public void NoExceptionIsThrownByConfig()
+        {
+            ThrownException.ShouldBeNull();
+        }
+    }
+}

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
@@ -21,21 +21,24 @@ namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
         protected override Task When()
         {
             CreateMeABus
-                .WithLogging(new LoggerFactory()).InRegion(null)
+                .WithLogging(new LoggerFactory())
+                .InRegion(null)
                 .ConfigurePublisherWith(configuration => { });
+
             return Task.CompletedTask;
         }
 
         [Fact]
         public void ConfigItemsAreRequired()
         {
-            ThrownException.ShouldBeAssignableTo<ArgumentNullException>();
+            ThrownException.ShouldNotBeNull();
+            ThrownException.ShouldBeAssignableTo<InvalidOperationException>();
         }
 
         [Fact]
         public void RegionIsRequested()
         {
-            ((ArgumentException)ThrownException).ParamName.ShouldBe("config.Regions");
+            ThrownException.Message.ShouldBe("Config cannot have a blank entry for the Regions property.");
         }
     }
 }

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenRegionIsDuplicated.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenRegionIsDuplicated.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
+{
+    public class WhenRegionIsDuplicated : JustSayingFluentlyTestBase
+    {
+        protected override JustSaying.JustSayingFluently CreateSystemUnderTest()
+        {
+            return null;
+        }
+
+        protected override void Given()
+        {
+            RecordAnyExceptionsThrown();
+        }
+
+        protected override Task When()
+        {
+            CreateMeABus
+                .WithLogging(new LoggerFactory())
+                .InRegions("dup1", "andalso2", "uniq", "andalso2", "dup1")
+                .ConfigurePublisherWith(configuration => { });
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public void DuplicateRegionsAreRejectedWithException()
+        {
+            ThrownException.ShouldNotBeNull();
+            ThrownException.ShouldBeAssignableTo<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void ExceptionMessageListsDuplicateRegions()
+        {
+            ThrownException.Message.ShouldBe("Config has duplicates in Regions for 'dup1,andalso2'.");
+        }
+    }
+}

--- a/JustSaying/MessagingConfig.cs
+++ b/JustSaying/MessagingConfig.cs
@@ -34,18 +34,21 @@ namespace JustSaying
                 throw new InvalidOperationException($"Config needs values for the {nameof(Regions)} property.");
             }
 
-            if (string.IsNullOrWhiteSpace(Regions.First()))
+            if (Regions.Any(string.IsNullOrWhiteSpace))
             {
                 throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(Regions)} property.");
             }
 
-            var duplicateRegion = Regions
+            var duplicateRegions = Regions
                 .GroupBy(x => x)
-                .FirstOrDefault(y => y.Count() > 1);
+                .Where(y => y.Count() > 1)
+                .Select(r => r.Key)
+                .ToList();
 
-            if (duplicateRegion != null)
+            if (duplicateRegions.Count > 0)
             {
-                throw new InvalidOperationException($"Config has a duplicate in {nameof(Regions)} for '{duplicateRegion.Key}'.");
+                var regionsText = string.Join(",", duplicateRegions);
+                throw new InvalidOperationException($"Config has duplicates in {nameof(Regions)} for '{regionsText}'.");
             }
 
             if (MessageSubjectProvider == null)

--- a/JustSaying/MessagingConfig.cs
+++ b/JustSaying/MessagingConfig.cs
@@ -29,9 +29,14 @@ namespace JustSaying
 
         public virtual void Validate()
         {
-            if (!Regions.Any() || string.IsNullOrWhiteSpace(Regions.First()))
+            if (!Regions.Any())
             {
-                throw new InvalidOperationException("Cannot have a blank entry for config.Regions");
+                throw new InvalidOperationException($"Config needs values for the {nameof(Regions)} property.");
+            }
+
+            if (string.IsNullOrWhiteSpace(Regions.First()))
+            {
+                throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(Regions)} property.");
             }
 
             var duplicateRegion = Regions
@@ -40,12 +45,12 @@ namespace JustSaying
 
             if (duplicateRegion != null)
             {
-                throw new InvalidOperationException($"Region {duplicateRegion.Key} was added multiple times");
+                throw new InvalidOperationException($"Config has a duplicate in {nameof(Regions)} for '{duplicateRegion.Key}'.");
             }
 
             if (MessageSubjectProvider == null)
             {
-                throw new InvalidOperationException("config.MessageSubjectProvider cannot be null");
+                throw new InvalidOperationException($"Config cannot have a null for the {nameof(MessageSubjectProvider)} property.");
             }
         }
     }

--- a/JustSaying/MessagingConfig.cs
+++ b/JustSaying/MessagingConfig.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;
@@ -24,7 +23,7 @@ namespace JustSaying
         public int PublishFailureBackoffMilliseconds { get; set; }
         public Action<MessageResponse, Message> MessageResponseLogger { get; set; }
         public IReadOnlyCollection<string> AdditionalSubscriberAccounts { get; set; }
-        public IList<string> Regions { get; private set; }
+        public IList<string> Regions { get; }
         public Func<string> GetActiveRegion { get; set; }
         public IMessageSubjectProvider MessageSubjectProvider { get; set; }
 
@@ -32,17 +31,22 @@ namespace JustSaying
         {
             if (!Regions.Any() || string.IsNullOrWhiteSpace(Regions.First()))
             {
-                throw new ArgumentNullException("config.Regions", "Cannot have a blank entry for config.Regions");
+                throw new InvalidOperationException("Cannot have a blank entry for config.Regions");
             }
 
-            var duplicateRegion = Regions.GroupBy(x => x).FirstOrDefault(y => y.Count() > 1);
+            var duplicateRegion = Regions
+                .GroupBy(x => x)
+                .FirstOrDefault(y => y.Count() > 1);
+
             if (duplicateRegion != null)
             {
-                throw new ArgumentException($"Region {duplicateRegion.Key} was added multiple times");
+                throw new InvalidOperationException($"Region {duplicateRegion.Key} was added multiple times");
             }
 
             if (MessageSubjectProvider == null)
-                throw new ArgumentNullException("config.MessageSubjectProvider");
+            {
+                throw new InvalidOperationException("config.MessageSubjectProvider cannot be null");
+            }
         }
     }
 }


### PR DESCRIPTION

_Summarise the changes this Pull Request makes._

Fix [analyser issue CA2208](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2208-instantiate-argument-exceptions-correctly) in the `MessagingConfig` class
use `InvalidOperationException` not `ArgumentNullExcpetion` because they're not arguments,  and often not null.

_Please include a reference to a GitHub issue if appropriate._

#401 