### PR TITLE
Add NuGet package for StructureMap

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -15,7 +15,8 @@ $sdkFile = Join-Path $solutionPath "global.json"
 $libraryProjects = @(
     (Join-Path $solutionPath "JustSaying\JustSaying.csproj"),
     (Join-Path $solutionPath "JustSaying.Models\JustSaying.Models.csproj"),
-    (Join-Path $solutionPath "JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj")
+    (Join-Path $solutionPath "JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj"),
+    (Join-Path $solutionPath "JustSaying.Extensions.DependencyInjection.StructureMap\JustSaying.Extensions.DependencyInjection.StructureMap.csproj")
 )
 
 $testProjects = @(

--- a/JustSaying.Extensions.DependencyInjection.StructureMap/ConfigurationExpressionExtensions.cs
+++ b/JustSaying.Extensions.DependencyInjection.StructureMap/ConfigurationExpressionExtensions.cs
@@ -1,0 +1,147 @@
+using System;
+using System.ComponentModel;
+using JustSaying;
+using JustSaying.Fluent;
+using JustSaying.Messaging;
+
+namespace StructureMap
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="ConfigurationExpression"/> class. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ConfigurationExpressionExtensions
+    {
+        /// <summary>
+        /// Adds JustSaying services to the registry.
+        /// </summary>
+        /// <param name="registry">The <see cref="ConfigurationExpression"/> to add JustSaying services to.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="registry"/> is <see langword="null"/>.
+        /// </exception>
+        public static void AddJustSaying(this ConfigurationExpression registry)
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            registry.AddJustSaying((_) => { });
+        }
+
+        /// <summary>
+        /// Adds JustSaying services to the registry.
+        /// </summary>
+        /// <param name="registry">The <see cref="ConfigurationExpression"/> to add JustSaying services to.</param>
+        /// <param name="regions">The AWS region(s) to configure.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="registry"/> or <paramref name="regions"/> is <see langword="null"/>.
+        /// </exception>
+        public static void AddJustSaying(this ConfigurationExpression registry, params string[] regions)
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            if (regions == null)
+            {
+                throw new ArgumentNullException(nameof(regions));
+            }
+
+            registry.AddJustSaying(
+                (builder) => builder.Messaging(
+                    (options) => options.WithRegions(regions)));
+        }
+
+        /// <summary>
+        /// Adds JustSaying services to the registry.
+        /// </summary>
+        /// <param name="registry">The <see cref="ConfigurationExpression"/> to add JustSaying services to.</param>
+        /// <param name="configure">A delegate to a method to use to configure JustSaying.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="registry"/> or <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static void AddJustSaying(this ConfigurationExpression registry, Action<MessagingBusBuilder> configure)
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            registry.AddJustSaying((builder, _) => configure(builder));
+        }
+
+        /// <summary>
+        /// Adds JustSaying services to the registry.
+        /// </summary>
+        /// <param name="registry">The <see cref="ConfigurationExpression"/> to add JustSaying services to.</param>
+        /// <param name="configure">A delegate to a method to use to configure JustSaying.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="registry"/> or <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static void AddJustSaying(this ConfigurationExpression registry, Action<MessagingBusBuilder, IContext> configure)
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            registry.AddRegistry(new JustSayingRegistry());
+
+            registry
+                .For<MessagingBusBuilder>()
+                .Singleton()
+                .Use(
+                    nameof(MessagingBusBuilder),
+                    (context) =>
+                    {
+                        var builder = new MessagingBusBuilder()
+                            .WithServiceResolver(new ContextResolver(context));
+
+                        configure(builder, context);
+
+                        var contributors = context.GetAllInstances<IMessageBusConfigurationContributor>();
+
+                        foreach (var contributor in contributors)
+                        {
+                            contributor.Configure(builder);
+                        }
+
+                        return builder;
+                    });
+
+            registry
+                .For<IMessagePublisher>()
+                .Singleton()
+                .Use(
+                    nameof(IMessagePublisher),
+                    (context) =>
+                    {
+                        var builder = context.GetInstance<MessagingBusBuilder>();
+                        return builder.BuildPublisher();
+                    });
+
+            registry
+                .For<IMessagingBus>()
+                .Singleton()
+                .Use(
+                    nameof(IMessagingBus),
+                    (context) =>
+                    {
+                        var builder = context.GetInstance<MessagingBusBuilder>();
+                        return builder.BuildSubscribers();
+                    });
+        }
+    }
+}

