### PR TITLE
Constants as TimeSpan not int

### DIFF
--- a/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
+++ b/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
@@ -33,7 +33,7 @@ namespace JustSaying.IntegrationTests
             var fluent = TestFixture.Builder()
                 .ConfigurePublisherWith(x =>
                 {
-                    x.PublishFailureBackoffMilliseconds = Configuration.PublishFailureBackoffMilliseconds;
+                    x.PublishFailureBackoff = Configuration.PublishFailureBackoff;
                     x.PublishFailureReAttempts = Configuration.PublishFailureReAttempts;
                 }) as JustSaying.JustSayingFluently;
 

--- a/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/GivenANotificationStack.cs
@@ -21,7 +21,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
         private IPublishConfiguration _config =
             new MessagingConfig
             {
-                PublishFailureBackoffMilliseconds = 1,
+                PublishFailureBackoff = TimeSpan.FromMilliseconds(1),
                 PublishFailureReAttempts = 3
             };
 
@@ -81,7 +81,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .WithMonitoring(Monitoring)
                 .ConfigurePublisherWith(c =>
                 {
-                    c.PublishFailureBackoffMilliseconds = _config.PublishFailureBackoffMilliseconds;
+                    c.PublishFailureBackoff = _config.PublishFailureBackoff;
                     c.PublishFailureReAttempts = _config.PublishFailureReAttempts;
                 })
                 .WithSnsMessagePublisher<SimpleMessage>()
@@ -90,7 +90,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .ConfigureSubscriptionWith(cf =>
                 {
                     cf.MessageRetention = TimeSpan.FromSeconds(60);
-                    cf.VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+                    cf.VisibilityTimeout = JustSayingConstants.DefaultVisibilityTimeout;
                     cf.InstancePosition = 1;
                 })
                 .WithMessageHandler(snsHandler)

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenAHandlerThrowsAnException.cs
@@ -40,7 +40,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .WithMonitoring(_monitoring)
                 .ConfigurePublisherWith(c =>
                     {
-                        c.PublishFailureBackoffMilliseconds = 1;
+                        c.PublishFailureBackoff = TimeSpan.FromMilliseconds(1);
                         c.PublishFailureReAttempts = 3;
                     })
                 .WithSnsMessagePublisher<SimpleMessage>()

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenPublishingWithoutAMonitor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
@@ -35,7 +36,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
             _bus = fixture.Builder()
                 .ConfigurePublisherWith(c =>
                     {
-                        c.PublishFailureBackoffMilliseconds = 1;
+                        c.PublishFailureBackoff = TimeSpan.FromMilliseconds(1);
                         c.PublishFailureReAttempts = 1;
                     })
                 .WithSnsMessagePublisher<SimpleMessage>()

--- a/JustSaying.IntegrationTests/JustSayingFluently/WhenThrottlingIsEnabledALongRunningHandler.cs
+++ b/JustSaying.IntegrationTests/JustSayingFluently/WhenThrottlingIsEnabledALongRunningHandler.cs
@@ -43,7 +43,7 @@ namespace JustSaying.IntegrationTests.JustSayingFluently
                 .WithMonitoring(Substitute.For<IMessageMonitor>())
                 .ConfigurePublisherWith(c =>
                 {
-                    c.PublishFailureBackoffMilliseconds = 1;
+                    c.PublishFailureBackoff = TimeSpan.FromMilliseconds(1);
                 })
                 .WithSnsMessagePublisher<SimpleMessage>()
                 .WithSqsTopicSubscriber()

--- a/JustSaying.UnitTests/CreateMe/WhenCreatingABus.cs
+++ b/JustSaying.UnitTests/CreateMe/WhenCreatingABus.cs
@@ -14,7 +14,7 @@ namespace JustSaying.UnitTests.CreateMe
             _region = "region-1";
             _config = x =>
             {
-                x.PublishFailureBackoffMilliseconds = 50;
+                x.PublishFailureBackoff = TimeSpan.FromMilliseconds(50);
                 x.PublishFailureReAttempts = 2;
             };
         }

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging;
@@ -18,7 +19,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             base.Given();
 
             Config.PublishFailureReAttempts.Returns(PublishAttempts);
-            Config.PublishFailureBackoffMilliseconds.Returns(0);
+            Config.PublishFailureBackoff.Returns(TimeSpan.Zero);
             RecordAnyExceptionsThrown();
 
             _publisher.When(x => x.PublishAsync(Arg.Any<Message>(), Arg.Any<CancellationToken>()))

