### PR TITLE
Exit early if already cancelled

### DIFF
--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -113,6 +113,11 @@ namespace JustSaying
 
         public void Start(CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             lock (_syncRoot)
             {
                 foreach (var regionSubscriber in _subscribersByRegionAndQueue)


### PR DESCRIPTION
If `Start()` is called with a `CancellationToken` that is already triggered, don't do anything.
