### PR TITLE
Review impl of RegionResourceCache

### DIFF
--- a/JustSaying.UnitTests/AwsTools/QueueCreation/RegionResourceCacheTests.cs
+++ b/JustSaying.UnitTests/AwsTools/QueueCreation/RegionResourceCacheTests.cs
@@ -1,0 +1,66 @@
+using JustSaying.AwsTools.QueueCreation;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.AwsTools.QueueCreation
+{
+    public class RegionResourceCacheTests
+    {
+        [Fact]
+        public void EmptyRegionResourceCacheWillReturnNulls()
+        {
+            var cache = new RegionResourceCache<string>();
+            var value = cache.TryGetFromCache("eu-west1", "someKey");
+
+            value.ShouldBeNull();
+        }
+
+        [Fact]
+        public void CanRetrieveValueByRegionAndKey()
+        {
+            var cache = new RegionResourceCache<string>();
+            cache.AddToCache("eu-west1", "testKey", "42");
+
+            var value = cache.TryGetFromCache("eu-west1", "testKey");
+
+            value.ShouldBe("42");
+        }
+
+        [Fact]
+        public void RegionDifferenceWillNotMatchValue()
+        {
+            var cache = new RegionResourceCache<string>();
+            cache.AddToCache("eu-west1", "testKey", "42");
+
+            var value = cache.TryGetFromCache("ap-southeast2", "testKey");
+
+            value.ShouldBeNull();
+        }
+
+        [Fact]
+        public void KeyDifferenceWillNotMatchValue()
+        {
+            var cache = new RegionResourceCache<string>();
+            cache.AddToCache("eu-west1", "testKey", "42");
+
+            var value = cache.TryGetFromCache("eu-west1", "otherKey");
+
+            value.ShouldBeNull();
+        }
+
+        [Fact]
+        public void CanRetrieveValueOutOfMany()
+        {
+            var cache = new RegionResourceCache<string>();
+            cache.AddToCache("eu-west1", "testKey", "42");
+            cache.AddToCache("ap-southeast2", "testKey", "12");
+            cache.AddToCache("eu-west1", "otherKey", "+");
+            cache.AddToCache("ap-southeast2", "otherKey", "-");
+            cache.AddToCache("eu-west1", "thirdKey", "value");
+
+            var value = cache.TryGetFromCache("ap-southeast2", "testKey");
+
+            value.ShouldBe("12");
+        }
+    }
+}

--- a/JustSaying.UnitTests/AwsTools/QueueCreation/RegionResourceCacheTests.cs
+++ b/JustSaying.UnitTests/AwsTools/QueueCreation/RegionResourceCacheTests.cs
@@ -16,6 +16,17 @@ namespace JustSaying.UnitTests.AwsTools.QueueCreation
         }
 
         [Fact]