--- a/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
@@ -33,21 +33,24 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
         [Fact]
         public void ConfigurationIsRequired()
         {
-            SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50);
+            SystemUnderTest.ConfigurePublisherWith(
+                conf => conf.PublishFailureBackoff = TimeSpan.FromMilliseconds(50));
         }
 
         /// Note: Ignored tests are here for fluent api exploration & expecting compile time issues when working on the fluent interface stuff...
         [Fact(Skip = "Testing compile-time issues")]
         public void ASnsPublisherCanBeSetup()
         {
-            SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50)
+            SystemUnderTest.ConfigurePublisherWith(
+                    conf => conf.PublishFailureBackoff = TimeSpan.FromMilliseconds(50))
                 .WithSnsMessagePublisher<SimpleMessage>();
         }
 
         [Fact(Skip = "Testing compile-time issues")]
         public void MultipleSnsPublishersCanBeSetup()
         {
-            SystemUnderTest.ConfigurePublisherWith(conf => conf.PublishFailureBackoffMilliseconds = 50)
+            SystemUnderTest.ConfigurePublisherWith(
+                    conf => conf.PublishFailureBackoff = TimeSpan.FromMilliseconds(50))
                 .WithSnsMessagePublisher<SimpleMessage>()
                 .WithSnsMessagePublisher<SimpleMessage>();
         }
@@ -57,7 +60,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
         {
             SystemUnderTest.WithSqsMessagePublisher<SimpleMessage>(c =>
             {
-                c.VisibilityTimeoutSeconds = 1;
+                c.VisibilityTimeout = TimeSpan.FromSeconds(1);
                 c.RetryCountBeforeSendingToErrorQueue = 2;
                 c.MessageRetention = TimeSpan.FromSeconds(3);
                 c.ErrorQueueOptOut = true;

--- a/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
+++ b/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
@@ -26,7 +26,7 @@ namespace JustSaying.UnitTests
                 .WithActiveRegion(() => "defaultRegion")
                 .ConfigurePublisherWith(x =>
                 {
-                    x.PublishFailureBackoffMilliseconds = Configuration.PublishFailureBackoffMilliseconds;
+                    x.PublishFailureBackoff = Configuration.PublishFailureBackoff;
                     x.PublishFailureReAttempts = Configuration.PublishFailureReAttempts;
 
                 }) as JustSaying.JustSayingFluently;

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -8,6 +8,7 @@ using Amazon.SQS.Model;
 using Amazon.SQS.Util;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace JustSaying.AwsTools
@@ -24,8 +25,8 @@ namespace JustSaying.AwsTools
         {
             return new Dictionary<string, string>
             {
-                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD, queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD, queueConfig.ErrorQueueRetentionPeriod.AsSecondsString() },
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.AsSecondsString() },
             };
         }
 
@@ -42,8 +43,7 @@ namespace JustSaying.AwsTools
                 Attributes = new Dictionary<string, string>
                 {
                     {
-                        JustSayingConstants.AttributeRetentionPeriod,
-                        queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)
+                        JustSayingConstants.AttributeRetentionPeriod, queueConfig.ErrorQueueRetentionPeriod.AsSecondsString()
                     }
                 }
             };

