### PR TITLE
Make timeout easier to reason with in IntegrationTestBase

### DIFF
--- a/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -99,7 +99,7 @@ namespace JustSaying.IntegrationTests.Fluent
 
                 if (resultTask == delayTask)
                 {
-                    throw new OperationCanceledException();
+                    throw new TimeoutException($"The bus related action took longer to execute than the timeout of {Timeout.TotalSeconds} seconds");
                 }
                 else
                 {

--- a/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -90,26 +90,23 @@ namespace JustSaying.IntegrationTests.Fluent
             IMessagePublisher publisher = serviceProvider.GetRequiredService<IMessagePublisher>();
             IMessagingBus listener = serviceProvider.GetRequiredService<IMessagingBus>();
 
-            using (var source = new CancellationTokenSource(Timeout))
+            using (var cts = new CancellationTokenSource())
             {
-                try
+                var delayTask = Task.Delay(Timeout, cts.Token);
+                var actionTask = action(publisher, listener, cts.Token);
+
+                var resultTask = await Task.WhenAny(actionTask, delayTask).ConfigureAwait(false);
+
+                if (resultTask == delayTask)
                 {
-                    var delayTask = Task.Delay(Timeout, source.Token);
-                    var actionTask = action(publisher, listener, source.Token);
-
-                    await Task.WhenAny(actionTask, delayTask).ConfigureAwait(false);
-
-                    source.Token.ThrowIfCancellationRequested();
-
-                    if (actionTask.IsFaulted)
-                    {
-                        await actionTask;
-                    }
+                    throw new OperationCanceledException();
                 }
-                finally
+                else
                 {
-                    source.Cancel();
+                    cts.Cancel();
                 }
+                
+                await actionTask;
             }
         }
     }


### PR DESCRIPTION
Following @shaynevanasperen comment, it isn't clear how the timeout task is behaving, is it finishing because it's duration is up, or is it cancelled because of the cancellation token being fired.