### PR TITLE
Retention period as TimeSpan not int

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/WhenCreatingErrorQueue.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenCreatingErrorQueue.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JustBehave;
 using JustSaying.AwsTools;
@@ -19,13 +20,13 @@ namespace JustSaying.IntegrationTests.AwsTools
         {
             var queueConfig = new SqsBasicConfiguration
             {
-                ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod,
+                ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod,
                 ErrorQueueOptOut = true
             };
 
             await SystemUnderTest.CreateAsync(queueConfig);
 
-            queueConfig.ErrorQueueRetentionPeriodSeconds = 100;
+            queueConfig.ErrorQueueRetentionPeriod =  TimeSpan.FromSeconds(100);
 
             await SystemUnderTest.UpdateQueueAttributeAsync(queueConfig);
         }
@@ -50,7 +51,7 @@ namespace JustSaying.IntegrationTests.AwsTools
         [AwsFact]
         public void TheRetentionPeriodOfTheErrorQueueStaysAsMaximum()
         {
-            SystemUnderTest.MessageRetentionPeriod.ShouldBe(100);
+            SystemUnderTest.MessageRetentionPeriod.ShouldBe(TimeSpan.FromSeconds(100));
         }
     }
 }

--- a/JustSaying.IntegrationTests/AwsTools/WhenUpdatingRetentionPeriod.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenUpdatingRetentionPeriod.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.QueueCreation;
 using Shouldly;
@@ -8,23 +9,24 @@ namespace JustSaying.IntegrationTests.AwsTools
     [Collection(GlobalSetup.CollectionName)]
     public class WhenUpdatingRetentionPeriod : WhenCreatingQueuesByName
     {
-        private int _oldRetentionPeriod;
-        private int _newRetentionPeriod;
+        private TimeSpan _oldRetentionPeriod;
+        private TimeSpan _newRetentionPeriod;
 
         protected override void Given()
         {
-            _oldRetentionPeriod = 600;
-            _newRetentionPeriod = 700;
+            _oldRetentionPeriod = TimeSpan.FromSeconds(600);
+            _newRetentionPeriod = TimeSpan.FromSeconds(700);
 
             base.Given();
         }
 
         protected override async Task When()
         {
-            await SystemUnderTest.CreateAsync(new SqsBasicConfiguration { MessageRetentionSeconds = _oldRetentionPeriod });
+            await SystemUnderTest.CreateAsync(
+                new SqsBasicConfiguration { MessageRetention = _oldRetentionPeriod });
 
             await SystemUnderTest.UpdateQueueAttributeAsync(
-                new SqsBasicConfiguration { MessageRetentionSeconds = _newRetentionPeriod });
+                new SqsBasicConfiguration { MessageRetention = _newRetentionPeriod });
         }
 
         [AwsFact]

--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -89,7 +89,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .IntoQueue(TestFixture.UniqueName)
                 .ConfigureSubscriptionWith(cf =>
                 {
-                    cf.MessageRetentionSeconds = 60;
+                    cf.MessageRetention = TimeSpan.FromSeconds(60);
                     cf.VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
                     cf.InstancePosition = 1;
                 })

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
@@ -48,7 +48,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .IntoQueue(fixture.UniqueName)
                 .ConfigureSubscriptionWith(cfg =>
                     {
-                        cfg.MessageRetentionSeconds = 60;
+                        cfg.MessageRetention = TimeSpan.FromSeconds(60);
                         cfg.InstancePosition = 1;
                         cfg.OnError = _globalErrorHandler;
                     })

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlerHasExactlyOnceAttribute.cs
@@ -35,7 +35,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
                 .WithMessageLockStoreOf(new MessageLockStore())
                 .WithSqsTopicSubscriber()
                 .IntoQueue(fixture.UniqueName)
