### PR TITLE
Update the analysers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AnalyzersPackageVersion>2.6.3</AnalyzersPackageVersion>
+    <AnalyzersPackageVersion>2.9.1</AnalyzersPackageVersion>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
+using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.AwsTools.MessageHandling;
@@ -153,7 +154,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             {
                 base.Given();
                 _messageBackoffStrategy.GetBackoffDuration(_typedMessage, Arg.Any<int>()).Returns(TimeSpan.FromMinutes(4));
-                _amazonSqsClient.ChangeMessageVisibilityAsync(Arg.Any<ChangeMessageVisibilityRequest>()).Throws(new Exception("Something gone wrong"));
+                _amazonSqsClient.ChangeMessageVisibilityAsync(Arg.Any<ChangeMessageVisibilityRequest>()).Throws(new AmazonServiceException("Something gone wrong"));
 
                 _handlerMap.Add(typeof(OrderAccepted), m => Task.FromResult(false));
                 _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, "1");

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeHandled.cs
@@ -52,7 +52,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 
         private static Task<PublishResponse> ThrowsException(CallInfo callInfo)
         {
-            throw new WebException("Operation timed out", WebExceptionStatus.Timeout);
+            throw new InternalErrorException("Operation timed out");
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -12,6 +12,7 @@ using NSubstitute;
 using NSubstitute.Core;
 using Shouldly;
 using Xunit;
+using Amazon.Runtime;
 
 namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 {
@@ -56,7 +57,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
             {
                 await SystemUnderTest.PublishAsync(new SimpleMessage());
             }
-            catch (Exception e)
+            catch (AmazonServiceException e)
             {
                 var exception = (WebException) e.InnerException;
                 exception.Status.ShouldBe(WebExceptionStatus.Timeout);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -57,16 +57,16 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
             {
                 await SystemUnderTest.PublishAsync(new SimpleMessage());
             }
-            catch (AmazonServiceException e)
+            catch (PublishException ex)
             {
-                var exception = (WebException) e.InnerException;
-                exception.Status.ShouldBe(WebExceptionStatus.Timeout);
+                var inner = ex.InnerException as AmazonServiceException;
+                inner.ShouldNotBeNull();
             }
         }
 
         private static Task<PublishResponse> ThrowsException(CallInfo callInfo)
         {
-            throw new WebException("Operation timed out", WebExceptionStatus.Timeout);
+            throw new AmazonServiceException("Operation timed out");
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncExceptionCanBeThrown.cs
@@ -61,6 +61,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
             {
                 var inner = ex.InnerException as AmazonServiceException;
                 inner.ShouldNotBeNull();
+                inner.Message.ShouldBe("Operation timed out");
             }
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenPublishingAsyncWithGenericMessageSubjectProvider.cs
@@ -13,7 +13,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.TopicByName
 {
     public class WhenPublishingAsyncWithGenericMessageSubjectProvider : WhenPublishingTestBase
     {
-        public class MessageWithTypeParameters<T, U> : Message
+        public class MessageWithTypeParameters<TA, TB> : Message
         {
         }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -113,7 +113,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             doneOk.ShouldBeTrue("Timeout occured before done signal");
         }
 
-        protected ReceiveMessageResponse GenerateResponseMessage(string messageType, Guid messageId)
+        protected static ReceiveMessageResponse GenerateResponseMessage(string messageType, Guid messageId)
         {
             return new ReceiveMessageResponse
             {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -90,7 +90,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             _callCount.ShouldBeGreaterThanOrEqualTo(3);
         }
 
-        private ReceiveMessageResponse GenerateEmptyMessage()
+        private static ReceiveMessageResponse GenerateEmptyMessage()
         {
             return new ReceiveMessageResponse
             {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
@@ -79,7 +79,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             _callCount.ShouldBeGreaterThan(3);
         }
 
-        private ReceiveMessageResponse GenerateEmptyMessage()
+        private static ReceiveMessageResponse GenerateEmptyMessage()
         {
             return new ReceiveMessageResponse { Messages = new List<Message>() };
         }

--- a/JustSaying/AwsTools/MessageHandling/LocalTopicArnProvider.cs
+++ b/JustSaying/AwsTools/MessageHandling/LocalTopicArnProvider.cs
@@ -26,7 +26,9 @@ namespace JustSaying.AwsTools.MessageHandling
                 _exists = true;
                 return topic.TopicArn;
             }
+#pragma warning disable CA1031
             catch
+#pragma warning restore CA1031
             {
                 // ignored
             }

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.Messaging.MessageHandling;
@@ -66,7 +67,9 @@ namespace JustSaying.AwsTools.MessageHandling
                 _onError(ex, message);
                 return;
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _logger.LogError(0, ex, "Error deserializing message with Id '{MessageId}' and body '{MessageBody}'.",
                     message.MessageId, message.Body);
@@ -91,7 +94,9 @@ namespace JustSaying.AwsTools.MessageHandling
                     await DeleteMessageFromQueue(message.ReceiptHandle).ConfigureAwait(false);
                 }
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 _logger.LogError(0, ex, "Error handling message with Id '{MessageId}' and body '{MessageBody}'.",
                     message.MessageId, message.Body);
@@ -166,7 +171,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
                     await _queue.Client.ChangeMessageVisibilityAsync(visibilityRequest).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (AmazonServiceException ex)
                 {
                     _logger.LogError(0, ex, "Failed to update message visibility timeout by {VisibilityTimeout} seconds.", visibilityTimeoutSeconds);
                     _onError(ex, message);

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -160,15 +160,15 @@ namespace JustSaying.AwsTools.MessageHandling
                 var visibilityTimeout = _messageBackoffStrategy.GetBackoffDuration(typedMessage, approxReceiveCount, lastException);
                 var visibilityTimeoutSeconds = (int)visibilityTimeout.TotalSeconds;
 
+                var visibilityRequest = new ChangeMessageVisibilityRequest
+                {
+                    QueueUrl = _queue.Uri.AbsoluteUri,
+                    ReceiptHandle = receiptHandle,
+                    VisibilityTimeout = visibilityTimeoutSeconds
+                };
+
                 try
                 {
-                    var visibilityRequest = new ChangeMessageVisibilityRequest
-                    {
-                        QueueUrl = _queue.Uri.AbsoluteUri,
-                        ReceiptHandle = receiptHandle,
-                        VisibilityTimeout = visibilityTimeoutSeconds
-                    };
-
                     await _queue.Client.ChangeMessageVisibilityAsync(visibilityRequest).ConfigureAwait(false);
                 }
                 catch (AmazonServiceException ex)

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using JustSaying.AwsTools.QueueCreation;
@@ -73,7 +74,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     MessageResponseLogger.Invoke(responseData, message);
                 }
             }
-            catch (Exception ex)
+            catch (AmazonServiceException ex)
             {
                 if (!ClientExceptionHandler(ex, message))
                 {

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -53,26 +53,10 @@ namespace JustSaying.AwsTools.MessageHandling
         public async Task PublishAsync(Message message, PublishMetadata metadata, CancellationToken cancellationToken)
         {
             var request = BuildPublishRequest(message, metadata);
-
+            PublishResponse response =null;
             try
             {
-                var response = await Client.PublishAsync(request, cancellationToken).ConfigureAwait(false);
-
-                _logger.LogInformation(
-                    "Published message with subject '{MessageSubject}' and content '{MessageBody}'.",
-                    request.Subject,
-                    request.Message);
-
-                if (MessageResponseLogger != null)
-                {
-                    var responseData = new MessageResponse
-                    {
-                        HttpStatusCode = response?.HttpStatusCode,
-                        MessageId = response?.MessageId,
-                        ResponseMetadata = response?.ResponseMetadata
-                    };
-                    MessageResponseLogger.Invoke(responseData, message);
-                }
+                response = await Client.PublishAsync(request, cancellationToken).ConfigureAwait(false);
             }
             catch (AmazonServiceException ex)
             {
@@ -83,6 +67,23 @@ namespace JustSaying.AwsTools.MessageHandling
                         ex);
                 }
             }
+
+            _logger.LogInformation(
+                "Published message with subject '{MessageSubject}' and content '{MessageBody}'.",
+                request.Subject,
+                request.Message);
+
+            if (MessageResponseLogger != null)
+            {
+                var responseData = new MessageResponse
+                {
+                    HttpStatusCode = response?.HttpStatusCode,
+                    MessageId = response?.MessageId,
+                    ResponseMetadata = response?.ResponseMetadata
+                };
+                MessageResponseLogger.Invoke(responseData, message);
+            }
+
         }
 
         private bool ClientExceptionHandler(Exception ex, Message message) => _snsWriteConfiguration?.HandleException?.Invoke(ex, message) ?? false;

--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -53,7 +53,7 @@ namespace JustSaying.AwsTools.MessageHandling
         public async Task PublishAsync(Message message, PublishMetadata metadata, CancellationToken cancellationToken)
         {
             var request = BuildPublishRequest(message, metadata);
-            PublishResponse response =null;
+            PublishResponse response = null;
             try
             {
                 response = await Client.PublishAsync(request, cancellationToken).ConfigureAwait(false);

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -140,7 +140,9 @@ namespace JustSaying.AwsTools.MessageHandling
                     _log.LogTrace(0, ex, "Suspected no message on queue '{QueueName}' in region '{Region}'.",
                         queueName, regionName);
                 }
+#pragma warning disable CA1031
                 catch (Exception ex)
+#pragma warning restore CA1031
                 {
                     _log.LogError(0, ex, "Error receiving messages on queue '{QueueName}' in region '{Region}'.",
                         queueName, regionName);
@@ -160,7 +162,9 @@ namespace JustSaying.AwsTools.MessageHandling
                         }
                     }
                 }
+#pragma warning disable CA1031
                 catch (Exception ex)
+#pragma warning restore CA1031
                 {
                     _log.LogError(0, ex, "Error in message handling loop for queue '{QueueName}' in region '{Region}'.",
                         queueName, regionName);

--- a/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
+using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.Messaging;
@@ -53,7 +54,7 @@ namespace JustSaying.AwsTools.MessageHandling
                     MessageResponseLogger.Invoke(responseData, message);
                 }
             }
-            catch (Exception ex)
+            catch (AmazonServiceException ex)
             {
                 throw new PublishException(
                     $"Failed to publish message to SQS. {nameof(request.QueueUrl)}: {request.QueueUrl},{nameof(request.MessageBody)}: {request.MessageBody}",

--- a/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -159,7 +159,7 @@ namespace JustSaying.AwsTools.MessageHandling
             return RedrivePolicy.ConvertFromString(queueAttributes[JustSayingConstants.AttributeRedrivePolicy]);
         }
 
-        private ServerSideEncryption ExtractServerSideEncryptionFromQueueAttributes(Dictionary<string, string> queueAttributes)
+        private static ServerSideEncryption ExtractServerSideEncryptionFromQueueAttributes(Dictionary<string, string> queueAttributes)
         {
             if (!queueAttributes.ContainsKey(JustSayingConstants.AttributeEncryptionKeyId))
             {


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Update the Roslyn code analysers
Remove `Text.Analyzers` as it is deprecated.

and deal with `CA1031`  - use specific exception types.
It looks like `AmazonServiceException` is a useful base class for exceptions from AWS

I'm happy to alter if people have different views on which base types should be caught where, and where to use the `#pragma` and a catch-all instead.

_Please include a reference to a GitHub issue if appropriate._
