### PR TITLE
Switch CA1001 on

### DIFF
--- a/CodeAnalysisRules.ruleset
+++ b/CodeAnalysisRules.ruleset
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="CodeProjects" Description="Code analysis rules for JustSaying Code." ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1001" Action="None" />
     <Rule Id="CA1068" Action="None" />
     <Rule Id="CA1308" Action="None" />
     <Rule Id="CA1716" Action="None" />

--- a/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructuremapNamedHandlerResolver.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringHandlersViaResolver/StructuremapNamedHandlerResolver.cs
@@ -3,6 +3,7 @@ using StructureMap;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringHandlersViaResolver
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Acceptable in tests")]
     public class StructureMapNamedHandlerResolver : IHandlerResolver
     {
         private readonly IContainer _container;

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -18,6 +18,7 @@ using Message = JustSaying.Models.Message;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Known issue")]
     public class SqsNotificationListener : INotificationSubscriber
     {
         private readonly SqsQueueBase _queue;

--- a/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
@@ -6,6 +6,7 @@ using JustSaying.Messaging.Monitoring;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Known issue")]
     public class Throttled : IMessageProcessingStrategy
     {
         private readonly IMessageMonitor _messageMonitor;


### PR DESCRIPTION
The disposable fields rule is quite valuable to leave enabled to prevent new occurrences of this kind.
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1001-types-that-own-disposable-fields-should-be-disposable?view=vs-2017