### PR TITLE
Test on macOS and Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 dist: trusty
 
+os:
+  - linux
+  - osx
+
 env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
-if [ "$CI" != "" ]; then
+if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
     docker pull pafortin/goaws
     docker run -d --name goaws -p 4100:4100 pafortin/goaws
     export AWS_SERVICE_URL="http://localhost:4100"


### PR DESCRIPTION
CI should test for both macOS and Linux, not just Linux. Otherwise if we have build issues (see #445), we might not find them.

Depending on the outcome from the tests for the first commit, might need to tweak things slightly to not run the integration tests on macOS if the Docker image doesn't work.