+        public void KeysAreCaseInsensitive()
+        {
+            var cache = new RegionResourceCache<string>();
+            cache.AddToCache("eu-west1", "testKey", "42");
+
+            var value = cache.TryGetFromCache("EU-West1", "TESTKEY");
+
+            value.ShouldBe("42");
+        }
+
+        [Fact]
         public void CanRetrieveValueByRegionAndKey()
         {
             var cache = new RegionResourceCache<string>();

--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -13,7 +13,7 @@ namespace JustSaying.AwsTools.QueueCreation
     {
         private readonly IAwsClientFactoryProxy _awsClientFactory;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly IRegionResourceCache<SqsQueueByName> _queueCache = new RegionResourceCache<SqsQueueByName>();
+        private readonly RegionResourceCache<SqsQueueByName> _queueCache = new RegionResourceCache<SqsQueueByName>();
         private readonly ILogger _log;
 
         private const string EmptyFilterPolicy = "{}";

--- a/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -14,7 +14,6 @@ namespace JustSaying.AwsTools.QueueCreation
         private readonly IAwsClientFactoryProxy _awsClientFactory;
         private readonly ILoggerFactory _loggerFactory;
         private readonly RegionResourceCache<SqsQueueByName> _queueCache = new RegionResourceCache<SqsQueueByName>();
-        private readonly ILogger _log;
 
         private const string EmptyFilterPolicy = "{}";
 
@@ -22,7 +21,6 @@ namespace JustSaying.AwsTools.QueueCreation
         {
             _awsClientFactory = awsClientFactory;
             _loggerFactory = loggerFactory;
-            _log = loggerFactory.CreateLogger("JustSaying");
         }
 
         public async Task<SqsQueueByName> EnsureTopicExistsWithQueueSubscribedAsync(string region, IMessageSerialisationRegister serialisationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider)

--- a/JustSaying/AwsTools/QueueCreation/IRegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/IRegionResourceCache.cs
@@ -1,8 +1,0 @@
-namespace JustSaying.AwsTools.QueueCreation
-{
-    public interface IRegionResourceCache<T>
-    {
-        T TryGetFromCache(string region, string key);
-        void AddToCache(string region, string key, T value);
-    }
-}

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 
 namespace JustSaying.AwsTools.QueueCreation
@@ -5,7 +6,7 @@ namespace JustSaying.AwsTools.QueueCreation
     public sealed class RegionResourceCache<T>
     {
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, T>> _regionsData
-            = new ConcurrentDictionary<string, ConcurrentDictionary<string, T>>();
+            = new ConcurrentDictionary<string, ConcurrentDictionary<string, T>>(StringComparer.InvariantCultureIgnoreCase);
 
         public T TryGetFromCache(string region, string key)
         {
@@ -21,7 +22,7 @@ namespace JustSaying.AwsTools.QueueCreation
         public void AddToCache(string region, string key, T value)
         {
             var regionDict = _regionsData.GetOrAdd(region,
-                r => new ConcurrentDictionary<string, T>());
+                r => new ConcurrentDictionary<string, T>(StringComparer.InvariantCultureIgnoreCase));
 
             regionDict[key] = value;
         }

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Concurrent;
 
 namespace JustSaying.AwsTools.QueueCreation

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace JustSaying.AwsTools.QueueCreation
 {
-    public sealed class RegionResourceCache<T> : IRegionResourceCache<T>
+    public sealed class RegionResourceCache<T>
     {
         private readonly Dictionary<string, Dictionary<string, T>> _regionsData
             = new Dictionary<string, Dictionary<string, T>>();

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 
 namespace JustSaying.AwsTools.QueueCreation
 {

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -9,27 +9,27 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public T TryGetFromCache(string region, string key)
         {
-            if (!_regionsData.ContainsKey(region))
+            if (! _regionsData.TryGetValue(region, out var regionDict))
             {
                 return default;
             }
 
-            var regionDict = _regionsData[region];
-            if (! regionDict.ContainsKey(key))
+            if (! regionDict.TryGetValue(key, out var value))
             {
                 return default;
             }
 
-            return regionDict[key];
+            return value;
         }
 
         public void AddToCache(string region, string key, T value)
         {
-            if (!_regionsData.ContainsKey(region))
+            if (!_regionsData.TryGetValue(region, out var regionDict))
             {
-                _regionsData[region] = new Dictionary<string, T>();
+                regionDict = new Dictionary<string, T>();
+                _regionsData[region] = regionDict;
             }
-            var regionDict = _regionsData[region];
+
             regionDict[key] = value;
         }
     }

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace JustSaying.AwsTools.QueueCreation
 {
@@ -9,12 +10,10 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public T TryGetFromCache(string region, string key)
         {
-            if (_regionsData.TryGetValue(region, out var regionDict))
+            if (_regionsData.TryGetValue(region, out var regionDict)
+                && regionDict.TryGetValue(key, out var value))
             {
-                if (regionDict.TryGetValue(key, out var value))
-                {
-                    return value;
-                }
+                return value;
             }
 
             return default;

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -2,19 +2,22 @@ using System.Collections.Generic;
 
 namespace JustSaying.AwsTools.QueueCreation
 {
-    public class RegionResourceCache<T> : Dictionary<string, Dictionary<string, T>>, IRegionResourceCache<T>
+    public sealed class RegionResourceCache<T> : IRegionResourceCache<T>
     {
+        private readonly Dictionary<string, Dictionary<string, T>> _regionsData
+            = new Dictionary<string, Dictionary<string, T>>();
+
         public T TryGetFromCache(string region, string key)
         {
-            if (! ContainsKey(region))
+            if (!_regionsData.ContainsKey(region))
             {
-                return default(T);
+                return default;
             }
 
-            var regionDict = this[region];
+            var regionDict = _regionsData[region];
             if (! regionDict.ContainsKey(key))
             {
-                return default(T);
+                return default;
             }
 
             return regionDict[key];
@@ -22,11 +25,11 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public void AddToCache(string region, string key, T value)
         {
-            if (!ContainsKey(region))
+            if (!_regionsData.ContainsKey(region))
             {
-                this[region] = new Dictionary<string, T>();
+                _regionsData[region] = new Dictionary<string, T>();
             }
-            var regionDict = this[region];
+            var regionDict = _regionsData[region];
             regionDict[key] = value;
         }
     }

--- a/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
+++ b/JustSaying/AwsTools/QueueCreation/RegionResourceCache.cs
@@ -6,7 +6,7 @@ namespace JustSaying.AwsTools.QueueCreation
     public sealed class RegionResourceCache<T>
     {
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, T>> _regionsData
-            = new ConcurrentDictionary<string, ConcurrentDictionary<string, T>>(StringComparer.InvariantCultureIgnoreCase);
+            = new ConcurrentDictionary<string, ConcurrentDictionary<string, T>>(StringComparer.OrdinalIgnoreCase);
 
         public T TryGetFromCache(string region, string key)
         {
@@ -22,7 +22,7 @@ namespace JustSaying.AwsTools.QueueCreation
         public void AddToCache(string region, string key, T value)
         {
             var regionDict = _regionsData.GetOrAdd(region,
-                r => new ConcurrentDictionary<string, T>(StringComparer.InvariantCultureIgnoreCase));
+                r => new ConcurrentDictionary<string, T>(StringComparer.OrdinalIgnoreCase));
 
             regionDict[key] = value;
         }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

review `RegionResourceCache` because the analyser doesn't like it.

Inheriting from `Dictionary<K,V>` comes with baggage for [naming](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1710-identifiers-should-have-correct-suffix) and [serialisation](https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca2237-mark-iserializable-types-with-serializableattribute)

better to encapsulate the dictionary and seal the containing class.
And the interface serves no role either - there's no injection happening on it, and no reason or mechanism for  swapping in a different implementation.

_Please include a reference to a GitHub issue if appropriate._

#401 