### PR TITLE
Cherry-pick from builder RFC

### DIFF
--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -23,7 +23,6 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoDefaultQueue()
-                .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
 
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
@@ -26,7 +26,6 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()
                 .IntoDefaultQueue()
-                .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
 
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -23,7 +23,6 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
             _response = SystemUnderTest
                 .WithSqsPointToPointSubscriber()
                 .IntoDefaultQueue()
-                .ConfigureSubscriptionWith(cfg => { })
                 .WithMessageHandler(_handler);
 
             return Task.CompletedTask;

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS;

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net;
 using System.Threading.Tasks;
 using Amazon;

--- a/JustSaying/Messaging/MessageHandling/BlockingMessageLock.cs
+++ b/JustSaying/Messaging/MessageHandling/BlockingMessageLock.cs
@@ -24,7 +24,7 @@ namespace JustSaying.Messaging.MessageHandling
         public Task ReleaseLockAsync(string key)
         {
             Inner.ReleaseLock(key);
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task<MessageLockResponse> TryAquireLockAsync(string key, TimeSpan howLong) => Task.FromResult(Inner.TryAquireLock(key, howLong));


### PR DESCRIPTION
Cherry-pick three commits from #431:
  * Remove redundant calls to `ConfigureSubscriptionWith()` in unit tests.
  * Use `Task.CompletedTask` in `BlockingMessageLock`.
  * Remove some unused `using` statements.