### PR TITLE
MessageMonitor values as timespan

### DIFF
--- a/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTests.cs
+++ b/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTests.cs
@@ -243,11 +243,11 @@ namespace JustSaying.IntegrationTests
             {
             }
 
-            public void HandleThrottlingTime(TimeSpan handleTime)
+            public void HandleThrottlingTime(TimeSpan duration)
             {
             }
 
-            public void HandleTime(TimeSpan handleTime)
+            public void HandleTime(TimeSpan duration)
             {
             }
 
@@ -259,11 +259,11 @@ namespace JustSaying.IntegrationTests
             {
             }
 
-            public void PublishMessageTime(TimeSpan handleTime)
+            public void PublishMessageTime(TimeSpan duration)
             {
             }
 
-            public void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region)
+            public void ReceiveMessageTime(TimeSpan duration, string queueName, string region)
             {
             }
         }

--- a/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTests.cs
+++ b/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTests.cs
@@ -243,11 +243,11 @@ namespace JustSaying.IntegrationTests
             {
             }
 
-            public void HandleThrottlingTime(long handleTimeMs)
+            public void HandleThrottlingTime(TimeSpan handleTime)
             {
             }
 
-            public void HandleTime(long handleTimeMs)
+            public void HandleTime(TimeSpan handleTime)
             {
             }
 
@@ -259,11 +259,11 @@ namespace JustSaying.IntegrationTests
             {
             }
 
-            public void PublishMessageTime(long handleTimeMs)
+            public void PublishMessageTime(TimeSpan handleTime)
             {
             }
 
-            public void ReceiveMessageTime(long handleTimeMs, string queueName, string region)
+            public void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region)
             {
             }
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
@@ -35,7 +35,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void ReceiveMessageTimeStatsSent()
         {
-            Monitor.Received().ReceiveMessageTime(Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>());
+            Monitor.Received().ReceiveMessageTime(Arg.Any<TimeSpan>(), Arg.Any<string>(), Arg.Any<string>());
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
@@ -32,7 +33,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         [Fact]
         public void MonitoringToldMessageHandlingTime()
         {
-            Monitor.Received().HandleTime(Arg.Is<long>(x => x > 0));
+            Monitor.Received()
+                .HandleTime(Arg.Is<TimeSpan>(x => x > TimeSpan.Zero));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/JustSayingBus/CustomMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingBus/CustomMonitor.cs
@@ -6,12 +6,12 @@ namespace JustSaying.UnitTests.JustSayingBus
     public class CustomMonitor : IMessageMonitor, IMeasureHandlerExecutionTime
     {
         public void HandleException(Type messageType) { }
-        public void HandleTime(long handleTimeMs) { }
+        public void HandleTime(TimeSpan handleTime) { }
         public void IssuePublishingMessage() { }
         public void IncrementThrottlingStatistic() { }
-        public void HandleThrottlingTime(long handleTimeMs) { }
-        public void PublishMessageTime(long handleTimeMs) { }
-        public void ReceiveMessageTime(long handleTimeMs, string queueName, string region) { }
+        public void HandleThrottlingTime(TimeSpan handleTime) { }
+        public void PublishMessageTime(TimeSpan handleTime) { }
+        public void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region) { }
         public void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan executionTime) { }
     }
 }

--- a/JustSaying.UnitTests/JustSayingBus/CustomMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingBus/CustomMonitor.cs
@@ -6,12 +6,12 @@ namespace JustSaying.UnitTests.JustSayingBus
     public class CustomMonitor : IMessageMonitor, IMeasureHandlerExecutionTime
     {
         public void HandleException(Type messageType) { }
-        public void HandleTime(TimeSpan handleTime) { }
+        public void HandleTime(TimeSpan duration) { }
         public void IssuePublishingMessage() { }
         public void IncrementThrottlingStatistic() { }
-        public void HandleThrottlingTime(TimeSpan handleTime) { }
-        public void PublishMessageTime(TimeSpan handleTime) { }
-        public void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region) { }
-        public void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan executionTime) { }
+        public void HandleThrottlingTime(TimeSpan duration) { }
+        public void PublishMessageTime(TimeSpan duration) { }
+        public void ReceiveMessageTime(TimeSpan duration, string queueName, string region) { }
+        public void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan duration) { }
     }
 }

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging;
@@ -29,7 +30,7 @@ namespace JustSaying.UnitTests.JustSayingBus
         [Fact]
         public void PublishMessageTimeStatsSent()
         {
-            Monitor.Received(1).PublishMessageTime(Arg.Any<long>());
+            Monitor.Received(1).PublishMessageTime(Arg.Any<TimeSpan>());
         }
     }
 }

--- a/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
@@ -77,7 +77,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
             await ListenLoopExecuted(actions, messageProcessingStrategy);
 
             fakeMonitor.Received().IncrementThrottlingStatistic();
-            fakeMonitor.Received().HandleThrottlingTime(Arg.Any<long>());
+            fakeMonitor.Received().HandleThrottlingTime(Arg.Any<TimeSpan>());
         }
 
         [Theory]

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -123,7 +123,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             watch.Stop();
             _log.LogTrace($"Handled message - MessageType: {message.GetType()}");
-            _messagingMonitor.HandleTime(watch.ElapsedMilliseconds);
+            _messagingMonitor.HandleTime(watch.Elapsed);
 
             return handlerSucceeded;
         }

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -194,7 +194,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 watch.Stop();
 
