### PR TITLE
Improve throttled processing strategy

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -8,7 +8,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingBeforeMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int MaxWorkers => int.MaxValue;
+        public int MaxConcurrency => int.MaxValue;
 
         public int AvailableWorkers
         {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -31,19 +31,20 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public Task WaitForAvailableWorkers()
+        public Task<int> WaitForAvailableWorkerAsync()
         {
             if (_firstTime)
             {
                 _firstTime = false;
                 Fail();
             }
-            return Task.FromResult(true);
+
+            return Task.FromResult(1);
         }
 
-        public Task StartWorker(Func<Task> action, CancellationToken cancellationToken)
+        public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
         private void Fail()
@@ -51,6 +52,5 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             TaskHelpers.DelaySendDone(_doneSignal);
             throw new TestException("Thrown by test ProcessMessage");
         }
-
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -8,7 +8,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingDuringMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int MaxWorkers => int.MaxValue;
+        public int MaxConcurrency => int.MaxValue;
 
         private readonly TaskCompletionSource<object> _doneSignal;
         private bool _firstTime = true;
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 
         public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.FromResult(MaxWorkers);
+            return Task.FromResult(MaxConcurrency);
         }
 
         public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -20,12 +20,12 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public Task WaitForAvailableWorkers()
+        public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.CompletedTask;
+            return Task.FromResult(AvailableWorkers);
         }
 
-        public Task StartWorker(Func<Task> action, CancellationToken cancellationToken)
+        public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)
         {
             if (_firstTime)
             {
@@ -33,14 +33,13 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
                 return Fail();
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
-        private Task Fail()
+        private Task<bool> Fail()
         {
             TaskHelpers.DelaySendDone(_doneSignal);
             throw new TestException("Thrown by test ProcessMessage");
         }
-
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -10,8 +10,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
     {
         public int MaxWorkers => int.MaxValue;
 
-        public int AvailableWorkers => int.MaxValue;
-
         private readonly TaskCompletionSource<object> _doneSignal;
         private bool _firstTime = true;
 
@@ -22,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 
         public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.FromResult(AvailableWorkers);
+            return Task.FromResult(MaxWorkers);
         }
 
         public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)

--- a/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
@@ -146,7 +146,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
 
             while (actions.Any())
             {
-                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.AvailableWorkers);
+                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.MaxWorkers);
 
                 if (batch.Count < 1)
                 {
@@ -158,10 +158,10 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                     (await messageProcessingStrategy.StartWorkerAsync(action, CancellationToken.None)).ShouldBeTrue();
                 }
 
-                messageProcessingStrategy.AvailableWorkers.ShouldBeGreaterThanOrEqualTo(0);
+                messageProcessingStrategy.MaxWorkers.ShouldBeGreaterThanOrEqualTo(0);
 
                 (await messageProcessingStrategy.WaitForAvailableWorkerAsync()).ShouldBeGreaterThan(0);
-                messageProcessingStrategy.AvailableWorkers.ShouldBeGreaterThan(0);
+                messageProcessingStrategy.MaxWorkers.ShouldBeGreaterThan(0);
 
                 stopwatch.Elapsed.ShouldBeLessThanOrEqualTo((timeout * 3),
                     $"ListenLoopExecuted took longer than timeout of {timeout}, with {actions.Count} of {initalActionCount} messages remaining.");

--- a/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
@@ -38,7 +38,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
         [InlineData(2, 20)]
         [InlineData(10, 20)]
         [InlineData(20, 20)]