-                .ConfigureSubscriptionWith(cfg => cfg.MessageRetentionSeconds = 60)
+                .ConfigureSubscriptionWith(cfg => cfg.MessageRetention = TimeSpan.FromSeconds(60))
                 .WithMessageHandler(_handler);
 
             publisher.StartListening();

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriber.cs
@@ -42,7 +42,8 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoQueue(QueueName)
-                .ConfigureSubscriptionWith(cfg => cfg.MessageRetentionSeconds = 60)
+                .ConfigureSubscriptionWith(cfg =>
+                    cfg.MessageRetention = TimeSpan.FromSeconds(60))
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
 
             return Task.CompletedTask;

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringASqsTopicSubscriberInANonDefaultRegion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
@@ -32,7 +33,8 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoQueue(_queueName)
-                .ConfigureSubscriptionWith(cfg => cfg.MessageRetentionSeconds = 60)
+                .ConfigureSubscriptionWith(
+                    cfg => cfg.MessageRetention = TimeSpan.FromSeconds(60))
                 .WithMessageHandler(Substitute.For<IHandlerAsync<Message>>());
 
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/AwsTools/SqsQueueConfiguration/Validation/WhenPublishEndpointIsNotProvided.cs
+++ b/JustSaying.UnitTests/AwsTools/SqsQueueConfiguration/Validation/WhenPublishEndpointIsNotProvided.cs
@@ -1,3 +1,4 @@
+using System;
 using JustBehave;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
@@ -26,7 +27,12 @@ namespace JustSaying.UnitTests.AwsTools.SqsQueueConfiguration.Validation
 
         protected override SqsReadConfiguration CreateSystemUnderTest()
         {
-            return new SqsReadConfiguration(SubscriptionType.ToTopic) { MessageRetentionSeconds = JustSayingConstants.MinimumRetentionPeriod +1, Topic = "ATopic", PublishEndpoint = null };
+            return new SqsReadConfiguration(SubscriptionType.ToTopic)
+            {
+                MessageRetention = JustSayingConstants.MinimumRetentionPeriod.Add(TimeSpan.FromSeconds(1)),
+                Topic = "ATopic",
+                PublishEndpoint = null
+            };
         }
     }
 }

--- a/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
@@ -3,6 +3,7 @@ using JustSaying.AwsTools;
 using JustSaying.TestingFramework;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using System;
 using Xunit;
 
 namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
@@ -58,7 +59,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
             {
                 c.VisibilityTimeoutSeconds = 1;
                 c.RetryCountBeforeSendingToErrorQueue = 2;
-                c.MessageRetentionSeconds = 3;
+                c.MessageRetention = TimeSpan.FromSeconds(3);
                 c.ErrorQueueOptOut = true;
             });
         }

--- a/JustSaying.UnitTests/WhenPublishEndpointIsNotProvided.cs
+++ b/JustSaying.UnitTests/WhenPublishEndpointIsNotProvided.cs
@@ -1,3 +1,4 @@
+using System;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
 using JustBehave;
@@ -25,6 +26,11 @@ namespace JustSaying.UnitTests
         }
 
         protected override SqsReadConfiguration CreateSystemUnderTest()
-            => new SqsReadConfiguration(SubscriptionType.ToTopic) { MessageRetentionSeconds = JustSayingConstants.MinimumRetentionPeriod +1, Topic = "ATopic", PublishEndpoint = null };
+            => new SqsReadConfiguration(SubscriptionType.ToTopic)
+            {
+                MessageRetention = JustSayingConstants.MinimumRetentionPeriod.Add(TimeSpan.FromSeconds(1)),
+                Topic = "ATopic",
+                PublishEndpoint = null
+            };
     }
 }

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -25,7 +25,7 @@ namespace JustSaying.AwsTools
             return new Dictionary<string, string>
             {
                 { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD, queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.ToString("F0", CultureInfo.InvariantCulture)},
             };
         }
 

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -24,8 +24,8 @@ namespace JustSaying.AwsTools
         {
             return new Dictionary<string, string>
             {
-                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD , queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , JustSayingConstants.DefaultVisibilityTimeout.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD, queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.ToString(CultureInfo.InvariantCulture)},
             };
         }
 