--- a/JustSaying.Extensions.DependencyInjection.StructureMap/ContextResolver.cs
+++ b/JustSaying.Extensions.DependencyInjection.StructureMap/ContextResolver.cs
@@ -1,0 +1,35 @@
+using JustSaying.Fluent;
+using JustSaying.Messaging.MessageHandling;
+using StructureMap;
+
+namespace JustSaying
+{
+    /// <summary>
+    /// A class that implements <see cref="IServiceResolver"/> and <see cref="IHandlerResolver"/>
+    /// for <see cref="IContext"/>. This class cannot be inherited.
+    /// </summary>
+    internal sealed class ContextResolver : IServiceResolver, IHandlerResolver
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContextResolver"/> class.
+        /// </summary>
+        /// <param name="container">The <see cref="IContext"/> to use.</param>
+        internal ContextResolver(IContext container)
+        {
+            Context = container;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IContext"/> to use.
+        /// </summary>
+        private IContext Context { get; }
+
+        /// <inheritdoc />
+        public IHandlerAsync<T> ResolveHandler<T>(HandlerResolutionContext context)
+            => Context.GetInstance<IHandlerAsync<T>>();
+
+        /// <inheritdoc />
+        public T ResolveService<T>()
+            => Context.GetInstance<T>();
+    }
+}

--- a/JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj
+++ b/JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>JustSaying extensions for StructureMap.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>aws,sns,sqs,structuremap</PackageTags>
+    <RootNamespace>StructureMap</RootNamespace>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="structuremap" Version="4.6.0" />
+  </ItemGroup>
+</Project>

--- a/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
+++ b/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
@@ -1,0 +1,44 @@
+using JustSaying.AwsTools;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Fluent;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Monitoring;
+using StructureMap;
+
+namespace JustSaying
+{
+    /// <summary>
+    /// A class representing a StructureMap registry for JustSaying services.
+    /// </summary>
+    internal sealed class JustSayingRegistry : Registry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JustSayingRegistry"/> class.
+        /// </summary>
+        public JustSayingRegistry()
+        {
+            // Register as self so the same singleton instance implements two different interfaces
+            For<ContextResolver>().Use((p) => new ContextResolver(p)).Singleton();
+            For<IHandlerResolver>().Use((p) => p.GetInstance<ContextResolver>()).Singleton();
+            For<IServiceResolver>().Use((p) => p.GetInstance<ContextResolver>()).Singleton();
+
+            For<IAwsClientFactory>().Use<DefaultAwsClientFactory>().Singleton();
+            For<IAwsClientFactoryProxy>().Use((p) => new AwsClientFactoryProxy(p.GetInstance<IAwsClientFactory>)).Singleton();
+            For<IMessagingConfig>().Use<MessagingConfig>().Singleton();
+            For<IMessageMonitor>().Use<NullOpMessageMonitor>().Singleton();
+            For<IMessageSerializationFactory>().Use<NewtonsoftSerializationFactory>().Singleton();
+            For<IMessageSubjectProvider>().Use<GenericMessageSubjectProvider>().Singleton();
+            For<IVerifyAmazonQueues>().Use<AmazonQueueCreator>().Singleton();
+
+            For<IMessageSerializationRegister>()
+                .Use(
+                    nameof(IMessageSerializationRegister),
+                    (p) =>
+                    {
+                        var config = p.GetInstance<IMessagingConfig>();
+                        return new MessageSerializationRegister(config.MessageSubjectProvider);
+                    })
+                .Singleton();
+        }
+    }
+}

--- a/JustSaying.Extensions.DependencyInjection.StructureMap/RegistryExtensions.cs
+++ b/JustSaying.Extensions.DependencyInjection.StructureMap/RegistryExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.ComponentModel;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Models;
+
+namespace StructureMap
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="Registry"/> class. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class RegistryExtensions
+    {
+        /// <summary>
+        /// Adds a JustSaying message handler to the registry.
+        /// </summary>
+        /// <typeparam name="TMessage">The type of the message handled.</typeparam>
+        /// <typeparam name="THandler">The type of the message handler to register.</typeparam>
+        /// <param name="registry">The <see cref="Registry"/> to add the message handler to.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="registry"/> is <see langword="null"/>.
+        /// </exception>
+        public static void AddJustSayingHandler<TMessage, THandler>(this Registry registry)
+            where TMessage : Message
+            where THandler : class, IHandlerAsync<TMessage>
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            registry.For<IHandlerAsync<TMessage>>().Use<THandler>();
+        }
+    }
+}

