### PR TITLE
Fewer exclusions in the integration test

### DIFF
--- a/JustSaying.IntegrationTests/AwsTools/WhenSettingUpMultipleHandlers.cs
+++ b/JustSaying.IntegrationTests/AwsTools/WhenSettingUpMultipleHandlers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,7 +64,9 @@ namespace JustSaying.IntegrationTests.AwsTools
         [AwsFact]
         public void GetQueueAttributesCalledOnce()
         {
-            _proxyAwsClientFactory.Counters["GetQueueAttributes"].First(x => x.Key.EndsWith(_queueName)).Value.Count
+            _proxyAwsClientFactory.Counters["GetQueueAttributes"].First(
+                    x => x.Key.EndsWith(_queueName, StringComparison.OrdinalIgnoreCase))
+                .Value.Count
                 .ShouldBe(1);
         }
 

--- a/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
+++ b/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
@@ -11,7 +11,6 @@ using NSubstitute;
 
 namespace JustSaying.IntegrationTests
 {
-#pragma warning disable CA1054
     public abstract class FluentNotificationStackTestBase : XAsyncBehaviourTest<JustSaying.JustSayingFluently>
     {
         protected RegionEndpoint Region => TestFixture.Region;
@@ -173,6 +172,8 @@ namespace JustSaying.IntegrationTests
             return (false, null);
         }
 
+// disable warning about "queueUrl" typed as string
+#pragma warning disable CA1054
         protected async Task<bool> IsQueueSubscribedToTopic(Topic topic, string queueUrl)
         {
             var request = new GetQueueAttributesRequest
@@ -205,5 +206,6 @@ namespace JustSaying.IntegrationTests
             return policy.Contains(topic.TopicArn, StringComparison.OrdinalIgnoreCase) ||
                    policy.Contains(wildcardedSubscription, StringComparison.OrdinalIgnoreCase);
         }
+#pragma warning restore CA1054
     }
 }

--- a/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
+++ b/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
@@ -175,6 +175,7 @@ namespace JustSaying.IntegrationTests
 // disable warning about "queueUrl" typed as string
 #pragma warning disable CA1054
         protected async Task<bool> IsQueueSubscribedToTopic(Topic topic, string queueUrl)
+#pragma warning restore CA1054
         {
             var request = new GetQueueAttributesRequest
             {
@@ -194,7 +195,10 @@ namespace JustSaying.IntegrationTests
             return subscriptions.Any(x => !string.IsNullOrEmpty(x.SubscriptionArn) && x.Endpoint == queueArn);
         }
 
+        // disable warning about "queueUrl" typed as string
+#pragma warning disable CA1054
         protected async Task<bool> QueueHasPolicyForTopic(Topic topic, string queueUrl)
+#pragma warning restore CA1054
         {
             var client = TestFixture.CreateSqsClient();
 
@@ -206,6 +210,5 @@ namespace JustSaying.IntegrationTests
             return policy.Contains(topic.TopicArn, StringComparison.OrdinalIgnoreCase) ||
                    policy.Contains(wildcardedSubscription, StringComparison.OrdinalIgnoreCase);
         }
-#pragma warning restore CA1054
     }
 }

--- a/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
+++ b/JustSaying.IntegrationTests/FluentNotificationStackTestBase.cs
@@ -11,6 +11,7 @@ using NSubstitute;
 
 namespace JustSaying.IntegrationTests
 {
+#pragma warning disable CA1054
     public abstract class FluentNotificationStackTestBase : XAsyncBehaviourTest<JustSaying.JustSayingFluently>
     {
         protected RegionEndpoint Region => TestFixture.Region;
@@ -201,7 +202,8 @@ namespace JustSaying.IntegrationTests
             int pos = topic.TopicArn.LastIndexOf(':');
             string wildcardedSubscription = topic.TopicArn.Substring(0, pos + 1) + "*";
 
-            return policy.Contains(topic.TopicArn) || policy.Contains(wildcardedSubscription);
+            return policy.Contains(topic.TopicArn, StringComparison.OrdinalIgnoreCase) ||
+                   policy.Contains(wildcardedSubscription, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>$(NoWarn);CA1001;CA1034;CA1052;CA1054;CA1063;CA1307;CA1707;CA1812;CA1816;CA1822;CA2007</NoWarn>
+    <NoWarn>$(NoWarn);CA1001;CA1707;CA1812;CA1822;CA2007</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
@@ -34,13 +34,14 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 
             policyJson.Statement.Count.ShouldBe(1,  $"Expecting 1 statement in Sqs policy but found {policyJson.Statement.Count}");
         }
-    }
 
-    public class TopicA : Message
-    {
-    }
+#pragma warning disable CA1034
+        public class TopicA : Message
+        {
+        }
 
-    public class TopicB : Message
-    {
+        public class TopicB : Message
+        {
+        }
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
@@ -34,13 +34,13 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 
             policyJson.Statement.Count.ShouldBe(1,  $"Expecting 1 statement in Sqs policy but found {policyJson.Statement.Count}");
         }
+    }
 
-        public class TopicA : Message
-        {
-        }
+    public class TopicA : Message
+    {
+    }
 
-        public class TopicB : Message
-        {
-        }
+    public class TopicB : Message
+    {
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
@@ -35,6 +35,7 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             policyJson.Statement.Count.ShouldBe(1,  $"Expecting 1 statement in Sqs policy but found {policyJson.Statement.Count}");
         }
 
+// disable warning about public nested classes
 #pragma warning disable CA1034
         public class TopicA : Message
         {
@@ -43,5 +44,6 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         public class TopicB : Message
         {
         }
+#pragma warning restore CA1034
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
@@ -5,6 +5,8 @@ using NSubstitute;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 {
+#pragma warning disable CA1052
+#pragma warning disable CA1034
     public class WhenRegisteringLongNameMessageTypeTopicSubscriber
     {
         public class LongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongMessage : Message

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
@@ -9,12 +9,14 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 #pragma warning disable CA1052
 #pragma warning disable CA1034
     public class WhenRegisteringLongNameMessageTypeTopicSubscriber
+#pragma warning restore CA1052
     {
         public class LongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLonggLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongMessage : Message
         {
         }
 
         public class WhenRegisteringASqsGenericMessageTopicSubscriber : WhenRegisteringASqsTopicSubscriber
+#pragma warning restore CA1034
         {
             protected override Task When()
             {

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 
 namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 {
+// disable warning about the pathological class names and class nesting in this test
 #pragma warning disable CA1052
 #pragma warning disable CA1034
     public class WhenRegisteringLongNameMessageTypeTopicSubscriber


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Removed a few project-wide code quality rule exclusions from  `JustSaying.IntegrationTests.csproj`
- some are only needed for one file that intentionally does edge-case things, so instead I do a `#pragma` there.
- some can be fixed, like the string comparison and nested message type classes.
- the rest are retained

_Please include a reference to a GitHub issue if appropriate._
