### PR TITLE
Add anonymous credentials method

### DIFF
--- a/JustSaying.IntegrationTests/Fluent/Subscribing/WhenReceivingIsThrottled.cs
+++ b/JustSaying.IntegrationTests/Fluent/Subscribing/WhenReceivingIsThrottled.cs
@@ -38,6 +38,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
         {
             // Arrange
             var services = GivenJustSaying()
+                .ConfigureJustSaying((builder) => builder.Client((client) => client.WithAnonymousCredentials()))
                 .ConfigureJustSaying((builder) => builder.Messaging((options) => options.WithPublishFailureBackoff(TimeSpan.FromMilliseconds(1))))
                 .ConfigureJustSaying((builder) => builder.Publications((options) => options.WithQueue<SimpleMessage>(UniqueName)))
                 .ConfigureJustSaying(

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.31.12" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.23" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.59" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.31.12" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3.23" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.59" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/JustSaying/Fluent/AwsClientFactoryBuilder.cs
+++ b/JustSaying/Fluent/AwsClientFactoryBuilder.cs
@@ -92,6 +92,18 @@ namespace JustSaying.Fluent
         }
 
         /// <summary>
+        /// Specifies that anonymous access to AWS should be used.
+        /// </summary>
+        /// <returns>
+        /// The current <see cref="AwsClientFactoryBuilder"/>.
+        /// </returns>
+        public AwsClientFactoryBuilder WithAnonymousCredentials()
+        {
+            Credentials = new AnonymousAWSCredentials();
+            return this;
+        }
+
+        /// <summary>
         /// Specifies the basic AWS credentials to use.
         /// </summary>
         /// <param name="accessKey">The access key to use.</param>


### PR DESCRIPTION
While reviewing #527 I found that without a local profile setup, even when using the goaws with the service URI specified, the AWS SDK still tries to contact the STS service on localhost to get an access token. This then fails as nothing is listening and JustSaying then doesn't start-up.

To prevent this, this PR adds a `WithAnonymousCredentials()` method so you can explicitly set _some_ credentials for the SDK to use without having to explicitly actually provide some fake ones that won't work and aren't otherwise needed.

```csharp
services.AddJustSaying(builder =>
{
    builder.Client(client =>
    {
        client.WithServiceUrl("http://localhost:4100")
              .WithAnonymousCredentials()
    })
});
```

Also updates to the latest AWS SDK in the _test_ projects.