@@ -43,7 +43,7 @@ namespace JustSaying.AwsTools
                 {
                     {
                         JustSayingConstants.AttributeRetentionPeriod,
-                        queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture)
+                        queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)
                     }
                 }
             };

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -24,7 +24,7 @@ namespace JustSaying.AwsTools
         {
             return new Dictionary<string, string>
             {
-                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD , queueConfig.ErrorQueueRetentionPeriodSeconds.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD , queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , JustSayingConstants.DefaultVisibilityTimeout.ToString(CultureInfo.InvariantCulture)},
             };
         }
@@ -43,7 +43,7 @@ namespace JustSaying.AwsTools
                 {
                     {
                         JustSayingConstants.AttributeRetentionPeriod,
-                        queueConfig.ErrorQueueRetentionPeriodSeconds.ToString(CultureInfo.InvariantCulture)
+                        queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -52,11 +52,11 @@ namespace JustSaying.AwsTools
 
             if (response.HttpStatusCode == HttpStatusCode.OK)
             {
-                MessageRetentionPeriod = queueConfig.ErrorQueueRetentionPeriodSeconds;
+                MessageRetentionPeriod = queueConfig.ErrorQueueRetentionPeriod;
             }
         }
 
         protected override bool QueueNeedsUpdating(SqsBasicConfiguration queueConfig)
-            => MessageRetentionPeriod != queueConfig.ErrorQueueRetentionPeriodSeconds;
+            => MessageRetentionPeriod != queueConfig.ErrorQueueRetentionPeriod;
     }
 }

--- a/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/JustSaying/AwsTools/JustSayingConstants.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace JustSaying.AwsTools
 {
     public static class JustSayingConstants
@@ -32,21 +34,21 @@ namespace JustSaying.AwsTools
         /// wait {interval}*{attemptCount} miliseconds before retrying,
         /// </summary>
         public static int DefaultPublisherRetryInterval => 100;//100 milliseconds
-        
+
         /// <summary>
         /// Minimum message retention period on a queue.
         /// </summary>
-        public static int MinimumRetentionPeriod => 60;         //1 minute
+        public static TimeSpan MinimumRetentionPeriod => TimeSpan.FromMinutes(1);
 
         /// <summary>
-        /// Default message retention period on a queue in seconds
+        /// Default message retention period on a queue.
         /// </summary>
-        public static int DefaultRetentionPeriod => 345600;    //4 days
+        public static TimeSpan DefaultRetentionPeriod => TimeSpan.FromDays(4);
 
         /// <summary>
-        /// Maximum message retention period on a queue in seconds
+        /// Maximum message retention period on a queue.
         /// </summary>
-        public static int MaximumRetentionPeriod => 1209600;    //14 days
+        public static TimeSpan MaximumRetentionPeriod => TimeSpan.FromDays(14);
         
         /// <summary>
         /// Minimum delay in message delivery for SQS i nseconds. This is also the default.

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -93,7 +93,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var attributes = new Dictionary<string, string>
                 {
-                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.TotalSeconds.ToString(CultureInfo.InvariantCulture) },
+                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture) },
                     {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture) },
                     {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture) }
                 };

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -18,7 +18,7 @@ namespace JustSaying.AwsTools.MessageHandling
         public string QueueName { get; protected set; }
         public RegionEndpoint Region { get; protected set; }
         public ErrorQueue ErrorQueue { get; protected set; }
-        internal int MessageRetentionPeriod { get; set; }
+        internal TimeSpan MessageRetentionPeriod { get; set; }
         internal int VisibilityTimeout { get; set; }
         internal int DeliveryDelay { get; set; }
         internal RedrivePolicy RedrivePolicy { get; set; }
@@ -68,7 +68,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 };
             var attributes = await GetAttrsAsync(keys).ConfigureAwait(false);
             Arn = attributes.QueueARN;
-            MessageRetentionPeriod = attributes.MessageRetentionPeriod;
+            MessageRetentionPeriod = TimeSpan.FromSeconds(attributes.MessageRetentionPeriod);
             VisibilityTimeout = attributes.VisibilityTimeout;
             Policy = attributes.Policy;
             DeliveryDelay = attributes.DelaySeconds;