--- a/JustSaying.IntegrationTests/Fluent/DependencyInjection/StructureMap/WhenUsingStructureMap.cs
+++ b/JustSaying.IntegrationTests/Fluent/DependencyInjection/StructureMap/WhenUsingStructureMap.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using StructureMap;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.DependencyInjection.StructureMap
+{
+    public class WhenUsingStructureMap
+    {
+        public WhenUsingStructureMap(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        private ITestOutputHelper OutputHelper { get; }
+
+        [AwsFact]
+        public async Task Can_Create_Messaging_Bus_Fluently_For_A_Queue()
+        {
+            // Arrange
+            var completionSource = new TaskCompletionSource<object>();
+            var handler = Substitute.For<IHandlerAsync<SimpleMessage>>();
+
+            handler.Handle(Arg.Any<SimpleMessage>())
+                   .Returns(true)
+                   .AndDoes((_) => completionSource.SetResult(null));
+
+            var container = new Container(
+                (registry) =>
+                {
+                    registry.For<ILoggerFactory>()
+                            .Use(() => OutputHelper.ToLoggerFactory())
+                            .Singleton();
+
+                    registry.For<IHandlerAsync<SimpleMessage>>()
+                            .Use(handler);
+
+                    registry.AddJustSaying(
+                        (builder) =>
+                        {
+                            builder.Client((options) => options.WithBasicCredentials("accessKey", "secretKey").WithServiceUri(TestEnvironment.SimulatorUrl))
+                                   .Messaging((options) => options.WithRegions("eu-west-1"))
+                                   .Publications((options) => options.WithQueue<SimpleMessage>())
+                                   .Subscriptions((options) => options.ForQueue<SimpleMessage>());
+                        });
+                });
+
+            IMessagePublisher publisher = container.GetInstance<IMessagePublisher>();
+            IMessagingBus listener = container.GetInstance<IMessagingBus>();
+
+            var message = new SimpleMessage();
+
+            using (var source = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+            {
+                listener.Start(source.Token);
+
+                // Act
+                await publisher.PublishAsync(message, source.Token);
+                completionSource.Task.Wait(source.Token);
+
+                // Assert
+                await handler.Received().Handle(Arg.Any<SimpleMessage>());
+            }
+        }
+    }
+}

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <ProjectReference Include="..\JustSaying\JustSaying.csproj" />
     <ProjectReference Include="..\JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj" />
+    <ProjectReference Include="..\JustSaying.Extensions.DependencyInjection.StructureMap\JustSaying.Extensions.DependencyInjection.StructureMap.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.5.1" />

--- a/JustSaying.sln
+++ b/JustSaying.sln
@@ -48,7 +48,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustSaying.Extensions.DependencyInjection.Microsoft", "JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj", "{1B9BB1E2-E46B-4E2B-A172-61ABA8B35B62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustSaying.Extensions.DependencyInjection.Microsoft", "JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj", "{1B9BB1E2-E46B-4E2B-A172-61ABA8B35B62}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustSaying.Extensions.DependencyInjection.StructureMap", "JustSaying.Extensions.DependencyInjection.StructureMap\JustSaying.Extensions.DependencyInjection.StructureMap.csproj", "{FC6E028F-01DA-47A5-895A-5C1DD27981D4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,6 +86,10 @@ Global
 		{1B9BB1E2-E46B-4E2B-A172-61ABA8B35B62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B9BB1E2-E46B-4E2B-A172-61ABA8B35B62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B9BB1E2-E46B-4E2B-A172-61ABA8B35B62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC6E028F-01DA-47A5-895A-5C1DD27981D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC6E028F-01DA-47A5-895A-5C1DD27981D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC6E028F-01DA-47A5-895A-5C1DD27981D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC6E028F-01DA-47A5-895A-5C1DD27981D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,7 @@ fi
 
 dotnet build JustSaying/JustSaying.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 dotnet build JustSaying.Extensions.DependencyInjection.Microsoft/JustSaying.Extensions.DependencyInjection.Microsoft.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
+dotnet build JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 
 dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj
 dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj


### PR DESCRIPTION
Building on from #479, this PR adds a NuGet package of extensions for using JustSaying with StructureMap.

I picked 4.6.0 as the version to reference as that's the first version that targeted .NET Standard 2.0.

~~Needs rebasing on top of #479 once that is merged.~~

Relates to #473.
