### PR TITLE
DeliveryDelay as TimeSpan not int

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/WhenUpdatingDeliveryDelay.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenUpdatingDeliveryDelay.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.QueueCreation;
 using Shouldly;
@@ -8,13 +9,13 @@ namespace JustSaying.IntegrationTests.AwsTools
     [Collection(GlobalSetup.CollectionName)]
     public class WhenUpdatingDeliveryDelay : WhenCreatingQueuesByName
     {
-        private int _oldDeliveryDelay;
-        private int _newDeliveryDelay;
+        private TimeSpan _oldDeliveryDelay;
+        private TimeSpan _newDeliveryDelay;
 
         protected override void Given()
         {
-            _oldDeliveryDelay = 120;
-            _newDeliveryDelay = 300;
+            _oldDeliveryDelay = TimeSpan.FromMinutes(2);
+            _newDeliveryDelay = TimeSpan.FromMinutes(5);
 
             base.Given();
         }
@@ -23,12 +24,12 @@ namespace JustSaying.IntegrationTests.AwsTools
         {
             var queueConfig = new SqsBasicConfiguration
             {
-                DeliveryDelaySeconds = _oldDeliveryDelay
+                DeliveryDelay = _oldDeliveryDelay
             };
 
             await SystemUnderTest.CreateAsync(queueConfig);
 
-            queueConfig.DeliveryDelaySeconds = _newDeliveryDelay;
+            queueConfig.DeliveryDelay = _newDeliveryDelay;
 
             await SystemUnderTest.UpdateQueueAttributeAsync(queueConfig);
         }

--- a/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/JustSaying/AwsTools/JustSayingConstants.cs
@@ -51,14 +51,14 @@ namespace JustSaying.AwsTools
         public static TimeSpan MaximumRetentionPeriod => TimeSpan.FromDays(14);
         
         /// <summary>
-        /// Minimum delay in message delivery for SQS i nseconds. This is also the default.
+        /// Minimum delay in message delivery for SQS. This is also the default.
         /// </summary>
-        public static int MinimumDeliveryDelay => 0;
+        public static TimeSpan MinimumDeliveryDelay => TimeSpan.Zero;
 
         /// <summary>
-        /// Maximum message delivery delay for SQS in seconds
+        /// Maximum message delivery delay for SQS
         /// </summary>
-        public static int MaximumDeliveryDelay => 900;          //15 minutes
+        public static TimeSpan MaximumDeliveryDelay => TimeSpan.FromMinutes(15);
 
         /// <summary>
         /// Default ID of an AWS-managed customer master key (CMK) for Amazon SQS

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -20,7 +20,7 @@ namespace JustSaying.AwsTools.MessageHandling
         public ErrorQueue ErrorQueue { get; protected set; }
         internal TimeSpan MessageRetentionPeriod { get; set; }
         internal int VisibilityTimeout { get; set; }
-        internal int DeliveryDelay { get; set; }
+        internal TimeSpan DeliveryDelay { get; set; }
         internal RedrivePolicy RedrivePolicy { get; set; }
         internal ServerSideEncryption ServerSideEncryption { get; set; }
         public string Policy { get; private set; }
@@ -71,7 +71,7 @@ namespace JustSaying.AwsTools.MessageHandling
             MessageRetentionPeriod = TimeSpan.FromSeconds(attributes.MessageRetentionPeriod);
             VisibilityTimeout = attributes.VisibilityTimeout;
             Policy = attributes.Policy;
-            DeliveryDelay = attributes.DelaySeconds;
+            DeliveryDelay = TimeSpan.FromSeconds(attributes.DelaySeconds);
             RedrivePolicy = ExtractRedrivePolicyFromQueueAttributes(attributes.Attributes);
             ServerSideEncryption = ExtractServerSideEncryptionFromQueueAttributes(attributes.Attributes);
         }
@@ -95,7 +95,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture) },
                     {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture) },
-                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture) }
+                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelay.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture) }
                 };
                 if (queueConfig.ServerSideEncryption != null)
                 {
@@ -119,7 +119,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     MessageRetentionPeriod = queueConfig.MessageRetention;
                     VisibilityTimeout = queueConfig.VisibilityTimeoutSeconds;
-                    DeliveryDelay = queueConfig.DeliveryDelaySeconds;
+                    DeliveryDelay = queueConfig.DeliveryDelay;
                     ServerSideEncryption = queueConfig.ServerSideEncryption;
                 }
             }
@@ -129,7 +129,7 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             return MessageRetentionPeriod != queueConfig.MessageRetention
                    || VisibilityTimeout != queueConfig.VisibilityTimeoutSeconds
-                   || DeliveryDelay != queueConfig.DeliveryDelaySeconds
+                   || DeliveryDelay != queueConfig.DeliveryDelay
                    || QueueNeedsUpdatingBecauseOfEncryption(queueConfig);
         }
 

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -119,7 +119,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelaySeconds.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelay.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
             };
             if (NeedErrorQueue(queueConfig))
             {

--- a/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -7,7 +7,7 @@ namespace JustSaying.AwsTools.QueueCreation
         public TimeSpan MessageRetention { get; set; }
         public TimeSpan ErrorQueueRetentionPeriod { get; set; }
         public int VisibilityTimeoutSeconds { get; set; }
-        public int DeliveryDelaySeconds { get; set; }
+        public TimeSpan DeliveryDelay { get; set; }
         public int RetryCountBeforeSendingToErrorQueue { get; set; }
         public bool ErrorQueueOptOut { get; set; }
         public ServerSideEncryption ServerSideEncryption { get; set; }
@@ -18,7 +18,7 @@ namespace JustSaying.AwsTools.QueueCreation
             ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
             VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
-            DeliveryDelaySeconds = JustSayingConstants.MinimumDeliveryDelay;
+            DeliveryDelay = JustSayingConstants.MinimumDeliveryDelay;
         }
 
         public virtual void Validate()
@@ -37,11 +37,11 @@ namespace JustSaying.AwsTools.QueueCreation
                     $"Invalid configuration. {nameof(ErrorQueueRetentionPeriod)} must be between {JustSayingConstants.MinimumRetentionPeriod} and {JustSayingConstants.MaximumRetentionPeriod}.");
             }
 
-            if (DeliveryDelaySeconds < JustSayingConstants.MinimumDeliveryDelay ||
-                DeliveryDelaySeconds > JustSayingConstants.MaximumDeliveryDelay)
+            if (DeliveryDelay < JustSayingConstants.MinimumDeliveryDelay ||
+                DeliveryDelay > JustSayingConstants.MaximumDeliveryDelay)
             {
                 throw new ConfigurationErrorsException(
-                    $"Invalid configuration. {nameof(DeliveryDelaySeconds)} must be between {JustSayingConstants.MinimumDeliveryDelay} and {JustSayingConstants.MaximumDeliveryDelay}.");
+                    $"Invalid configuration. {nameof(DeliveryDelay)} must be between {JustSayingConstants.MinimumDeliveryDelay} and {JustSayingConstants.MaximumDeliveryDelay}.");
             }
         }
     }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

`DeliveryDelay` as `TimeSpan` not `int`.

Follow on from #425

_Please include a reference to a GitHub issue if appropriate._
