### PR TITLE
don't use floating Version numbers

### DIFF
--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="StructureMap" Version="4.7.0" />

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="StructureMap" Version="4.7.0" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.*" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -6,9 +6,9 @@
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -6,9 +6,9 @@
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

don't use floating Version numbers.
We were using them in _some_ places and not others 
which was causing issues when building in Visual Studio (errors about two analyser assembly versions)
Rather insist on a very recent version

_Please include a reference to a GitHub issue if appropriate._
