### PR TITLE
Use analysers version 2.6.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="version.props" />
   <PropertyGroup>
-    <AnalyzersPackageVersion>2.6.2</AnalyzersPackageVersion>
+    <AnalyzersPackageVersion>2.6.3</AnalyzersPackageVersion>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -237,7 +237,7 @@ namespace JustSaying.AwsTools.MessageHandling
             return _messageProcessingStrategy.StartWorker(action, ct);
         }
 
-        public ICollection<ISubscriber> Subscribers { get; set; }
+        public ICollection<ISubscriber> Subscribers { get; }
 
         private static void DefaultErrorHandler(Exception exception, Amazon.SQS.Model.Message message)
         {

--- a/JustSaying/Messaging/Interrogation/INotificationSubscriberInterrogation.cs
+++ b/JustSaying/Messaging/Interrogation/INotificationSubscriberInterrogation.cs
@@ -4,6 +4,6 @@ namespace JustSaying.Messaging.Interrogation
 {
     public interface INotificationSubscriberInterrogation
     {
-        ICollection<ISubscriber> Subscribers { get; set; }
+        ICollection<ISubscriber> Subscribers { get; }
     }
 }

--- a/JustSaying/Messaging/PublishMetadata.cs
+++ b/JustSaying/Messaging/PublishMetadata.cs
@@ -8,7 +8,7 @@ namespace JustSaying.Messaging
     {
         public TimeSpan? Delay { get; set; }
 
-        public IDictionary<string, MessageAttributeValue> MessageAttributes { get; set; }
+        public IDictionary<string, MessageAttributeValue> MessageAttributes { get; private set; }
 
         public PublishMetadata AddMessageAttribute(string key, MessageAttributeValue value)
         {


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Use analysers version 2.6.3
Which came out 8 days ago ( https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/2.6.3 )
And fix the "writeable collection" warning
https://docs.microsoft.com/en-gb/visualstudio/code-quality/ca2227-collection-properties-should-be-read-only?view=vs-2017


_Please include a reference to a GitHub issue if appropriate._