-                _messagingMonitor.ReceiveMessageTime(watch.ElapsedMilliseconds, queueName, region);
+                _messagingMonitor.ReceiveMessageTime(watch.Elapsed, queueName, region);
 
                 return sqsMessageResponse;
             }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -202,7 +202,7 @@ namespace JustSaying
                     .ConfigureAwait(false);
 
                 watch.Stop();
-                Monitor.PublishMessageTime(watch.ElapsedMilliseconds);
+                Monitor.PublishMessageTime(watch.Elapsed);
             }
             catch (Exception ex)
             {

--- a/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
@@ -57,7 +57,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             await AsTask(_semaphore.AvailableWaitHandle).ConfigureAwait(false);
             watch.Stop();
 
-            _messageMonitor.HandleThrottlingTime(watch.ElapsedMilliseconds);
+            _messageMonitor.HandleThrottlingTime(watch.Elapsed);
         }
 
         private static Task AsTask(WaitHandle waitHandle)

--- a/JustSaying/Messaging/Monitoring/IMeasureHandlerExecutionTime.cs
+++ b/JustSaying/Messaging/Monitoring/IMeasureHandlerExecutionTime.cs
@@ -4,6 +4,6 @@ namespace JustSaying.Messaging.Monitoring
 {
     public interface IMeasureHandlerExecutionTime
     {
-        void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan executionTime);
+        void HandlerExecutionTime(Type handlerType, Type messageType, TimeSpan duration);
     }
 }

--- a/JustSaying/Messaging/Monitoring/IMessageMonitor.cs
+++ b/JustSaying/Messaging/Monitoring/IMessageMonitor.cs
@@ -5,11 +5,11 @@ namespace JustSaying.Messaging.Monitoring
     public interface IMessageMonitor
     {
         void HandleException(Type messageType);
-        void HandleTime(long handleTimeMs);
+        void HandleTime(TimeSpan handleTime);
         void IssuePublishingMessage();
         void IncrementThrottlingStatistic();
-        void HandleThrottlingTime(long handleTimeMs);
-        void PublishMessageTime(long handleTimeMs);
-        void ReceiveMessageTime(long handleTimeMs, string queueName, string region);
+        void HandleThrottlingTime(TimeSpan handleTime);
+        void PublishMessageTime(TimeSpan handleTime);
+        void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region);
     }
 }

--- a/JustSaying/Messaging/Monitoring/IMessageMonitor.cs
+++ b/JustSaying/Messaging/Monitoring/IMessageMonitor.cs
@@ -5,11 +5,11 @@ namespace JustSaying.Messaging.Monitoring
     public interface IMessageMonitor
     {
         void HandleException(Type messageType);
-        void HandleTime(TimeSpan handleTime);
+        void HandleTime(TimeSpan duration);
         void IssuePublishingMessage();
         void IncrementThrottlingStatistic();
-        void HandleThrottlingTime(TimeSpan handleTime);
-        void PublishMessageTime(TimeSpan handleTime);
-        void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region);
+        void HandleThrottlingTime(TimeSpan duration);
+        void PublishMessageTime(TimeSpan duration);
+        void ReceiveMessageTime(TimeSpan duration, string queueName, string region);
     }
 }

--- a/JustSaying/Messaging/Monitoring/NullOpMessageMonitor.cs
+++ b/JustSaying/Messaging/Monitoring/NullOpMessageMonitor.cs
@@ -6,16 +6,16 @@ namespace JustSaying.Messaging.Monitoring
     {
         public void HandleException(Type messageType) { }
 
-        public void HandleTime(TimeSpan handleTime) { }
+        public void HandleTime(TimeSpan duration) { }
 
         public void IssuePublishingMessage() { }
 
         public void IncrementThrottlingStatistic() { }
 
-        public void HandleThrottlingTime(TimeSpan handleTime) { }
+        public void HandleThrottlingTime(TimeSpan duration) { }
 
-        public void PublishMessageTime(TimeSpan handleTime) { }
+        public void PublishMessageTime(TimeSpan duration) { }
 
-        public void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region) { }
+        public void ReceiveMessageTime(TimeSpan duration, string queueName, string region) { }
     }
 }

--- a/JustSaying/Messaging/Monitoring/NullOpMessageMonitor.cs
+++ b/JustSaying/Messaging/Monitoring/NullOpMessageMonitor.cs
@@ -6,16 +6,16 @@ namespace JustSaying.Messaging.Monitoring
     {
         public void HandleException(Type messageType) { }
 
-        public void HandleTime(long handleTimeMs) { }
+        public void HandleTime(TimeSpan handleTime) { }
 
         public void IssuePublishingMessage() { }
 
         public void IncrementThrottlingStatistic() { }
 
-        public void HandleThrottlingTime(long handleTimeMs) { }
+        public void HandleThrottlingTime(TimeSpan handleTime) { }
 
-        public void PublishMessageTime(long handleTimeMs) { }
+        public void PublishMessageTime(TimeSpan handleTime) { }
 
-        public void ReceiveMessageTime(long handleTimeMs, string queueName, string region) { }
+        public void ReceiveMessageTime(TimeSpan handleTime, string queueName, string region) { }
     }
 }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Duration values are typed as `TimeSpan` not `long` in methods on `IMessageMonitor`

In line with what we now do in Statsd, values that express a duration are more correctly typed as `TimeSpan` not `long` (implicitly milliseconds)
I noticed this while looking at the consumer that sends these to statsd, which _formerly_ required values as long milliseconds, but now [also accepts `TimeSpan` structs](https://github.com/justeat/JustEat.StatsD/blob/master/src/JustEat.StatsD/IStatsDPublisherExtensions.cs#L159). So we keep the  value as the richer `TimeSpan` type until the last responsible place.

