### PR TITLE
Remove redundant IsTestProject

### DIFF
--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>$(NoWarn);CA1001;CA1034;CA1052;CA1054;CA1063;CA1307;CA1816;CA1822;CA2007</NoWarn>

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>$(NoWarn);CA1001;CA1034;CA1051;CA1307;CA1707;CA1812;CA2007</NoWarn>


### PR DESCRIPTION
`IsTestProject` is always defined for projects referencing `Microsoft.NET.Test.Sdk`
 `15.9.0` (just learnt with thanks to @shep1987). https://github.com/Microsoft/vstest/blob/76fd0f5b09ac3c4c3db0e283deb01b43f7f8a6ab/src/package/nuspec/Microsoft.NET.Test.Sdk.props#L24