### PR TITLE
Rename "When"

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -70,7 +70,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             return Task.CompletedTask;
         }
 
-
         protected virtual void Given()
         {
             _typedMessage = new OrderAccepted();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishing.cs
@@ -32,7 +32,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
                 .Returns(new Topic { TopicArn = TopicArn });
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(new SimpleMessage());
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsync.cs
@@ -37,7 +37,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
                 .Returns(new Topic { TopicArn = TopicArn });
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             var metadata = new PublishMetadata()
                 .AddMessageAttribute(MessageAttributeKey, MessageAttributeValue);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
@@ -36,7 +36,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
                 .Returns(new Topic { TopicArn = TopicArn });
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             Sns.PublishAsync(Arg.Any<PublishRequest>()).Returns(ThrowsException);
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -37,7 +37,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
                 .Returns(new Topic { TopicArn = TopicArn });
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             Sns.PublishAsync(Arg.Any<PublishRequest>()).Returns(ThrowsException);
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncResponseLoggerIsCalled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncResponseLoggerIsCalled.cs
@@ -50,7 +50,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
                 .Returns(PublishResult);
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             return SystemUnderTest.PublishAsync(new SimpleMessage());
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
@@ -35,7 +35,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
                 .Returns(new Topic { TopicArn = TopicArn });
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(new MessageWithTypeParameters<int, string>());
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingTestBase.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingTestBase.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
             SystemUnderTest = await CreateSystemUnderTestAsync();
 
-            await WhenAction().ConfigureAwait(false);
+            await WhenAsync().ConfigureAwait(false);
         }
 
         public virtual Task DisposeAsync()
@@ -35,6 +35,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
         protected abstract void Given();
         protected abstract Task<SnsTopicByName> CreateSystemUnderTestAsync();
 
-       protected abstract Task WhenAction();
+       protected abstract Task WhenAsync();
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishing.cs
@@ -38,7 +38,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
                 .Returns("serialized_contents");
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(_message);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsync.cs
@@ -38,7 +38,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
                 .Returns("serialized_contents");
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(_message);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsyncResponseLoggerAsyncIsCalled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingAsyncResponseLoggerAsyncIsCalled.cs
@@ -58,7 +58,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
                 .Returns(PublishResult);
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(_testMessage);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingDelayedMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingDelayedMessage.cs
@@ -40,7 +40,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
             Sqs.GetQueueAttributesAsync(Arg.Any<GetQueueAttributesRequest>()).Returns(new GetQueueAttributesResponse());
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(_message, _metadata);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingDelayedMessageAsync.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingDelayedMessageAsync.cs
@@ -40,7 +40,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
                 .Returns(new GetQueueAttributesResponse());
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(_message, _metadata);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingTestBase.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenPublishingTestBase.cs
@@ -17,7 +17,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
 
             SystemUnderTest = await CreateSystemUnderTestAsync();
 
-            await WhenAction().ConfigureAwait(false);
+            await WhenAsync().ConfigureAwait(false);
         }
 
         public virtual Task DisposeAsync()
@@ -34,6 +34,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         protected abstract void Given();
         protected abstract Task<SqsPublisher> CreateSystemUnderTestAsync();
 
-       protected abstract Task WhenAction();
+       protected abstract Task WhenAsync();
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -44,7 +44,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
             SystemUnderTest = CreateSystemUnderTest();
 
-            await WhenAction().ConfigureAwait(false);
+            await WhenAsync().ConfigureAwait(false);
         }
 
         public virtual Task DisposeAsync()
@@ -96,7 +96,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             SerializationRegister.DeserializeMessage(Arg.Any<string>()).Returns(DeserializedMessage);
         }
 
-        protected virtual async Task WhenAction()
+        protected virtual async Task WhenAsync()
         {
             var doneSignal = new TaskCompletionSource<object>();
             var signallingHandler = new SignallingHandler<SimpleMessage>(doneSignal, Handler);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -44,7 +44,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
             SystemUnderTest = CreateSystemUnderTest();
 
-            await When().ConfigureAwait(false);
+            await WhenAction().ConfigureAwait(false);
         }
 
         public virtual Task DisposeAsync()
