### PR TITLE
Improve extensibility for AWS clients

### DIFF
--- a/JustSaying/AwsTools/AwsClientFactoryProxy.cs
+++ b/JustSaying/AwsTools/AwsClientFactoryProxy.cs
@@ -16,6 +16,11 @@ namespace JustSaying.AwsTools
             _awsClientFactoryFunc = awsClientFactoryFunc;
         }
 
+        public AwsClientFactoryProxy(Lazy<IAwsClientFactory> factory)
+        {
+            _awsClientFactoryFunc = () => factory.Value;
+        }
+
         public IAwsClientFactory GetAwsClientFactory() => _awsClientFactoryFunc();
 
         public void SetAwsClientFactory(Func<IAwsClientFactory> func) => _awsClientFactoryFunc = func;

--- a/JustSaying/AwsTools/DefaultAwsClientFactory.cs
+++ b/JustSaying/AwsTools/DefaultAwsClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using Amazon;
+using System;
+using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
@@ -19,10 +20,56 @@ namespace JustSaying.AwsTools
             _credentials = customCredentials;
         }
 
+        public Uri ServiceUri { get; set; }
+
         public IAmazonSimpleNotificationService GetSnsClient(RegionEndpoint region) 
-            => new AmazonSimpleNotificationServiceClient(_credentials, region);
+            => new AmazonSimpleNotificationServiceClient(_credentials, CreateSNSConfig(region));
 
         public IAmazonSQS GetSqsClient(RegionEndpoint region)
-            => new AmazonSQSClient(_credentials, region);
+            => new AmazonSQSClient(_credentials, CreateSQSConfig(region));
+
+        protected virtual void Configure(AmazonSimpleNotificationServiceConfig config)
+        {
+            // For derived classes to override and customise
+        }
+
+        protected virtual void Configure(AmazonSQSConfig config)
+        {
+            // For derived classes to override and customise
+        }
+
+        private AmazonSimpleNotificationServiceConfig CreateSNSConfig(RegionEndpoint region)
+        {
+            var config = new AmazonSimpleNotificationServiceConfig()
+            {
+                RegionEndpoint = region,
+            };
+
+            if (ServiceUri != null)
+            {
+                config.ServiceURL = ServiceUri.ToString();
+            }
+
+            Configure(config);
+
+            return config;
+        }
+
+        private AmazonSQSConfig CreateSQSConfig(RegionEndpoint region)
+        {
+            var config = new AmazonSQSConfig()
+            {
+                RegionEndpoint = region,
+            };
+
+            if (ServiceUri != null)
+            {
+                config.ServiceURL = ServiceUri.ToString();
+            }
+
+            Configure(config);
+
+            return config;
+        }
     }
 }


### PR DESCRIPTION
Port two commits from #431 that improve extensibility:
  1. Allow the SQS and SNS clients to be more easily configured by allowing extension points in `DefaultAwsClientFactory`.
  1. Add a constructor to `AwsClientFactoryProxy` that supports re-using the same single factory via `Lazy<T>`.