--- a/JustSaying/AwsTools/ErrorQueue.cs
+++ b/JustSaying/AwsTools/ErrorQueue.cs
@@ -25,7 +25,7 @@ namespace JustSaying.AwsTools
             return new Dictionary<string, string>
             {
                 { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD, queueConfig.ErrorQueueRetentionPeriod.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.ToString("F0", CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT, JustSayingConstants.DefaultVisibilityTimeout.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
             };
         }
 

--- a/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/JustSaying/AwsTools/JustSayingConstants.cs
@@ -31,7 +31,7 @@ namespace JustSaying.AwsTools
 
         /// <summary>
         /// Every time a publisher is not able to deliver a message, it will 
-        /// wait {interval}*{attemptCount}  before retrying,
+        /// wait {interval} * {attemptCount} before retrying,
         /// </summary>
         public static TimeSpan DefaultPublisherRetryInterval => TimeSpan.FromMilliseconds(100);
 

--- a/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/JustSaying/AwsTools/JustSayingConstants.cs
@@ -14,9 +14,9 @@ namespace JustSaying.AwsTools
         public const string AttributeEncryptionKeyReusePeriodSecondId = "KmsDataKeyReusePeriodSeconds";
 
         /// <summary>
-        /// Default visibility timeout for message in seconds
+        /// Default visibility timeout for message
         /// </summary>
-        public static int DefaultVisibilityTimeout => 30;
+        public static TimeSpan DefaultVisibilityTimeout => TimeSpan.FromSeconds(30);
         
         /// <summary>
         /// Number of times a handler will retry a message until a message 
@@ -31,9 +31,9 @@ namespace JustSaying.AwsTools
 
         /// <summary>
         /// Every time a publisher is not able to deliver a message, it will 
-        /// wait {interval}*{attemptCount} miliseconds before retrying,
+        /// wait {interval}*{attemptCount}  before retrying,
         /// </summary>
-        public static int DefaultPublisherRetryInterval => 100;//100 milliseconds
+        public static TimeSpan DefaultPublisherRetryInterval => TimeSpan.FromMilliseconds(100);
 
         /// <summary>
         /// Minimum message retention period on a queue.

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -7,6 +7,7 @@ using Amazon;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
@@ -93,9 +94,9 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var attributes = new Dictionary<string, string>
                 {
-                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture) },
-                    {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeout.TotalSeconds.ToString("F0",CultureInfo.InvariantCulture) },
-                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelay.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture) }
+                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.AsSecondsString() },
+                    {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeout.AsSecondsString() },
+                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelay.AsSecondsString() }
                 };
 
                 if (queueConfig.ServerSideEncryption != null)

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -7,6 +7,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using Amazon.SQS.Util;
 using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace JustSaying.AwsTools.MessageHandling
@@ -117,9 +118,9 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             var policy = new Dictionary<string, string>
             {
-                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeout.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelay.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.AsSecondsString() },
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeout.AsSecondsString() },
+                { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelay.AsSecondsString() },
             };
 
             if (NeedErrorQueue(queueConfig))

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -118,9 +118,10 @@ namespace JustSaying.AwsTools.MessageHandling
             var policy = new Dictionary<string, string>
             {
                 { SQSConstants.ATTRIBUTE_MESSAGE_RETENTION_PERIOD ,queueConfig.MessageRetention.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
-                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeoutSeconds.ToString(CultureInfo.InvariantCulture)},
+                { SQSConstants.ATTRIBUTE_VISIBILITY_TIMEOUT  , queueConfig.VisibilityTimeout.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
                 { SQSConstants.ATTRIBUTE_DELAY_SECONDS  , queueConfig.DeliveryDelay.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture)},
             };
