### PR TITLE
[WIP] Unit tests with the new fluent api

### DIFF
--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/JustSaying/MessagingBusBuilder.cs
+++ b/JustSaying/MessagingBusBuilder.cs
@@ -312,10 +312,16 @@ namespace JustSaying
             return ServicesBuilder?.MessageSerializationFactory?.Invoke() ?? ServiceResolver.ResolveService<IMessageSerializationFactory>();
         }
 
+        private IVerifyAmazonQueues CreateAmazonQueueVerifier(ILoggerFactory loggerFactory, IAwsClientFactoryProxy proxy)
+        {
+            return ServiceResolver.ResolveService<IVerifyAmazonQueues>() ??
+                   new AmazonQueueCreator(proxy, loggerFactory);
+        }
+
         private JustSayingFluently CreateFluent(JustSayingBus bus, ILoggerFactory loggerFactory)
         {
             IAwsClientFactoryProxy proxy = CreateFactoryProxy();
-            IVerifyAmazonQueues queueCreator = new AmazonQueueCreator(proxy, loggerFactory);
+            IVerifyAmazonQueues queueCreator = CreateAmazonQueueVerifier(loggerFactory, proxy); ;
 
             var fluent = new JustSayingFluently(bus, queueCreator, proxy, loggerFactory);
 


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Work towards deprecating the old fluent api and using the new one instead. Trying to port a unit test by building a base class `UnitTestBase` to replace `JustSayingFluentlyTestBase`.

I found that the `IVerifyAmazonQueues` instance needs to be injectable.

The tests in `WhenAddingASubscriptionHandler` that are commented out depend on verifying against a mock `IAmJustSaying Bus`. 

What equivalent should be mocked, if any? Do these tests still make sense? 

_Please include a reference to a GitHub issue if appropriate._
