### PR TITLE
Analysers in place

### DIFF
--- a/CodeAnalysisRules.ruleset
+++ b/CodeAnalysisRules.ruleset
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="CodeProjects" Description="Code analysis rules for JustSaying Code." ToolsVersion="15.0">
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="None" />
+    <Rule Id="CA1068" Action="None" />
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1716" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA2008" Action="None" />
+  </Rules>
+</RuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,17 +1,18 @@
 <Project>
   <Import Project="version.props" />
+  <PropertyGroup>
+    <AnalyzersPackageVersion>2.6.2</AnalyzersPackageVersion>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Text.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)justeat-oss.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,15 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)justeat-oss.snk</AssemblyOriginatorKeyFile>
     <Authors>JUSTEAT_OSS</Authors>
     <Company>Just Eat</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,9 +10,10 @@
     <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  <PropertyGroup>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)justeat-oss.snk</AssemblyOriginatorKeyFile>
     <Authors>JUSTEAT_OSS</Authors>
     <Company>Just Eat</Company>

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CA2007;CA1054;CA1307;CA1063;CA1822;CA1052;CA1034;CA1816</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>CA2007;CA1054;CA1307;CA1063;CA1822;CA1052;CA1034;CA1816</NoWarn>
+    <NoWarn>$(NoWarn);CA2007;CA1054;CA1307;CA1063;CA1822;CA1052;CA1034;CA1816</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;CA2007;CA1054;CA1307;CA1063;CA1822;CA1052;CA1034;CA1816</NoWarn>
+    <NoWarn>CA2007;CA1054;CA1307;CA1063;CA1822;CA1052;CA1034;CA1816</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.Tools/Program.cs
+++ b/JustSaying.Tools/Program.cs
@@ -1,4 +1,4 @@
-﻿using Magnum.CommandLineParser;
+using Magnum.CommandLineParser;
 using Magnum.Extensions;
 
 namespace JustSaying.Tools
@@ -16,8 +16,7 @@ namespace JustSaying.Tools
 
         private static bool ProcessLine(string line)
         {
-            var commandParser = new CommandParser();
-            return commandParser.Parse(line);
+            return CommandParser.Parse(line);
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.SQS;
@@ -100,7 +101,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
                 base.Given();
                 _messageBackoffStrategy.GetBackoffDuration(_typedMessage, 1, _expectedException).Returns(_expectedBackoffTimeSpan);
                 _handlerMap.Add(typeof(OrderAccepted), m => throw _expectedException);
-                _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, ExpectedReceiveCount.ToString());
+                _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, ExpectedReceiveCount.ToString(CultureInfo.InvariantCulture));
             }
 
             [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishing.cs
@@ -47,7 +47,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         private static bool B(PublishRequest x)
         {
-            return x.Message.Equals(Message, StringComparison.OrdinalIgnoreCase);
+            return x.Message.Equals(Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishing.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
@@ -46,7 +47,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         private static bool B(PublishRequest x)
         {
-            return x.Message.Equals(Message);
+            return x.Message.Equals(Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
@@ -52,7 +52,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         private static bool B(PublishRequest x)
         {
-            return x.Message.Equals(Message, StringComparison.InvariantCulture);
+            return x.Message.Equals(Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
@@ -51,7 +52,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         private static bool B(PublishRequest x)
         {
-            return x.Message.Equals(Message);
+            return x.Message.Equals(Message, StringComparison.InvariantCulture);
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
@@ -44,7 +44,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public void MessageIsPublishedToQueue()
         {
             // ToDo: Could be better...
-            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(x => x.MessageBody.Equals("serialized_contents")));
+            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(
+                x => x.MessageBody.Equals("serialized_contents", StringComparison.OrdinalIgnoreCase)));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
@@ -45,7 +45,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         {
             // ToDo: Could be better...
             _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(
-                x => x.MessageBody.Equals("serialized_contents", StringComparison.OrdinalIgnoreCase)));
+                x => x.MessageBody.Equals("serialized_contents", StringComparison.Ordinal)));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
@@ -49,7 +49,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public void MessageIsPublishedToQueue()
         {
             // ToDo: Could be better...
-            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(x => x.MessageBody.Equals("serialized_contents")));
+            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(
+                x => x.MessageBody.Equals("serialized_contents", StringComparison.InvariantCulture)));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
@@ -50,7 +50,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         {
             // ToDo: Could be better...
             _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(
-                x => x.MessageBody.Equals("serialized_contents", StringComparison.InvariantCulture)));
+                x => x.MessageBody.Equals("serialized_contents", StringComparison.Ordinal)));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -94,7 +94,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             };
         }
 
-        protected string SqsMessageBody(string messageType)
+        protected static string SqsMessageBody(string messageType)
         {
             return "{\"Subject\":\"" + messageType + "\"," + "\"Message\":\"" + MessageBody + "\"}";
         }

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>CA2007;CA1051;CA1707;CA1034;CA1812;CA1307</NoWarn>
+    <NoWarn>$(NoWarn);CA2007;CA1051;CA1707;CA1034;CA1812;CA1307</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;CA2007;CA1051;CA1707;CA1034;CA1812;CA1307</NoWarn>
+    <NoWarn>CA2007;CA1051;CA1707;CA1034;CA1812;CA1307</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CA2007;CA1051;CA1707;CA1034;CA1812;CA1307</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
@@ -105,7 +105,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
             fakeMonitor.DidNotReceive().IncrementThrottlingStatistic();
         }
 
-        private async Task ListenLoopExecuted(Queue<Func<Task>> actions,
+        private static async Task ListenLoopExecuted(Queue<Func<Task>> actions,
             IMessageProcessingStrategy messageProcessingStrategy)
         {
             var initalActionCount = actions.Count;
@@ -136,7 +136,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
             }
         }
 
-        private IList<Func<Task>> GetFromFakeSnsQueue(Queue<Func<Task>> actions, int requestedBatchSize)
+        private static IList<Func<Task>> GetFromFakeSnsQueue(Queue<Func<Task>> actions, int requestedBatchSize)
         {
             var batchSize = Math.Min(requestedBatchSize, MaxAmazonBatchSize);
             batchSize = Math.Min(batchSize, actions.Count);
@@ -150,7 +150,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
             return batch;
         }
 
-        private Queue<Func<Task>> BuildFakeIncomingMessages(int numberOfMessagesToCreate, ThreadSafeCounter counter)
+        private static Queue<Func<Task>> BuildFakeIncomingMessages(int numberOfMessagesToCreate, ThreadSafeCounter counter)
         {
             var random = new Random();
             var actions = new Queue<Func<Task>>();


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Code analysers are in place
There are exclusions, globally in `CodeAnalysisRules.ruleset` and in individual test projects.

It's not perfect yet, but it's a big step in the right direction to change from "no analysers automatically run, checks performed as and when someone feels like it" to "analysers are automatically run, with significant exclusions". The exclusions can be pared down to the minimum in following steps.

In particular, there is work pending ( #403 )  on `IDisposable` and use of Disposable resources, where the code currently sets off analyser errors ([CA1001](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1001-types-that-own-disposable-fields-should-be-disposable) )  for valid reasons, but this is being addressed in another PR.

_Please include a reference to a GitHub issue if appropriate._

#401 - Use code analysers
