### PR TITLE
Bus should be a property not a field

### DIFF
--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -28,7 +28,7 @@ namespace JustSaying
         private readonly ILogger _log;
         private readonly IVerifyAmazonQueues _amazonQueueCreator;
         private readonly IAwsClientFactoryProxy _awsClientFactoryProxy;
-        protected readonly IAmJustSaying Bus;
+        protected IAmJustSaying Bus { get; }
         private SqsReadConfiguration _subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic);
         private IMessageSerialisationFactory _serialisationFactory;
         private Func<INamingStrategy> _busNamingStrategyFunc;


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Bus should be a get-only property not a read-only field
Compliance with analyser rule: https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca1051-do-not-declare-visible-instance-fields
This is shallow fix in order to get the analysers passing, pending better design


_Please include a reference to a GitHub issue if appropriate._

#401 