### PR TITLE
remove ReceiptHandle and QueueUri from the message

### DIFF
--- a/JustSaying.Models/Message.cs
+++ b/JustSaying.Models/Message.cs
@@ -17,8 +17,6 @@ namespace JustSaying.Models
         public string SourceIp { get; private set; }
         public string Tenant { get; set; }
         public string Conversation { get; set; }
-        public string ReceiptHandle { get; set; }
-        public Uri QueueUri { get; set; }
 
         //footprint in order to avoid the same message being processed multiple times.
         public virtual string UniqueKey() => Id.ToString();

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -81,9 +81,6 @@ namespace JustSaying.AwsTools.MessageHandling
                 {
                     _messageContextAccessor.MessageContext = new MessageContext(message, _queue.Uri);
 
-                    typedMessage.ReceiptHandle = message.ReceiptHandle;
-                    typedMessage.QueueUri = _queue.Uri;
-
                     handlingSucceeded = await CallMessageHandler(typedMessage).ConfigureAwait(false);
                 }
 


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Remove `ReceiptHandle` and `QueueUri` from the message base class
They are not part of the deserialised message body, and are stamped on afterwards from metedata
the Right Way to get them (and other similar metadata) now is via `MessageContext`
which you can see set up immediately beforehand in `MessageDispatcher`

_Please include a reference to a GitHub issue if appropriate._