@@ -96,10 +96,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             SerializationRegister.DeserializeMessage(Arg.Any<string>()).Returns(DeserializedMessage);
         }
 
-#pragma warning disable CA1716
-        protected virtual async Task When()
-#pragma warning restore CA1716
-
+        protected virtual async Task WhenAction()
         {
             var doneSignal = new TaskCompletionSource<object>();
             var signallingHandler = new SignallingHandler<SimpleMessage>(doneSignal, Handler);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
@@ -34,7 +34,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler = _handler;
         }
 
-        protected override async Task When()
+        protected override async Task WhenAction()
         {
             SystemUnderTest.AddMessageHandler(() => Handler);
             var cts = new CancellationTokenSource();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandler.cs
@@ -34,7 +34,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler = _handler;
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessageHandler(() => Handler);
             var cts = new CancellationTokenSource();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -34,7 +34,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler = _handler;
         }
 
-        protected override async Task When()
+        protected override async Task WhenAction()
         {
             SystemUnderTest.AddMessageHandler(() => Handler);
             var cts = new CancellationTokenSource();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -34,7 +34,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler = _handler;
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessageHandler(() => Handler);
             var cts = new CancellationTokenSource();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
@@ -39,9 +39,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
                 _ => response2);
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
-            await base.WhenAction();
+            await base.WhenAsync();
 
             var cts = new CancellationTokenSource();
             SystemUnderTest.Listen(cts.Token);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
@@ -39,9 +39,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
                 _ => response2);
         }
 
