### PR TITLE
BaseQueuePollingTest.Given sync

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -40,9 +40,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
         public virtual async Task InitializeAsync()
         {
-            await Given().ConfigureAwait(false);
+            Given();
 
-            SystemUnderTest = await CreateSystemUnderTestAsync().ConfigureAwait(false);
+            SystemUnderTest = CreateSystemUnderTest();
 
             await When().ConfigureAwait(false);
         }
@@ -64,17 +64,17 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             return Task.CompletedTask;
         }
 
-        protected virtual Task<JustSaying.AwsTools.MessageHandling.SqsNotificationListener> CreateSystemUnderTestAsync()
+        protected JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
         {
             var queue = new SqsQueueByUrl(RegionEndpoint.EUWest1, new Uri(QueueUrl), Sqs);
             var listener = new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(
                 queue, SerializationRegister, Monitor, LoggerFactory,
                 Substitute.For<IMessageContextAccessor>(),
                 null, MessageLock);
-            return Task.FromResult(listener);
+            return listener;
         }
 
-        protected virtual Task Given()
+        protected virtual void Given()
         {
             LoggerFactory = new LoggerFactory();
             Sqs = Substitute.For<IAmazonSQS>();
@@ -94,7 +94,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
             DeserializedMessage = new SimpleMessage { RaisingComponent = "Component" };
             SerializationRegister.DeserializeMessage(Arg.Any<string>()).Returns(DeserializedMessage);
-            return Task.CompletedTask;
         }
 
 #pragma warning disable CA1716

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
@@ -16,9 +16,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         private ExplicitExactlyOnceSignallingHandler _handler;
 
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             _expectedTimeout = 5;
 
             var messageLockResponse = new MessageLockResponse

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -17,9 +17,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         private ExactlyOnceSignallingHandler _handler;
 
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
 
             var messageLockResponse = new MessageLockResponse
             {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
@@ -16,9 +16,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
         private int _expectedMaxMessageCount;
 
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
 
             // we expect to get max 10 messages per batch
             // except on single-core machines when we top out at ParallelHandlerExecutionPerCore=8

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingFails.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingFails.cs
@@ -9,9 +9,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public class WhenMessageHandlingFails : BaseQueuePollingTest
     {
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             Handler.Handle(Arg.Any<SimpleMessage>()).ReturnsForAnyArgs(false);
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingSucceeds.cs
@@ -8,9 +8,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public class WhenMessageHandlingSucceeds : BaseQueuePollingTest
     {
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageHandlingThrows.cs
@@ -11,9 +11,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
     {
         private bool _firstTime = true;
 
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             Handler.Handle(Arg.Any<SimpleMessage>()).Returns(
                 _ => ExceptionOnFirstCall());
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
@@ -14,9 +14,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
     /// </summary>
     public class WhenMessageProcessingThrowsBefore : BaseQueuePollingTest
     {
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
@@ -14,9 +14,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
     /// </summary>
     public class WhenMessageProcessingThrowsDuring : BaseQueuePollingTest
     {
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenPassingAHandledAndUnhandledMessage.cs
@@ -9,9 +9,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public class WhenPassingAHandledAndUnhandledMessage : BaseQueuePollingTest
     {
-        protected override async Task Given()
+        protected override void Given()
         {
-            await base.Given();
+            base.Given();
             Handler.Handle(null)
                 .ReturnsForAnyArgs(info => true)
                 .AndDoes(x => Thread.Sleep(1)); // Ensure at least one ms wait on processing

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -19,7 +19,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         private int _sqsCallCounter;
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
 
-        protected override Task Given()
+        protected override void Given()
         {
             Sqs = Substitute.For<IAmazonSQS>();
             SerializationRegister = Substitute.For<IMessageSerializationRegister>();
@@ -34,8 +34,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
                     Arg.Any<ReceiveMessageRequest>(),
                     Arg.Any<CancellationToken>())
                 .Returns(_ =>  ExceptionOnFirstCall());
-
-            return Task.CompletedTask;
         }
 
         private Task ExceptionOnFirstCall()


### PR DESCRIPTION

_Summarise the changes this Pull Request makes._

`BaseQueuePollingTest.Given` can be sync, the async was never used, was inherited from JustBehave.
Similarly `CreateSystemUnderTest`

_Please include a reference to a GitHub issue if appropriate._
