### PR TITLE
Add Code Coverage

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -130,9 +130,11 @@ function DotNetTest {
             -skipautoprops `
             `"-filter:+[JustSaying]* -[*Test*]*`"
 
-        & $dotnet $reportGeneratorPath `
+        & $dotnet `
+            $reportGeneratorPath `
             `"-reports:$coverageOutput`" `
             `"-targetdir:$reportOutput`" `
+            -reporttypes:HTML`;Cobertura `
             -verbosity:Warning
     }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -3,7 +3,7 @@ param(
     [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
     [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests,
-    [Parameter(Mandatory = $false)][switch] $EnableCodeCoverage,
+    [Parameter(Mandatory = $false)][switch] $DisableCodeCoverage,
     [Parameter(Mandatory = $false)][switch] $EnableIntegrationTests
 )
 
@@ -24,7 +24,7 @@ $testProjects = @(
 )
 
 if ($EnableIntegrationTests -eq $true) {
-  $testProjects += (Join-Path $solutionPath "JustSaying.IntegrationTests\JustSaying.IntegrationTests.csproj");
+    $testProjects += (Join-Path $solutionPath "JustSaying.IntegrationTests\JustSaying.IntegrationTests.csproj");
 }
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
@@ -94,7 +94,7 @@ function DotNetPack {
 function DotNetTest {
     param([string]$Project)
 
-    if ($EnableCodeCoverage -eq $false) {
+    if ($DisableCodeCoverage -eq $true) {
         & $dotnet test $Project --output $OutputPath
     }
     else {
@@ -108,10 +108,10 @@ function DotNetTest {
 
         $nugetPath = Join-Path $env:USERPROFILE ".nuget\packages"
 
-        $openCoverVersion = "4.6.519"
+        $openCoverVersion = "4.7.922"
         $openCoverPath = Join-Path $nugetPath "OpenCover\$openCoverVersion\tools\OpenCover.Console.exe"
 
-        $reportGeneratorVersion = "4.0.4"
+        $reportGeneratorVersion = "4.0.11"
         $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\netcoreapp2.0\ReportGenerator.dll"
 
         $coverageOutput = Join-Path $OutputPath "code-coverage.xml"
@@ -121,13 +121,14 @@ function DotNetTest {
             `"-target:$dotnetPath`" `
             `"-targetargs:test $Project --output $OutputPath`" `
             -output:$coverageOutput `
+            `"-excludebyattribute:System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage*`" `
             -hideskipped:All `
             -mergebyhash `
             -mergeoutput `
             -oldstyle `
             -register:user `
             -skipautoprops `
-            `"-filter:+[JustSaying]* -[JustSaying.Tests]*`"
+            `"-filter:+[JustSaying]* -[*Test*]*`"
 
         & $dotnet $reportGeneratorPath `
             `"-reports:$coverageOutput`" `
@@ -149,7 +150,7 @@ ForEach ($libraryProject in $libraryProjects) {
 if (($null -ne $env:CI) -And ($EnableIntegrationTests -eq $true)) {
     & docker pull pafortin/goaws
     & docker run -d --name goaws -p 4100:4100 pafortin/goaws
-    $env:AWS_SERVICE_URL="http://localhost:4100"
+    $env:AWS_SERVICE_URL = "http://localhost:4100"
 }
 
 if ($SkipTests -eq $false) {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-    <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="4.0.4" PrivateAssets="All" />
+    <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.0.11" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/JustSaying.svg?maxAge=3600)](https://www.nuget.org/packages/JustSaying/)
 [![Gitter](https://img.shields.io/gitter/room/justeat/JustSaying.js.svg?maxAge=2592000)](https://gitter.im/justeat/JustSaying)
 
-[![Build status](https://ci.appveyor.com/api/projects/status/vha51pup5lcnesu3/branch/develop?svg=true)](https://ci.appveyor.com/project/justeattech/justsaying)
+[![Build status](https://ci.appveyor.com/api/projects/status/vha51pup5lcnesu3/branch/master?svg=true)](https://ci.appveyor.com/project/justeattech/justsaying)
 [![codecov](https://codecov.io/gh/justeat/JustSaying/branch/master/graph/badge.svg)](https://codecov.io/gh/justeat/JustSaying)
 
 A helpful library for publishing and consuming events / messages over SNS (SNS / SQS as a message bus).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # JustSaying
 
 [![NuGet](https://img.shields.io/nuget/v/JustSaying.svg?maxAge=3600)](https://www.nuget.org/packages/JustSaying/)
-[![Build status](https://ci.appveyor.com/api/projects/status/vha51pup5lcnesu3/branch/develop?svg=true)](https://ci.appveyor.com/project/justeattech/justsaying)
 [![Gitter](https://img.shields.io/gitter/room/justeat/JustSaying.js.svg?maxAge=2592000)](https://gitter.im/justeat/JustSaying)
+
+[![Build status](https://ci.appveyor.com/api/projects/status/vha51pup5lcnesu3/branch/develop?svg=true)](https://ci.appveyor.com/project/justeattech/justsaying)
+[![codecov](https://codecov.io/gh/justeat/JustSaying/branch/master/graph/badge.svg)](https://codecov.io/gh/justeat/JustSaying)
 
 A helpful library for publishing and consuming events / messages over SNS (SNS / SQS as a message bus).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,11 @@ install:
 build_script:
   - ps: .\Build.ps1
 
+after_build:
+    - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+    - pip install codecov
+    - codecov -f "artifacts\code-coverage.xml"
+
 nuget:
   disable_publish_on_pr: true
 


### PR DESCRIPTION
  * Collect code coverage (on Windows) using OpenCover and report it to codecov.io now that .NET Core portable PDBs are supported in v4.7.
  * Update ReportGenerator to the latest release.
