### PR TITLE
Use "Logging.Abstractions" version 2 for all target frameworks

### DIFF
--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -10,11 +10,6 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,8 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
-    docker pull pafortin/goaws@sha256:84c8879550c78aff7d2ec2ef6922273f98f15e1d20d27377c2b1164d1cb91ccf
-    docker run -d --name goaws -p 4100:4100 pafortin/goaws
+    docker pull pafortin/goaws:1.0.3
+    docker run -d --name goaws -p 4100:4100 pafortin/goaws:1.0.3
     export AWS_SERVICE_URL="http://localhost:4100"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
-    docker pull pafortin/goaws
+    docker pull pafortin/goaws:1.0.3
     docker run -d --name goaws -p 4100:4100 pafortin/goaws
     export AWS_SERVICE_URL="http://localhost:4100"
 fi

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
-    docker pull pafortin/goaws:1.0.3
+    docker pull pafortin/goaws:sha256:84c8879550c78aff7d2ec2ef6922273f98f15e1d20d27377c2b1164d1cb91ccf
     docker run -d --name goaws -p 4100:4100 pafortin/goaws
     export AWS_SERVICE_URL="http://localhost:4100"
 fi

--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,9 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
-    docker pull pafortin/goaws:1.0.3
-    docker run -d --name goaws -p 4100:4100 pafortin/goaws:1.0.3
+    goaws_tag=1.0.3 # Use latest once issue #494 is resolved
+    docker pull pafortin/goaws:$goaws_tag
+    docker run -d --name goaws -p 4100:4100 pafortin/goaws:$goaws_tag
     export AWS_SERVICE_URL="http://localhost:4100"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ if [ "$dotnet_version" != "$CLI_VERSION" ]; then
 fi
 
 if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
-    docker pull pafortin/goaws:sha256:84c8879550c78aff7d2ec2ef6922273f98f15e1d20d27377c2b1164d1cb91ccf
+    docker pull pafortin/goaws@sha256:84c8879550c78aff7d2ec2ef6922273f98f15e1d20d27377c2b1164d1cb91ccf
     docker run -d --name goaws -p 4100:4100 pafortin/goaws
     export AWS_SERVICE_URL="http://localhost:4100"
 fi


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Use `Microsoft.Extensions.Logging.Abstractions` version 2.0 for all target frameworks.

Although it may be more technically correct to use version 1.1 for the `net461` target
What we found when using this, was that other libs  (e.g. [NLog.Extensions.Logging](https://www.nuget.org/packages/NLog.Extensions.Logging/) or [Serilog.Extensions.Logging](https://www.nuget.org/packages/Serilog.Extensions.Logging/)) force the use of Logging.Abstractions version 2.0 anyway on `net461`. And reconciling this is additional hassle. It is simpler to always use  Logging.Abstractions version 2.0.

_Please include a reference to a GitHub issue if appropriate._

This [was mentioned in comments](https://github.com/justeat/JustSaying/pull/493#issuecomment-449739928) for #493 but decided for a separate PR.