-        protected override async Task When()
+        protected override async Task WhenAction()
         {
-            await base.When();
+            await base.WhenAction();
 
             var cts = new CancellationTokenSource();
             SystemUnderTest.Listen(cts.Token);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             var doneSignal = new TaskCompletionSource<object>();
             SystemUnderTest.WithMessageProcessingStrategy(new ThrowingBeforeMessageProcessingStrategy(doneSignal));

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsBefore.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 
-        protected override async Task When()
+        protected override async Task WhenAction()
         {
             var doneSignal = new TaskCompletionSource<object>();
             SystemUnderTest.WithMessageProcessingStrategy(new ThrowingBeforeMessageProcessingStrategy(doneSignal));

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             var doneSignal = new TaskCompletionSource<object>();
             SystemUnderTest.WithMessageProcessingStrategy(new ThrowingDuringMessageProcessingStrategy(doneSignal));

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenMessageProcessingThrowsDuring.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             Handler.Handle(null).ReturnsForAnyArgs(true);
         }
 
-        protected override async Task When()
+        protected override async Task WhenAction()
         {
             var doneSignal = new TaskCompletionSource<object>();
             SystemUnderTest.WithMessageProcessingStrategy(new ThrowingDuringMessageProcessingStrategy(doneSignal));

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -23,7 +23,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         private readonly IMessageSerializationRegister _serializationRegister =
             Substitute.For<IMessageSerializationRegister>();
 
-        private JustSaying.AwsTools.MessageHandling.SqsNotificationListener SystemUnderTest;
+        private JustSaying.AwsTools.MessageHandling.SqsNotificationListener _systemUnderTest;
 
         private int _callCount;
 
@@ -31,7 +31,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         {
             Given();
 
-            SystemUnderTest = CreateSystemUnderTest();
+            _systemUnderTest = CreateSystemUnderTest();
 
             await When().ConfigureAwait(false);
         }
@@ -47,7 +47,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             return Task.CompletedTask;
         }
 
-        protected JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
+        private JustSaying.AwsTools.MessageHandling.SqsNotificationListener CreateSystemUnderTest()
         {
             var listener = new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(
                 new SqsQueueByUrl(RegionEndpoint.EUWest1, new Uri("http://foo.com"), _sqs),
@@ -59,7 +59,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             return listener;
         }
 
-        protected void Given()
+        private void Given()
         {
             _serializationRegister
                 .DeserializeMessage(Arg.Any<string>())
@@ -76,12 +76,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         }
 
 
-#pragma warning disable CA1716
-        protected async Task When()
-#pragma warning restore CA1716
+        private async Task When()
         {
             var cts = new CancellationTokenSource();
-            SystemUnderTest.Listen(cts.Token);
+            _systemUnderTest.Listen(cts.Token);
             await Task.Delay(100);
             cts.Cancel();
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -51,7 +51,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             return Task.FromResult(new ReceiveMessageResponse());
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessageHandler(() => Handler);
             var cts = new CancellationTokenSource();

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInSqsCalling.cs
@@ -51,7 +51,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             return Task.FromResult(new ReceiveMessageResponse());
         }
 
-        protected override async Task When()
+        protected override async Task WhenAction()
         {
             SystemUnderTest.AddMessageHandler(() => Handler);
             var cts = new CancellationTokenSource();

--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBus.cs
@@ -25,7 +25,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             try
             {
                 SystemUnderTest = CreateSystemUnderTest();
-                await WhenAction().ConfigureAwait(false);
+                await WhenAsync().ConfigureAwait(false);
             }
             catch (Exception ex) when (_recordThrownExceptions)
             {
@@ -45,7 +45,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             LoggerFactory = Substitute.For<ILoggerFactory>();
         }
 
-        protected abstract Task WhenAction();
+        protected abstract Task WhenAsync();
 
         private JustSaying.JustSayingBus CreateSystemUnderTest()
         {

--- a/JustSaying.UnitTests/JustSayingBus/GivenAServiceBusWithoutMonitoring.cs
+++ b/JustSaying.UnitTests/JustSayingBus/GivenAServiceBusWithoutMonitoring.cs
@@ -17,7 +17,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             Given();
 
             SystemUnderTest = CreateSystemUnderTest();
-            await WhenAction().ConfigureAwait(false);
+            await WhenAsync().ConfigureAwait(false);
         }
 
 
@@ -32,7 +32,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             LoggerFactory = Substitute.For<ILoggerFactory>();
         }
 
-        protected abstract Task WhenAction();
+        protected abstract Task WhenAsync();
 
         private JustSaying.JustSayingBus CreateSystemUnderTest()
         {

--- a/JustSaying.UnitTests/JustSayingBus/WhenAddingAPublisherWithNoTopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenAddingAPublisherWithNoTopic.cs
@@ -14,7 +14,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             SystemUnderTest.AddMessagePublisher<SimpleMessage>(Substitute.For<IMessagePublisher>(), string.Empty);
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingFails.cs
@@ -27,7 +27,7 @@ namespace JustSaying.UnitTests.JustSayingBus
                 .Do(x => { throw new TestException("Thrown by test WhenPublishingFails"); });
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessagePublisher<SimpleMessage>(_publisher, string.Empty);
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessageWithoutMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessageWithoutMonitor.cs
@@ -12,7 +12,7 @@ namespace JustSaying.UnitTests.JustSayingBus
     {
         private readonly IMessagePublisher _publisher = Substitute.For<IMessagePublisher>();
         
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessagePublisher<SimpleMessage>(_publisher, string.Empty);
             await SystemUnderTest.PublishAsync(new SimpleMessage());

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingMessages.cs
@@ -13,7 +13,7 @@ namespace JustSaying.UnitTests.JustSayingBus
     {
         private readonly IMessagePublisher _publisher = Substitute.For<IMessagePublisher>();
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessagePublisher<SimpleMessage>(_publisher, string.Empty);
 

--- a/JustSaying.UnitTests/JustSayingBus/WhenPublishingWithoutRegistering.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenPublishingWithoutRegistering.cs
@@ -16,7 +16,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(Substitute.For<Message>());
         }

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringMessageHandlers.cs
@@ -28,7 +28,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             _region = "west-1";
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             SystemUnderTest.AddNotificationSubscriber(_region, _subscriber);
             SystemUnderTest.AddNotificationSubscriber(_region, _subscriber);

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             _publisher = Substitute.For<IMessagePublisher>();
         }
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             SystemUnderTest.AddMessagePublisher<OrderAccepted>(_publisher, string.Empty);
             SystemUnderTest.AddMessagePublisher<OrderRejected>(_publisher, string.Empty);

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringSubscribers.cs
@@ -30,7 +30,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             _subscriber2.Subscribers.Returns(new Collection<ISubscriber> {new Subscriber(typeof (SimpleMessage))});
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber1);
             SystemUnderTest.AddNotificationSubscriber("region1", _subscriber2);

--- a/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
@@ -19,7 +19,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             SystemUnderTest.AddMessagePublisher<Message>(_publisher, string.Empty);
             SystemUnderTest.AddMessagePublisher<Message>(_publisher, string.Empty);

--- a/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenSubscribingAndNotPassingATopic.cs
@@ -13,7 +13,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             RecordAnyExceptionsThrown();
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             SystemUnderTest.AddNotificationSubscriber(" ", null);
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/JustSayingBus/WhenUsingMultipleRegions.cs
+++ b/JustSaying.UnitTests/JustSayingBus/WhenUsingMultipleRegions.cs
@@ -15,7 +15,7 @@ namespace JustSaying.UnitTests.JustSayingBus
             Config.Regions.Returns(new List<string>{"region1", "region2"});
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             return Task.CompletedTask;
         }

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -16,7 +16,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         private readonly IHandlerAsync<Message> _handler = Substitute.For<IHandlerAsync<Message>>();
         private object _response;
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerForAGenericMessage.cs
@@ -19,7 +19,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         private readonly IHandlerAsync<JustSayingMessage<MyMessage>> _handler = Substitute.For<IHandlerAsync<JustSayingMessage<MyMessage>>>();
         private object _response;
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             _response = SystemUnderTest
                 .WithSqsTopicSubscriber()

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandlerWithoutCustomConfig.cs
@@ -12,7 +12,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         private IFluentSubscription _bus;
 
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             _bus = SystemUnderTest
                 .WithSqsTopicSubscriber()

--- a/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -16,7 +16,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         private readonly IHandlerAsync<Message> _handler = Substitute.For<IHandlerAsync<Message>>();
         private object _response;
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             _response = SystemUnderTest
                 .WithSqsPointToPointSubscriber()

--- a/JustSaying.UnitTests/JustSayingFluently/AddingMonitoring/WhenAddingACustomMonitor.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/AddingMonitoring/WhenAddingACustomMonitor.cs
@@ -10,7 +10,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingMonitoring
     {
         readonly IMessageMonitor _monitor = Substitute.For<IMessageMonitor>();
         private object _response;
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             _response = SystemUnderTest.WithMonitoring(_monitor);
             return Task.CompletedTask;

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenConfigIsValid.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenConfigIsValid.cs
@@ -17,7 +17,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
             RecordAnyExceptionsThrown();
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             CreateMeABus
                 .WithLogging(new LoggerFactory())

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenNoRegionIsProvided.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
             RecordAnyExceptionsThrown();
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             CreateMeABus
                 .WithLogging(new LoggerFactory())

--- a/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenRegionIsDuplicated.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/ConfigValidation/WhenRegionIsDuplicated.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.ConfigValidation
             RecordAnyExceptionsThrown();
         }
 
-        protected override Task WhenAction()
+        protected override Task WhenAsync()
         {
             CreateMeABus
                 .WithLogging(new LoggerFactory())

--- a/JustSaying.UnitTests/JustSayingFluently/Publishing/WhenPublishing.cs
+++ b/JustSaying.UnitTests/JustSayingFluently/Publishing/WhenPublishing.cs
@@ -11,7 +11,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.Publishing
     {
         private readonly SimpleMessage _message = new SimpleMessage();
 
-        protected override async Task WhenAction()
+        protected override async Task WhenAsync()
         {
             await SystemUnderTest.PublishAsync(_message);
         }

--- a/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
+++ b/JustSaying.UnitTests/JustSayingFluentlyTestBase.cs
@@ -67,7 +67,7 @@ namespace JustSaying.UnitTests
             try
             {
                 SystemUnderTest = CreateSystemUnderTest();
-                await WhenAction().ConfigureAwait(false);
+                await WhenAsync().ConfigureAwait(false);
             }
             catch (Exception ex) when (_recordThrownExceptions)
             {
@@ -80,7 +80,7 @@ namespace JustSaying.UnitTests
 
         }
 
-        protected abstract Task WhenAction();
+        protected abstract Task WhenAsync();
 
         public Task DisposeAsync()
         {


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

In the unit tests, rename virtual methods called `When` to avoid `CA1716`.
private and not-virtual methods can be called "When", that's not a warning.

This is tidy-up after #504, #506, #507

_Please include a reference to a GitHub issue if appropriate._
