### PR TITLE
[WIP] Short Circuit Retries on NonRetryableException

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -264,7 +264,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
         {
         }
 
-        public NonRetryableException()
+        public NonRetryableException() : base("msg")
         {
         }
     }

--- a/JustSaying/AwsTools/MessageHandling/INonRetryable.cs
+++ b/JustSaying/AwsTools/MessageHandling/INonRetryable.cs
@@ -1,0 +1,6 @@
+namespace JustSaying.AwsTools.MessageHandling
+{
+#pragma warning disable CA1040
+    public interface INonRetryable { }
+#pragma warning disable CA1040
+}

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -152,7 +152,7 @@ namespace JustSaying.AwsTools.MessageHandling
             if (_queue.ErrorQueue != null)
             {
                 var sendMessageRequest = new SendMessageRequest(_queue.ErrorQueue.Uri.AbsoluteUri, message.Body);
-                sendMessageResponse = await _queue.Client.SendMessageAsync(sendMessageRequest).ConfigureAwait(false);
+                sendMessageResponse = await _queue.ErrorQueue.Client.SendMessageAsync(sendMessageRequest).ConfigureAwait(false);
             }
 
             if (sendMessageResponse == null || sendMessageResponse.HttpStatusCode == HttpStatusCode.OK)

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -101,8 +101,9 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 if (!handlingSucceeded && ex is INonRetryable)
                 {
-                    await MoveMessageToErrorQueue(message).ConfigureAwait(false);
+                    await MoveMessageToErrorQueueAsync(message).ConfigureAwait(false);
                 }
+
                 _logger.LogError(0, ex, "Error handling message with Id '{MessageId}' and body '{MessageBody}'.",
                     message.MessageId, message.Body);
 
@@ -146,7 +147,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             return handlerSucceeded;
         }
-        private async Task MoveMessageToErrorQueue(SQSMessage message)
+        private async Task MoveMessageToErrorQueueAsync(SQSMessage message)
         {
             SendMessageResponse sendMessageResponse = null;
             if (_queue.ErrorQueue != null)
@@ -203,5 +204,4 @@ namespace JustSaying.AwsTools.MessageHandling
             return attributes.TryGetValue(MessageSystemAttributeName.ApproximateReceiveCount, out string rawApproxReceiveCount) && int.TryParse(rawApproxReceiveCount, out approxReceiveCount);
         }
     }
-
 }


### PR DESCRIPTION
_Changes this Pull Request makes._

This PR adds an interface INonRetryable that can be extended by any Message Handling Exceptions that should not result in any retries. 
If during handling the message a non transient error is detected the message will be moved to the error queue if it exists on the message dispatchers queue.
The message will be deleted from the default queue if there is no error queue or if the response to moving to the error queue is successful. 
If there is an error queue and the re-queue is not successful the message is allowed to either return to the default queue or be driven to the error queue as part of the re-drive behaviour. This is to try and and ensure that as far as possible messages are not dropped. 

There are tests to support the behaviour. 

_reference to a GitHub issue_
https://github.com/justeat/JustSaying/issues/543

Tests requiring AWS simulator URL not run locally.
