### PR TITLE
Remove ListSubscriptionsByTopic

### DIFF
--- a/JustSaying/AwsTools/MessageHandling/SnsPolicy.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsPolicy.cs
@@ -46,7 +46,6 @@ namespace JustSaying.AwsTools.MessageHandling
                     SNSActionIdentifiers.RemovePermission,
                     SNSActionIdentifiers.DeleteTopic,
                     SNSActionIdentifiers.Subscribe,
-                    SNSActionIdentifiers.ListSubscriptionsByTopic,
                     SNSActionIdentifiers.Publish)
                 .WithResources(new Resource(sourceArn))
                 .WithConditions(new Condition("StringEquals", "AWS:SourceOwner", sourceAccountId));


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._
Removes `ListSubscriptionsByTopic` from the default SNS policy as no longer needed
