### PR TITLE
Fewer rule exclusions in unit tests

### DIFF
--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>$(NoWarn);CA1001;CA1707;CA1812;CA1822;CA2007</NoWarn>
+    <NoWarn>$(NoWarn);CA1001;CA1034;CA1707;CA1812;CA1822;CA2007</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenHandlingMultipleTopics.cs
@@ -35,8 +35,6 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
             policyJson.Statement.Count.ShouldBe(1,  $"Expecting 1 statement in Sqs policy but found {policyJson.Statement.Count}");
         }
 
-// disable warning about public nested classes
-#pragma warning disable CA1034
         public class TopicA : Message
         {
         }
@@ -44,6 +42,5 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         public class TopicB : Message
         {
         }
-#pragma warning restore CA1034
     }
 }

--- a/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
+++ b/JustSaying.IntegrationTests/WhenRegisteringASqsSubscriber/WhenRegisteringLongNameMessageTypeTopicSubscriber.cs
@@ -7,7 +7,6 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
 {
 // disable warning about the pathological class names and class nesting in this test
 #pragma warning disable CA1052
-#pragma warning disable CA1034
     public class WhenRegisteringLongNameMessageTypeTopicSubscriber
 #pragma warning restore CA1052
     {
@@ -16,7 +15,6 @@ namespace JustSaying.IntegrationTests.WhenRegisteringASqsSubscriber
         }
 
         public class WhenRegisteringASqsGenericMessageTopicSubscriber : WhenRegisteringASqsTopicSubscriber
-#pragma warning restore CA1034
         {
             protected override Task When()
             {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsync.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -59,7 +60,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         private static bool B(PublishRequest x)
         {
-            return x.Message.Equals(Message);
+            return x.Message.Equals(Message, StringComparison.OrdinalIgnoreCase);
         }
 
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
@@ -46,7 +47,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public void MessageIsPublishedToQueue()
         {
             // ToDo: Could be better...
-            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(x => x.MessageBody.Equals("serialized_contents")));
+            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(
+                x => x.MessageBody.Equals("serialized_contents", StringComparison.OrdinalIgnoreCase)));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
@@ -52,7 +53,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public void MessageIsPublishedToQueue()
         {
             // ToDo: Could be better...
-            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(x => x.MessageBody.Equals("serialized_contents")));
+            _sqs.Received().SendMessageAsync(Arg.Is<SendMessageRequest>(
+                x => x.MessageBody.Equals("serialized_contents", StringComparison.OrdinalIgnoreCase)));
         }
 
         [Fact]

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -18,7 +18,10 @@ using Shouldly;
 
 namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
+// this class should be disposable, but that' not important for tests
+#pragma warning disable CA1001
     public abstract class BaseQueuePollingTest : XAsyncBehaviourTest<JustSaying.AwsTools.MessageHandling.SqsNotificationListener>
+#pragma warning restore CA1001
     {
         protected const string QueueUrl = "http://testurl.com/queue";
         protected IAmazonSQS Sqs;

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -18,7 +18,8 @@ using Shouldly;
 
 namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
-// this class should be disposable, but that' not important for tests
+    // this class should be disposable because it owns a ILoggerFactory and IAmazonSQS,
+    // but that's not important for tests.
 #pragma warning disable CA1001
     public abstract class BaseQueuePollingTest : XAsyncBehaviourTest<JustSaying.AwsTools.MessageHandling.SqsNotificationListener>
 #pragma warning restore CA1001

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
@@ -57,7 +57,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             var messageId = DeserializedMessage.Id.ToString();
 
             await MessageLock.Received().TryAquireLockAsync(
-                Arg.Is<string>(a => a.Contains(messageId)),
+                Arg.Is<string>(a => a.Contains(messageId, StringComparison.OrdinalIgnoreCase)),
                 TimeSpan.FromSeconds(_expectedtimeout));
         }
     }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -51,7 +51,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             var messageId = DeserializedMessage.Id.ToString();
 
             MessageLock.Received().TryAquireLockAsync(
-                Arg.Is<string>(a => a.Contains(messageId)),
+                Arg.Is<string>(a => a.Contains(messageId, StringComparison.OrdinalIgnoreCase)),
                 TimeSpan.FromSeconds(_maximumTimeout));
         }
 

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>$(NoWarn);CA1001;CA1034;CA1051;CA1307;CA1707;CA1812;CA2007</NoWarn>
+    <NoWarn>$(NoWarn);CA1034;CA1051;CA1707;CA2007</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
@@ -1,3 +1,4 @@
+using System;
 using JustBehave;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.TestingFramework;
@@ -21,7 +22,7 @@ namespace JustSaying.UnitTests.Messaging.Serialization.Newtonsoft
             _jsonMessage = SystemUnderTest.Serialize(_messageOut, false, _messageOut.GetType().Name);
 
             //add extra property to see what happens:
-            _jsonMessage = _jsonMessage.Replace("{__", "{\"New\":\"Property\",__");
+            _jsonMessage = _jsonMessage.Replace("{__", "{\"New\":\"Property\",__", StringComparison.OrdinalIgnoreCase);
             _messageIn = SystemUnderTest.Deserialize(_jsonMessage, typeof(MessageWithEnum)) as MessageWithEnum;
         }
 

--- a/JustSaying.UnitTests/Messaging/Serialization/SubjectProviders/GenericMessageSubjectProviderTests.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/SubjectProviders/GenericMessageSubjectProviderTests.cs
@@ -6,9 +6,12 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SubjectProviders
 {
     public class GenericMessageSubjectProviderTests
     {
+// these classes are never instantiated, but the types are used in tests
+#pragma warning disable CA1812
         class Foo { }
 
         class Bar<T> { }
+#pragma warning restore CA1812
 
         [Fact]
         public void GetSubjectForType_NonGenericType_ReturnsTypeNameWithNamespace_NonWordCharactersReplaced() =>

--- a/JustSaying.UnitTests/Messaging/Serialization/SubjectProviders/NonGenericMessageSubjectProviderTests.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/SubjectProviders/NonGenericMessageSubjectProviderTests.cs
@@ -7,7 +7,10 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SubjectProviders
 {
     public class NonGenericMessageSubjectProviderTests
     {
+        // this class is never instantiated, but the type is used in tests
+#pragma warning disable CA1812
         class Foo { }
+#pragma warning restore CA1812
 
         [Fact]
         public void GetSubjectForType_ReturnsTypeName() =>


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Fewer roslyn analyser rule exclusions in unit tests.
Since newted class warning `CA1034` is off in the unit tests, it seems fair to turn it off in the integration tests too rather than use pragmas.

_Please include a reference to a GitHub issue if appropriate._