@@ -93,7 +93,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var attributes = new Dictionary<string, string>
                 {
-                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetentionSeconds.ToString(CultureInfo.InvariantCulture) },
+                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.TotalSeconds.ToString(CultureInfo.InvariantCulture) },
                     {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture) },
                     {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture) }
                 };
@@ -117,7 +117,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 if (response.HttpStatusCode == HttpStatusCode.OK)
                 {
-                    MessageRetentionPeriod = queueConfig.MessageRetentionSeconds;
+                    MessageRetentionPeriod = queueConfig.MessageRetention;
                     VisibilityTimeout = queueConfig.VisibilityTimeoutSeconds;
                     DeliveryDelay = queueConfig.DeliveryDelaySeconds;
                     ServerSideEncryption = queueConfig.ServerSideEncryption;
@@ -127,7 +127,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
         protected virtual bool QueueNeedsUpdating(SqsBasicConfiguration queueConfig)
         {
-            return MessageRetentionPeriod != queueConfig.MessageRetentionSeconds
+            return MessageRetentionPeriod != queueConfig.MessageRetention
                    || VisibilityTimeout != queueConfig.VisibilityTimeoutSeconds
                    || DeliveryDelay != queueConfig.DeliveryDelaySeconds
                    || QueueNeedsUpdatingBecauseOfEncryption(queueConfig);

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -29,8 +29,11 @@ namespace JustSaying.AwsTools.MessageHandling
                 var exisits = await ErrorQueue.ExistsAsync().ConfigureAwait(false);
                 if (!exisits)
                 {
-                    await ErrorQueue.CreateAsync(
-                        new SqsBasicConfiguration { ErrorQueueRetentionPeriodSeconds = queueConfig.ErrorQueueRetentionPeriodSeconds, ErrorQueueOptOut = true }).ConfigureAwait(false);
+                    await ErrorQueue.CreateAsync(new SqsBasicConfiguration
+                        {
+                            ErrorQueueRetentionPeriod = queueConfig.ErrorQueueRetentionPeriod,
+                            ErrorQueueOptOut = true
+                        }).ConfigureAwait(false);
                 }
             }
 
@@ -91,7 +94,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var errorQueueConfig = new SqsReadConfiguration(SubscriptionType.ToTopic)
                 {
-                    ErrorQueueRetentionPeriodSeconds = queueConfig.ErrorQueueRetentionPeriodSeconds,
+                    ErrorQueueRetentionPeriod = queueConfig.ErrorQueueRetentionPeriod,
                     ErrorQueueOptOut = true
                 };
 
@@ -114,7 +117,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var policy = new Dictionary<string, string>
             {
-                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetentionSeconds.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.TotalSeconds.ToString(CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture)},
             };

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -117,7 +117,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var policy = new Dictionary<string, string>
             {
-                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.TotalSeconds.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture)},
             };

