### PR TITLE
Add deserialization of incoming sqs message attributes

### DIFF
--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -49,23 +49,6 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 typedMessage = _serialisationRegister.DeserializeMessage(message.Body);
 
-                typedMessage.MessageAttributes = message.MessageAttributes?.ToDictionary(
-                    source => source.Key,
-                    source =>
-                    {
-                        if (source.Value == null)
-                        {
-                            return null;
-                        }
-
-                        return new JustSaying.Models.MessageAttributeValue
-                        {
-                            StringValue = source.Value.StringValue,
-                            BinaryValue = source.Value.BinaryValue?.ToArray(),
-                            DataType = source.Value.DataType
-                        };
-                typedMessage = _serialisationRegister.DeserializeMessage(message.Body);
-
                 Models.MessageAttributeValue MapAttribute(MessageAttributeValue sourceAttribute) =>
                     new Models.MessageAttributeValue
                     {
@@ -73,7 +56,7 @@ namespace JustSaying.AwsTools.MessageHandling
                         BinaryValue = sourceAttribute.BinaryValue?.ToArray(),
                         DataType = sourceAttribute.DataType
                     };
-                
+
                 typedMessage.MessageAttributes = message.MessageAttributes?.ToDictionary(
                     source => source.Key,
                     source => source.Value == null ? null : MapAttribute(source.Value));

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -64,7 +64,19 @@ namespace JustSaying.AwsTools.MessageHandling
                             BinaryValue = source.Value.BinaryValue?.ToArray(),
                             DataType = source.Value.DataType
                         };
-                    });
+                typedMessage = _serialisationRegister.DeserializeMessage(message.Body);
+
+                Models.MessageAttributeValue MapAttribute(MessageAttributeValue sourceAttribute) =>
+                    new Models.MessageAttributeValue
+                    {
+                        StringValue = sourceAttribute.StringValue,
+                        BinaryValue = sourceAttribute.BinaryValue?.ToArray(),
+                        DataType = sourceAttribute.DataType
+                    };
+                
+                typedMessage.MessageAttributes = message.MessageAttributes?.ToDictionary(
+                    source => source.Key,
+                    source => source.Value == null ? null : MapAttribute(source.Value));
             }
             catch (MessageFormatNotSupportedException ex)
             {


### PR DESCRIPTION
I will try to add the ability to allow client code to access incoming SQS messages attributes. There is a high demand for this feature in my and neighboring teams to read the `ApproximateReceiveCount`. Currently it is being populated if you set the `IMessageBackoffStrategy` on the subscription config, but is not accessible for the client code.

Would be great if it could appear in the 6.* branch