-        public async Task SimulatedListenLoop_ProcessedAllMessages_With_Thread_Pool(
+        public async Task SimulatedListenLoop_ProcessedAllMessages_In_Parallel(
             int numberOfMessagesToProcess,
             int concurrency)
         {
@@ -48,7 +48,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = Substitute.For<ILogger>(),
                 MessageMonitor = Substitute.For<IMessageMonitor>(),
                 StartTimeout = StartTimeout,
-                UseThreadPool = true,
+                ProcessMessagesSequentially = false,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -71,7 +71,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
         [InlineData(2, 20)]
         [InlineData(10, 20)]
         [InlineData(20, 20)]
-        public async Task SimulatedListenLoop_ProcessedAllMessages_Without_Thread_Pool(
+        public async Task SimulatedListenLoop_ProcessedAllMessages_Sequentially(
             int numberOfMessagesToProcess,
             int concurrency)
         {
@@ -81,7 +81,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = Substitute.For<ILogger>(),
                 MessageMonitor = Substitute.For<IMessageMonitor>(),
                 StartTimeout = StartTimeout,
-                UseThreadPool = false,
+                ProcessMessagesSequentially = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -119,7 +119,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = Substitute.For<ILogger>(),
                 MessageMonitor = fakeMonitor,
                 StartTimeout = TimeSpan.FromTicks(1),
-                UseThreadPool = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -169,7 +168,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = Substitute.For<ILogger>(),
                 MessageMonitor = fakeMonitor,
                 StartTimeout = Timeout.InfiniteTimeSpan,
-                UseThreadPool = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -196,7 +194,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = Substitute.For<ILogger>(),
                 MessageMonitor = fakeMonitor,
                 StartTimeout = Timeout.InfiniteTimeSpan,
-                UseThreadPool = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);

--- a/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/ThrottledTests.cs
+++ b/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/ThrottledTests.cs
@@ -31,7 +31,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             // Act
@@ -51,7 +50,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             // Act
@@ -71,7 +69,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -96,7 +93,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -120,7 +116,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             var messageProcessingStrategy = new Throttled(options);
@@ -148,7 +143,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             const int capacity = 10;
@@ -177,7 +171,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             const int capacity = 10;
@@ -208,7 +201,6 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                 Logger = _logger,
                 MessageMonitor = _monitor,
                 StartTimeout = TimeSpan.FromSeconds(5),
-                UseThreadPool = true,
             };
 
             const int capacity = 10;

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -290,7 +290,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 await _messageDispatcher.DispatchMessage(message, ct);
             }
 
-            return _messageProcessingStrategy.StartWorker(DispatchAsync, ct);
+            return _messageProcessingStrategy.StartWorkerAsync(DispatchAsync, ct);
         }
 
         public ICollection<ISubscriber> Subscribers { get; }

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -80,7 +80,6 @@ namespace JustSaying.AwsTools.MessageHandling
                 StartTimeout = startTimeout ?? Timeout.InfiniteTimeSpan,
                 Logger = _log,
                 MessageMonitor = _messagingMonitor,
-                UseThreadPool = true,
             };
 
             _messageProcessingStrategy = new Throttled(options);

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -74,11 +74,16 @@ namespace JustSaying.AwsTools.MessageHandling
             int maximumAllowedMesagesInFlight,
             TimeSpan? startTimeout = null)
         {
-            _messageProcessingStrategy = new Throttled(
-                maximumAllowedMesagesInFlight,
-                startTimeout ?? Timeout.InfiniteTimeSpan,
-                _messagingMonitor,
-                _log);
+            var options = new ThrottledOptions()
+            {
+                MaxConcurrency = maximumAllowedMesagesInFlight,
+                StartTimeout = startTimeout ?? Timeout.InfiniteTimeSpan,
+                Logger = _log,
+                MessageMonitor = _messagingMonitor,
+                UseThreadPool = true,
+            };
+
+            _messageProcessingStrategy = new Throttled(options);
 
             return this;
         }
@@ -258,7 +263,7 @@ namespace JustSaying.AwsTools.MessageHandling
         private async Task<int> GetDesiredNumberOfMessagesToRequestFromSqsAsync()
         {
             int maximumMessagesFromAws = MessageConstants.MaxAmazonMessageCap;
-            int maximumWorkers = _messageProcessingStrategy.MaxWorkers;
+            int maximumWorkers = _messageProcessingStrategy.MaxConcurrency;
 
             int messagesToRequest = Math.Min(maximumWorkers, maximumMessagesFromAws);
 

--- a/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
@@ -5,14 +5,40 @@ using Microsoft.Extensions.Logging;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
+    /// <summary>
+    /// A class representing the default implementation of <see cref="Throttled"/>.
+    /// </summary>
     public class DefaultThrottledThroughput : Throttled
     {
-        private static readonly int MaxActiveHandlersForProcessors =
-            Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultThrottledThroughput"/> class.
+        /// </summary>
+        /// <param name="options">The <see cref="ThrottledOptions"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="options"/> does not specify an <see cref="ILogger"/> or <see cref="IMessageMonitor"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The concurrency specified by <paramref name="options"/> is less than one,
+        /// or the start timeout specified by <paramref name="options"/> is zero or negative.
+        /// </exception>
         public DefaultThrottledThroughput(IMessageMonitor messageMonitor, ILogger logger)
-            : base(MaxActiveHandlersForProcessors, Timeout.InfiniteTimeSpan, messageMonitor, logger)
+            : base(CreateOptions(messageMonitor, logger))
         {
+        }
+
+        private static ThrottledOptions CreateOptions(IMessageMonitor messageMonitor, ILogger logger)
+        {
+            return new ThrottledOptions()
+            {
+                MaxConcurrency = Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore,
+                Logger = logger,
+                MessageMonitor = messageMonitor,
+                StartTimeout = Timeout.InfiniteTimeSpan,
+                UseThreadPool = true,
+            };
         }
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
@@ -37,7 +37,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
                 Logger = logger,
                 MessageMonitor = messageMonitor,
                 StartTimeout = Timeout.InfiniteTimeSpan,
-                UseThreadPool = true,
+                ProcessMessagesSequentially = false,
             };
         }
     }

