### PR TITLE
[WIP] Switch to coverlet

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,9 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19324-01" PrivateAssets="All" />
-    <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
@@ -44,5 +44,13 @@
     <ComVisible>false</ComVisible>
     <DebugType>embedded</DebugType>
     <EmbedAllSources Condition=" '$(IsTestProject)' != 'true' AND '$(NCrunch)' == '' ">true</EmbedAllSources>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutput>$(OutputPath)\</CoverletOutput>
+    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <Exclude>[*.Benchmarks]*,[*Sample*]*,[*Test*]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+    <MergeWith>$(CoverletOutput)coverage.json</MergeWith>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build_script:
 after_build:
     - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
     - pip install codecov
-    - codecov -f "artifacts\code-coverage.xml"
+    - codecov -f "artifacts\coverage.cobertura.xml"
 
 nuget:
   disable_publish_on_pr: true

--- a/build.sh
+++ b/build.sh
@@ -25,5 +25,5 @@ dotnet build JustSaying/JustSaying.csproj --output $artifacts --configuration $c
 dotnet build JustSaying.Extensions.DependencyInjection.Microsoft/JustSaying.Extensions.DependencyInjection.Microsoft.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 dotnet build JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 
-dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj
-dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj --output $artifacts || exit 1
+dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj --output $artifacts || exit 1


### PR DESCRIPTION
Switch to coverlet for code coverage from OpenCover.

coverlet is supported on non-Windows platforms, as well as being easier to configure.