+
             if (NeedErrorQueue(queueConfig))
             {
                 policy.Add(JustSayingConstants.AttributeRedrivePolicy, new RedrivePolicy(_retryCountBeforeSendingToErrorQueue, ErrorQueue.Arn).ToString());

--- a/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -6,7 +6,7 @@ namespace JustSaying.AwsTools.QueueCreation
     {
         public TimeSpan MessageRetention { get; set; }
         public TimeSpan ErrorQueueRetentionPeriod { get; set; }
-        public int VisibilityTimeoutSeconds { get; set; }
+        public TimeSpan VisibilityTimeout { get; set; }
         public TimeSpan DeliveryDelay { get; set; }
         public int RetryCountBeforeSendingToErrorQueue { get; set; }
         public bool ErrorQueueOptOut { get; set; }
@@ -16,7 +16,7 @@ namespace JustSaying.AwsTools.QueueCreation
         {
             MessageRetention = JustSayingConstants.DefaultRetentionPeriod;
             ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
-            VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+            VisibilityTimeout = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
             DeliveryDelay = JustSayingConstants.MinimumDeliveryDelay;
         }

--- a/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
@@ -12,7 +12,7 @@ namespace JustSaying.AwsTools.QueueCreation
             SubscriptionType = subscriptionType;
             MessageRetention = JustSayingConstants.DefaultRetentionPeriod;
             ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
-            VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+            VisibilityTimeout = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
         }
 

--- a/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
+++ b/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
@@ -6,7 +6,7 @@ namespace JustSaying.AwsTools.QueueCreation
         {
             MessageRetention = JustSayingConstants.DefaultRetentionPeriod;
             ErrorQueueRetentionPeriod = JustSayingConstants.MaximumRetentionPeriod;
-            VisibilityTimeoutSeconds = JustSayingConstants.DefaultVisibilityTimeout;
+            VisibilityTimeout = JustSayingConstants.DefaultVisibilityTimeout;
             RetryCountBeforeSendingToErrorQueue = JustSayingConstants.DefaultHandlerRetryCount;
         }
 

--- a/JustSaying/Extensions/TimespanExtensions.cs
+++ b/JustSaying/Extensions/TimespanExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+
+namespace JustSaying.Extensions
+{
+    public static class TimespanExtensions
+    {
+        /// <summary>
+        /// Convert the duration to an integer number of seconds, in a string
+        /// As AWS requires
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static string AsSecondsString(this TimeSpan value)
+        {
+            return value.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/JustSaying/Extensions/TimespanExtensions.cs
+++ b/JustSaying/Extensions/TimespanExtensions.cs
@@ -1,16 +1,15 @@
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 namespace JustSaying.Extensions
 {
-    public static class TimespanExtensions
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class TimespanExtensions
     {
-        /// <summary>
-        /// Convert the duration to an integer number of seconds, in a string
-        /// As AWS requires
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        // Convert the duration from TimeSpan
+        // to an integer number of seconds, in a string
+        // As AWS requires
         public static string AsSecondsString(this TimeSpan value)
         {
             return value.TotalSeconds.ToString("F0", CultureInfo.InvariantCulture);

--- a/JustSaying/IPublishConfiguration.cs
+++ b/JustSaying/IPublishConfiguration.cs
@@ -8,7 +8,7 @@ namespace JustSaying
     public interface IPublishConfiguration
     {
         int PublishFailureReAttempts { get; set; }
-        int PublishFailureBackoffMilliseconds { get; set; }
+        TimeSpan PublishFailureBackoff { get; set; }
         Action<MessageResponse, Message> MessageResponseLogger { get; set;}
         IReadOnlyCollection<string> AdditionalSubscriberAccounts { get; set; }
     }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -216,7 +216,8 @@ namespace JustSaying
                 }
 
                 _log.LogWarning(0, ex, $"Failed to publish message {message.GetType()}. Retrying after attempt {attemptCount} of {Config.PublishFailureReAttempts}");
-                await Task.Delay(Config.PublishFailureBackoffMilliseconds * attemptCount, cancellationToken).ConfigureAwait(false);
+                var millisDelay = (int)(Config.PublishFailureBackoff.TotalMilliseconds * attemptCount);
+                await Task.Delay(millisDelay, cancellationToken).ConfigureAwait(false);
                 await PublishAsync(publisher, message, attemptCount, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -216,8 +216,10 @@ namespace JustSaying
                 }
 
                 _log.LogWarning(0, ex, $"Failed to publish message {message.GetType()}. Retrying after attempt {attemptCount} of {Config.PublishFailureReAttempts}");
-                var millisDelay = (int)(Config.PublishFailureBackoff.TotalMilliseconds * attemptCount);
-                await Task.Delay(millisDelay, cancellationToken).ConfigureAwait(false);
+
+                var delayForAttempt = TimeSpan.FromMilliseconds(Config.PublishFailureBackoff.TotalMilliseconds * attemptCount);
+                await Task.Delay(delayForAttempt, cancellationToken).ConfigureAwait(false);
+
                 await PublishAsync(publisher, message, attemptCount, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/JustSaying/MessagingConfig.cs
+++ b/JustSaying/MessagingConfig.cs
@@ -13,14 +13,14 @@ namespace JustSaying
         public MessagingConfig()
         {
             PublishFailureReAttempts = JustSayingConstants.DefaultPublisherRetryCount;
-            PublishFailureBackoffMilliseconds = JustSayingConstants.DefaultPublisherRetryInterval;
+            PublishFailureBackoff = JustSayingConstants.DefaultPublisherRetryInterval;
             AdditionalSubscriberAccounts = new List<string>();
             Regions = new List<string>();
             MessageSubjectProvider = new NonGenericMessageSubjectProvider();
         }
 
         public int PublishFailureReAttempts { get; set; }
-        public int PublishFailureBackoffMilliseconds { get; set; }
+        public TimeSpan PublishFailureBackoff { get; set; }
         public Action<MessageResponse, Message> MessageResponseLogger { get; set; }
         public IReadOnlyCollection<string> AdditionalSubscriberAccounts { get; set; }
         public IList<string> Regions { get; }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

`DefaultVisibilityTimeout` and `DefaultPublisherRetryInterval` as `TimeSpan` not `int`.
These are the last 2 in `JustSayingConstants`.


_Please include a reference to a GitHub issue if appropriate._

Follow on from #425 and #427