--- a/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
@@ -1,17 +1,18 @@
-﻿using System;
+using System;
+using System.Threading;
 using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public class DefaultThrottledThroughput : Throttled
     {
-        public DefaultThrottledThroughput(IMessageMonitor messageMonitor) :
-            base(MaxActiveHandlersForProcessors(), messageMonitor)
+        private static readonly int MaxActiveHandlersForProcessors =
+            Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
+
+        public DefaultThrottledThroughput(IMessageMonitor messageMonitor, ILogger logger)
+            : base(MaxActiveHandlersForProcessors, Timeout.InfiniteTimeSpan, messageMonitor, logger)
         {
-
         }
-
-        private static int MaxActiveHandlersForProcessors()
-            => Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -1,39 +1,47 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
+    /// <summary>
+    /// Defines a strategy for processing messages asynchronously.
+    /// </summary>
     public interface IMessageProcessingStrategy
     {
         /// <summary>
-        /// The maximum number of worker tasks that will be used to run messages handlers at any one time
+        /// Gets the maximum number of workers that can be used to process messages concurrently.
         /// </summary>
         int MaxWorkers { get; }
 
         /// <summary>
-        /// The number of worker tasks that are free to run messages handlers right now,
-        /// Always in the range 0 to MaxWorkers
-        /// the number of currently running workers will be = (MaxWorkers - AvailableWorkers)
+        /// Gets the number of workers that are available to process messages.
         /// </summary>
         int AvailableWorkers { get; }
 
         /// <summary>
-        /// Launch a worker to start processing a message.
+        /// Starts a worker task to process a message as an asynchronous operation.
         /// </summary>
-        /// <param name="action"></param>
+        /// <param name="action">A delegate to a method that processes the message.</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation of queuing <paramref name="action"/>,
-        /// including waiting for a worker to become available.
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation of queueing <paramref name="action"/>,
+        /// including waiting for a worker to become available. If the task returns <see cref="false"/>
+        /// an available worker was not available and the action was not queued to be run.
         /// </returns>
-        Task StartWorker(Func<Task> action, CancellationToken cancellationToken);
+        Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken);
 
         /// <summary>
-        /// After awaiting this, you should be in a position to start another worker
-        /// i.e. AvailableWorkers should be above 0
+        /// Attempts to wait for a available worker as an asynchronous operation.
         /// </summary>
-        /// <returns></returns>
-        Task WaitForAvailableWorkers();
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to wait for an
+        /// available worker which returns the current number of available workers.
+        /// </returns>
+        /// <remarks>
+        /// The task returned by this method completing does not guarantee that a worker
+        /// will be available immediately when <see cref="StartWorkerAsync"/> is subsequently called.
+        /// </remarks>
+        Task<int> WaitForAvailableWorkerAsync();
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -10,9 +10,9 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
     public interface IMessageProcessingStrategy
     {
         /// <summary>
-        /// Gets the maximum number of workers that can be used to process messages concurrently.
+        /// Gets the maximum number of messages that can be processed concurrently.
         /// </summary>
-        int MaxWorkers { get; }
+        int MaxConcurrency { get; }
 
         /// <summary>
         /// Starts a worker task to process a message as an asynchronous operation.

--- a/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -15,11 +15,6 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         int MaxWorkers { get; }
 
         /// <summary>
-        /// Gets the number of workers that are available to process messages.
-        /// </summary>
-        int AvailableWorkers { get; }
-
-        /// <summary>
         /// Starts a worker task to process a message as an asynchronous operation.
         /// </summary>
         /// <param name="action">A delegate to a method that processes the message.</param>

--- a/JustSaying/Messaging/MessageProcessingStrategies/ThrottledOptions.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/ThrottledOptions.cs
@@ -15,10 +15,13 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         public int MaxConcurrency { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to process messages by dispatching
-        /// them to the thread pool or whether to process messages before returning.
+        /// Gets or sets a value indicating whether to process messages sequentially
+        /// instead of dispatching them to the thread pool to process in parallel.
         /// </summary>
-        public bool UseThreadPool { get; set; }
+        /// <remarks>
+        /// By default, batches of received messages are processed in parallel.
+        /// </remarks>
+        public bool ProcessMessagesSequentially { get; set; }
 
         /// <summary>
         /// Gets or sets the timeout for starting to process a message.

--- a/JustSaying/Messaging/MessageProcessingStrategies/ThrottledOptions.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/ThrottledOptions.cs
@@ -1,0 +1,38 @@
+using System;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.Messaging.MessageProcessingStrategies
+{
+    /// <summary>
+    /// A class representing options for the <see cref="Throttled"/> class.
+    /// </summary>
+    public class ThrottledOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of messages to process concurrently.
+        /// </summary>
+        public int MaxConcurrency { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process messages by dispatching
+        /// them to the thread pool or whether to process messages before returning.
+        /// </summary>
+        public bool UseThreadPool { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout for starting to process a message.
+        /// </summary>
+        public TimeSpan StartTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IMessageMonitor"/> to use.
+        /// </summary>
+        public IMessageMonitor MessageMonitor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ILogger"/> to use.
+        /// </summary>
+        public ILogger Logger { get; set; }
+    }
+}


### PR DESCRIPTION
_**TL;DR** In high throughput scenarios, the `Throttled` class' implementation causes `Task` backlogs that consume CPU and memory that cannot be recovered when message rates drop off._

This PR attempts to improve the behaviour of the `Throttled` implementation to use the async methods on the `SemaphoreSlim` class rather than wrap wait handles in tasks and manually queue to the thread pool.

Also makes changes to consider the fact that code using the processing strategy can race and think there are available workers but then there not be any available when it attempts to process the message.

This last point in particular needs some thought and discussion, as the implementation seems quite baked into that fact, so seems to just be asking for race conditions in retrospect.

The implementation does not appear to take into account that reads of the "free workers" value is non-atomic with respect to the time it takes to request messages from SQS and start to process them.

## Details

These changes stem from a production issue where a worker that processes a single SQS queue was migrated from .NET Framework 4.7.2 to .NET Core 2.2.5. This change was canary'd on a single EC2 instance for ~24 hours on a queue that has a _particularly_ high message throughput rate.

Below are the CPU and memory consumption for a 24 hour period where the code using JustSaying 6.0.1 is in use:

![image](https://user-images.githubusercontent.com/1439341/59865829-f317d380-9381-11e9-92b8-cf1a814b2084.png)

As can be seen, there is a slow memory leak in the service, as well as an increasing CPU usage from approximately 5pm which climbs up to ~50% by 9pm which never recovers even when messages being delivered drops off to near zero, as shown below.

![image](https://user-images.githubusercontent.com/1439341/59865961-4722b800-9382-11e9-9662-5c12ed832d31.png)

There was otherwise no obvious signs of the worker being in distress, apart from the memory and CPU. The mean time to process messages in the canary was actually more consistent and messages where being handled faster than the .NET Framework version:

![image](https://user-images.githubusercontent.com/1439341/59866118-a7b1f500-9382-11e9-8fdb-a64608f7aa66.png)

Capturing a process dump from the canary showed that there were _hundreds_ of tasks scheduled to be run with various stacks and start points, suggesting the thread pool was reaching its limits.

Some sniffing around in the code lead to looking at the `Throttled` class for performance bottlenecks, as the application is small and only consumes one queue with a single handler and makes a HTTP call to an external service based on the contents of the message, so is quite simple and lightweight.

Digging into the history leads to some refactoring in #440, but that was merged to master after 6.0.1 was released to NuGet, with no significant changes in the rest of the commit history (as far back as 5th April 2017, it's hard to look before that due to renaming).

My working hunch is that the processing rate improved to a degree that the throttling became the bottleneck, and tasks to process messages were backing up due to the indefinite wait for the semaphore here:

https://github.com/justeat/JustSaying/blob/88f241c8a6bcb5768e2d57fae4aef906aacad53a/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs#L26

The attached refactoring is based on changes made directly to the application yesterday which was tested overnight last night to test the hypothesis (as well as increase the throttle factor from 8 to 16), which showed the same throughput improvements but without the CPU or memory issues. In fact, the CPU used is now less that the .NET Framework version in general.

Below are the comparison charts to the above with the fix. The CPU is the lowest orange line (look near 8pm) and the memory is the lowest yellow line, showing that while slightly more memory is used, there's no leak.

![image](https://user-images.githubusercontent.com/1439341/59866564-c49af800-9383-11e9-8d4d-8ea9754b9d68.png)

![image](https://user-images.githubusercontent.com/1439341/59866641-0035c200-9384-11e9-9057-83246f49e174.png)