--- a/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace JustSaying.AwsTools.QueueCreation
 {
     public class SqsBasicConfiguration
     {
-        public int MessageRetentionSeconds { get; set; }
-        public int ErrorQueueRetentionPeriodSeconds { get; set; }
+        public TimeSpan MessageRetention { get; set; }
+        public TimeSpan ErrorQueueRetentionPeriod { get; set; }
         public int VisibilityTimeoutSeconds { get; set; }
         public int DeliveryDelaySeconds { get; set; }
         public int RetryCountBeforeSendingToErrorQueue { get; set; }
@@ -12,8 +14,8 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public SqsBasicConfiguration()
         {
-            MessageRetentionSeconds = JustSayingConstants.DefaultRetentionPeriod;
-            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod;
+            MessageRetention = JustSayingConstants.DefaultRetentionPeriod;
+            ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
             VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
             DeliveryDelaySeconds = JustSayingConstants.MinimumDeliveryDelay;
@@ -21,15 +23,15 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public virtual void Validate()
         {
-            if (MessageRetentionSeconds < JustSayingConstants.MinimumRetentionPeriod ||
-                MessageRetentionSeconds > JustSayingConstants.MaximumRetentionPeriod)
+            if (MessageRetention < JustSayingConstants.MinimumRetentionPeriod ||
+                MessageRetention > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
                     $"Invalid configuration. MessageRetentionSeconds must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
-            if (ErrorQueueRetentionPeriodSeconds < JustSayingConstants.MinimumRetentionPeriod ||
-                ErrorQueueRetentionPeriodSeconds > JustSayingConstants.MaximumRetentionPeriod)
+            if (ErrorQueueRetentionPeriod < JustSayingConstants.MinimumRetentionPeriod ||
+                ErrorQueueRetentionPeriod > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
                     $"Invalid configuration. ErrorQueueRetentionPeriodSeconds must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");

--- a/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -27,21 +27,21 @@ namespace JustSaying.AwsTools.QueueCreation
                 MessageRetention > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. MessageRetention must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
+                    $"Invalid configuration. {nameof(MessageRetention)} must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
             if (ErrorQueueRetentionPeriod < JustSayingConstants.MinimumRetentionPeriod ||
                 ErrorQueueRetentionPeriod > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. ErrorQueueRetentionPeriod must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
+                    $"Invalid configuration. {nameof(ErrorQueueRetentionPeriod)} must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
             if (DeliveryDelaySeconds < JustSayingConstants.MinimumDeliveryDelay ||
                 DeliveryDelaySeconds > JustSayingConstants.MaximumDeliveryDelay)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. DeliveryDelaySeconds must be between {JustSayingConstants.MinimumDeliveryDelay} and {JustSayingConstants.MaximumDeliveryDelay}.");
+                    $"Invalid configuration. {nameof(DeliveryDelaySeconds)} must be between {JustSayingConstants.MinimumDeliveryDelay} and {JustSayingConstants.MaximumDeliveryDelay}.");
             }
         }
     }

--- a/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -27,14 +27,14 @@ namespace JustSaying.AwsTools.QueueCreation
                 MessageRetention > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. MessageRetentionSeconds must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
+                    $"Invalid configuration. MessageRetention must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
             if (ErrorQueueRetentionPeriod < JustSayingConstants.MinimumRetentionPeriod ||
                 ErrorQueueRetentionPeriod > JustSayingConstants.MaximumRetentionPeriod)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. ErrorQueueRetentionPeriodSeconds must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
+                    $"Invalid configuration. ErrorQueueRetentionPeriod must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
             if (DeliveryDelaySeconds < JustSayingConstants.MinimumDeliveryDelay ||

--- a/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
@@ -10,8 +10,8 @@ namespace JustSaying.AwsTools.QueueCreation
         public SqsReadConfiguration(SubscriptionType subscriptionType)
         {
             SubscriptionType = subscriptionType;
-            MessageRetentionSeconds = JustSayingConstants.DefaultRetentionPeriod;
-            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod;
+            MessageRetention = JustSayingConstants.DefaultRetentionPeriod;
+            ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
             VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
         }

--- a/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
@@ -4,8 +4,8 @@ namespace JustSaying.AwsTools.QueueCreation
     {
         public SqsWriteConfiguration()
         {
-            MessageRetentionSeconds = JustSayingConstants.DefaultRetentionPeriod;
-            ErrorQueueRetentionPeriodSeconds = JustSayingConstants.MaximumRetentionPeriod;
+            MessageRetention = JustSayingConstants.DefaultRetentionPeriod;
+            ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
             VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
         }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Retention period typed as as `TimeSpan` not `int`. Convert to and from seconds only when needed by AWS.

Strong typing is good. Constants are now self-documenting - e.g. `int DefaultRetentionPeriod => 345600;    //4 days` becomes `TimeSpan DefaultRetentionPeriod => TimeSpan.FromDays(4);`

I have one concern, if  `duration.TotalSeconds.ToString(CultureInfo.InvariantCulture)` is the same as before, because `TotalSeconds` is typed as `double` not `int`. A helper / extension method may be needed to handle the conversions to Seconds, to int and then to string.

There are other duration constants still typed as `int` and they are a mixture of milliseconds and seconds scales, but out of scope as small PRs work better.

_Please include a reference to a GitHub issue if appropriate._

Based on discussion here https://github.com/justeat/JustSaying/pull/411#discussion_r230061498