### PR TITLE
Fix Null Reference Exceptions

### DIFF
--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -232,6 +232,11 @@ namespace JustSaying
         /// <returns></returns>
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerAsync<T> handler) where T : Message
         {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
             if (_serialisationFactory == null)
             {
                 throw new InvalidOperationException($"No {nameof(IMessageSerialisationFactory)} has been configured.");

--- a/JustSaying/JustSayingFluently.cs
+++ b/JustSaying/JustSayingFluently.cs
@@ -6,11 +6,11 @@ using JustSaying.AwsTools;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Extensions;
+using JustSaying.Messaging.Interrogation;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialisation;
 using JustSaying.Messaging.Monitoring;
 using JustSaying.Models;
-using JustSaying.Messaging.Interrogation;
 using Microsoft.Extensions.Logging;
 
 namespace JustSaying
@@ -232,6 +232,11 @@ namespace JustSaying
         /// <returns></returns>
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerAsync<T> handler) where T : Message
         {
+            if (_serialisationFactory == null)
+            {
+                throw new InvalidOperationException($"No {nameof(IMessageSerialisationFactory)} has been configured.");
+            }
+
             // TODO - Subscription listeners should be just added once per queue,
             // and not for each message handler
             var thing =  _subscriptionConfig.SubscriptionType == SubscriptionType.PointToPoint
@@ -250,6 +255,11 @@ namespace JustSaying
 
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerResolver handlerResolver) where T : Message
         {
+            if (_serialisationFactory == null)
+            {
+                throw new InvalidOperationException($"No {nameof(IMessageSerialisationFactory)} has been configured.");
+            }
+
             var thing = _subscriptionConfig.SubscriptionType == SubscriptionType.PointToPoint
                 ? PointToPointHandler<T>()
                 : TopicHandler<T>();

--- a/JustSaying/JustSayingFluentlyExtensions.cs
+++ b/JustSaying/JustSayingFluentlyExtensions.cs
@@ -66,9 +66,14 @@ namespace JustSaying
         public static IHaveFulfilledSubscriptionRequirements WithMessageHandlers<T>(
              this IFluentSubscription sub, params IHandlerAsync<T>[] handlers) where T : Message
         {
+            if (handlers == null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
+
             if (handlers.Length == 0)
             {
-                throw new ArgumentException("No handlers in list");
+                throw new ArgumentException("No message handlers specified.", nameof(handlers));
             }
 
             if (handlers.Length == 1)


### PR DESCRIPTION
Port three commits from #431 that fix scenarios that can cause a `NullReferenceException` to be thrown.