### PR TITLE
Cancellable handler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19324-01" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="4.1.9" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />

--- a/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -79,7 +79,7 @@ namespace JustSaying.IntegrationTests.Fluent
 
             handler.Handle(Arg.Any<T>())
                    .Returns(true)
-                   .AndDoes((_) => completionSource.SetResult(null));
+                   .AndDoes((_) => completionSource.TrySetResult(null));
 
             return handler;
         }

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -12,11 +12,11 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.102" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.17" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.28" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.103.5" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.30" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.41" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="StructureMap" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\JustSaying.Extensions.DependencyInjection.StructureMap\JustSaying.Extensions.DependencyInjection.StructureMap.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.10.0" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-62" />
     <PackageReference Include="JustBehave.xUnit" Version="2.0.0-beta-62" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/HandlerMapTests.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/HandlerMapTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Models;
@@ -31,7 +32,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         public void HandlerIsReturnedForMatchingType()
         {
             var map = new HandlerMap();
-            map.Add(typeof(SimpleMessage), m => Task.FromResult(true));
+            map.Add(typeof(SimpleMessage), (m, ct) => Task.FromResult(true));
 
             var handler = map.Get(typeof(SimpleMessage));
 
@@ -42,7 +43,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         public void HandlerContainsKeyForMatchingTypeOnly()
         {
             var map = new HandlerMap();
-            map.Add(typeof(SimpleMessage), m => Task.FromResult(true));
+            map.Add(typeof(SimpleMessage), (m, ct) => Task.FromResult(true));
 
             map.ContainsKey(typeof(SimpleMessage)).ShouldBeTrue();
             map.ContainsKey(typeof(AnotherSimpleMessage)).ShouldBeFalse();
@@ -52,7 +53,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         public void HandlerIsNotReturnedForNonMatchingType()
         {
             var map = new HandlerMap();
-            map.Add(typeof(SimpleMessage), m => Task.FromResult(true));
+            map.Add(typeof(SimpleMessage), (m, ct) => Task.FromResult(true));
 
             var handler = map.Get(typeof(AnotherSimpleMessage));
 
@@ -62,8 +63,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         [Fact]
         public void CorrectHandlerIsReturnedForType()
         {
-            Func<Message, Task<bool>> fn1 = m => Task.FromResult(true);
-            Func<Message, Task<bool>> fn2 = m => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn1 = (m, ct) => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn2 = (m, ct) => Task.FromResult(true);
 
             var map = new HandlerMap();
             map.Add(typeof(SimpleMessage), fn1);
@@ -81,8 +82,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         [Fact]
         public void MultipleHandlersForATypeAreNotSupported()
         {
-            Func<Message, Task<bool>> fn1 = m => Task.FromResult(true);
-            Func<Message, Task<bool>> fn2 = m => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn1 = (m, ct) => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn2 = (m, ct) => Task.FromResult(true);
 
             var map = new HandlerMap();
 
@@ -93,9 +94,9 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         [Fact]
         public void MultipleHandlersForATypeWithOtherHandlersAreNotSupported()
         {
-            Func<Message, Task<bool>> fn1 = m => Task.FromResult(true);
-            Func<Message, Task<bool>> fn2 = m => Task.FromResult(false);
-            Func<Message, Task<bool>> fn3 = m => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn1 = (m, ct) => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn2 = (m, ct) => Task.FromResult(false);
+            Func<Message, CancellationToken, Task<bool>> fn3 = (m, ct) => Task.FromResult(true);
 
             var map = new HandlerMap();
             map.Add(typeof(SimpleMessage), fn1);

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -105,7 +105,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             protected override void Given()
             {
                 base.Given();
-                _handlerMap.Add(typeof(OrderAccepted), m => Task.FromResult(true));
+                _handlerMap.Add(typeof(OrderAccepted), (m, ct) => Task.FromResult(true));
             }
 
             [Fact]
@@ -131,7 +131,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             {
                 base.Given();
                 _messageBackoffStrategy.GetBackoffDuration(_typedMessage, 1, _expectedException).Returns(_expectedBackoffTimeSpan);
-                _handlerMap.Add(typeof(OrderAccepted), m => throw _expectedException);
+                _handlerMap.Add(typeof(OrderAccepted), (m, ct) => throw _expectedException);
                 _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, ExpectedReceiveCount.ToString(CultureInfo.InvariantCulture));
             }
 
@@ -156,7 +156,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
                 _messageBackoffStrategy.GetBackoffDuration(_typedMessage, Arg.Any<int>()).Returns(TimeSpan.FromMinutes(4));
                 _amazonSqsClient.ChangeMessageVisibilityAsync(Arg.Any<ChangeMessageVisibilityRequest>()).Throws(new AmazonServiceException("Something gone wrong"));
 
-                _handlerMap.Add(typeof(OrderAccepted), m => Task.FromResult(false));
+                _handlerMap.Add(typeof(OrderAccepted), (m, ct) => Task.FromResult(false));
                 _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, "1");
             }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageHandlerWrapperTests.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageHandlerWrapperTests.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Messaging.MessageHandling;
@@ -35,7 +36,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
             // act
             var wrapped = handlerWrapper.WrapMessageHandler(() => mockHandler);
 
-            var result = await wrapped(new SimpleMessage());
+            var result = await wrapped(new SimpleMessage(), CancellationToken.None);
 
             result.ShouldBeTrue();
         }
@@ -55,7 +56,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
             // act
             var wrapped = handlerWrapper.WrapMessageHandler(() => mockHandler);
 
-            await wrapped(testMessage);
+            await wrapped(testMessage, CancellationToken.None);
 
             await mockHandler.Received().Handle(testMessage);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -8,7 +8,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingBeforeMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int MaxWorkers => int.MaxValue;
+        public int MaxConcurrency => int.MaxValue;
 
         public int AvailableWorkers
         {

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -31,19 +31,20 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public Task WaitForAvailableWorkers()
+        public Task<int> WaitForAvailableWorkerAsync()
         {
             if (_firstTime)
             {
                 _firstTime = false;
                 Fail();
             }
-            return Task.FromResult(true);
+
+            return Task.FromResult(1);
         }
 
-        public Task StartWorker(Func<Task> action, CancellationToken cancellationToken)
+        public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
         private void Fail()
@@ -51,6 +52,5 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             TaskHelpers.DelaySendDone(_doneSignal);
             throw new TestException("Thrown by test ProcessMessage");
         }
-
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -8,7 +8,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 {
     public class ThrowingDuringMessageProcessingStrategy : IMessageProcessingStrategy
     {
-        public int MaxWorkers => int.MaxValue;
+        public int MaxConcurrency => int.MaxValue;
 
         private readonly TaskCompletionSource<object> _doneSignal;
         private bool _firstTime = true;
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 
         public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.FromResult(MaxWorkers);
+            return Task.FromResult(MaxConcurrency);
         }
 
         public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -20,12 +20,12 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             _doneSignal = doneSignal;
         }
 
-        public Task WaitForAvailableWorkers()
+        public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.CompletedTask;
+            return Task.FromResult(AvailableWorkers);
         }
 
-        public Task StartWorker(Func<Task> action, CancellationToken cancellationToken)
+        public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)
         {
             if (_firstTime)
             {
@@ -33,14 +33,13 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
                 return Fail();
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
-        private Task Fail()
+        private Task<bool> Fail()
         {
             TaskHelpers.DelaySendDone(_doneSignal);
             throw new TestException("Thrown by test ProcessMessage");
         }
-
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -10,8 +10,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
     {
         public int MaxWorkers => int.MaxValue;
 
-        public int AvailableWorkers => int.MaxValue;
-
         private readonly TaskCompletionSource<object> _doneSignal;
         private bool _firstTime = true;
 
@@ -22,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
 
         public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.FromResult(AvailableWorkers);
+            return Task.FromResult(MaxWorkers);
         }
 
         public Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -12,7 +12,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public class WhenExactlyOnceIsAppliedWithoutSpecificTimeout : BaseQueuePollingTest
     {
-        //private readonly int _maximumTimeout = int.MaxValue;
         private readonly int _maximumTimeout = (int)TimeSpan.MaxValue.TotalSeconds;
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         private ExactlyOnceSignallingHandler _handler;

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
@@ -12,10 +12,10 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.102" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.17" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.28" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.103.5" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.30" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.41" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
+++ b/JustSaying.UnitTests/Messaging/MessageProcessingStrategies/MessageLoopTests.cs
@@ -146,7 +146,7 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
 
             while (actions.Any())
             {
-                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.AvailableWorkers);
+                var batch = GetFromFakeSnsQueue(actions, messageProcessingStrategy.MaxWorkers);
 
                 if (batch.Count < 1)
                 {
@@ -158,10 +158,10 @@ namespace JustSaying.UnitTests.Messaging.MessageProcessingStrategies
                     (await messageProcessingStrategy.StartWorkerAsync(action, CancellationToken.None)).ShouldBeTrue();
                 }
 
-                messageProcessingStrategy.AvailableWorkers.ShouldBeGreaterThanOrEqualTo(0);
+                messageProcessingStrategy.MaxWorkers.ShouldBeGreaterThanOrEqualTo(0);
 
                 (await messageProcessingStrategy.WaitForAvailableWorkerAsync()).ShouldBeGreaterThan(0);
-                messageProcessingStrategy.AvailableWorkers.ShouldBeGreaterThan(0);
+                messageProcessingStrategy.MaxWorkers.ShouldBeGreaterThan(0);
 
                 stopwatch.Elapsed.ShouldBeLessThanOrEqualTo((timeout * 3),
                     $"ListenLoopExecuted took longer than timeout of {timeout}, with {actions.Count} of {initalActionCount} messages remaining.");

--- a/JustSaying/AwsTools/MessageHandling/HandlerMap.cs
+++ b/JustSaying/AwsTools/MessageHandling/HandlerMap.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using HandlerFunc = System.Func<JustSaying.Models.Message, System.Threading.Tasks.Task<bool>>;
+using HandlerFunc = System.Func<JustSaying.Models.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>;
 
 namespace JustSaying.AwsTools.MessageHandling
 {

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -46,7 +46,7 @@ namespace JustSaying.AwsTools.MessageHandling
             onError = onError ?? DefaultErrorHandler;
             _log = loggerFactory.CreateLogger("JustSaying");
 
-            _messageProcessingStrategy = new DefaultThrottledThroughput(_messagingMonitor);
+            _messageProcessingStrategy = new DefaultThrottledThroughput(_messagingMonitor, _log);
             _messageHandlerWrapper = new MessageHandlerWrapper(messageLock, _messagingMonitor);
 
             _messageDispatcher = new MessageDispatcher(
@@ -70,9 +70,16 @@ namespace JustSaying.AwsTools.MessageHandling
         public string Queue => _queue.QueueName;
 
         // ToDo: This should not be here.
-        public SqsNotificationListener WithMaximumConcurrentLimitOnMessagesInFlightOf(int maximumAllowedMesagesInFlight)
+        public SqsNotificationListener WithMaximumConcurrentLimitOnMessagesInFlightOf(
+            int maximumAllowedMesagesInFlight,
+            TimeSpan? startTimeout = null)
         {
-            _messageProcessingStrategy = new Throttled(maximumAllowedMesagesInFlight, _messagingMonitor);
+            _messageProcessingStrategy = new Throttled(
+                maximumAllowedMesagesInFlight,
+                startTimeout ?? Timeout.InfiniteTimeSpan,
+                _messagingMonitor,
+                _log);
+
             return this;
         }
 
@@ -105,7 +112,7 @@ namespace JustSaying.AwsTools.MessageHandling
             // ListenLoop will cancel gracefully, so no need to pass cancellation token to Task.Run
             _ = Task.Run(async () =>
             {
-                await ListenLoop(cancellationToken).ConfigureAwait(false);
+                await ListenLoopAsync(cancellationToken).ConfigureAwait(false);
                 IsListening = false;
                 _log.LogInformation("Stopped listening on queue '{QueueName}' in region '{Region}'.", queueName, region);
             });
@@ -114,7 +121,7 @@ namespace JustSaying.AwsTools.MessageHandling
             _log.LogInformation("Starting listening on queue '{QueueName}' in region '{Region}'.", queueName, region);
         }
 
-        internal async Task ListenLoop(CancellationToken ct)
+        internal async Task ListenLoopAsync(CancellationToken ct)
         {
             var queueName = _queue.QueueName;
             var regionName = _queue.Region.SystemName;
@@ -124,21 +131,29 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 try
                 {
-                    sqsMessageResponse = await GetMessagesFromSqsQueue(queueName, regionName, ct).ConfigureAwait(false);
+                    sqsMessageResponse = await GetMessagesFromSqsQueueAsync(queueName, regionName, ct).ConfigureAwait(false);
                     var messageCount = sqsMessageResponse.Messages.Count;
 
-                    _log.LogTrace("Polled for messages on queue '{QueueName}' in region '{Region}', and received {MessageCount} messages.",
-                        queueName, regionName, messageCount);
+                    _log.LogTrace(
+                        "Polled for messages on queue '{QueueName}' in region '{Region}', and received {MessageCount} messages.",
+                        queueName,
+                        regionName,
+                        messageCount);
                 }
                 catch (InvalidOperationException ex)
                 {
-                    _log.LogTrace(0, ex, "Could not determine number of messages to read from queue '{QueueName}' in '{Region}'.",
+                    _log.LogTrace(
+                        ex,
+                        "Could not determine number of messages to read from queue '{QueueName}' in '{Region}'.",
                         queueName, regionName);
                 }
                 catch (OperationCanceledException ex)
                 {
-                    _log.LogTrace(0, ex, "Suspected no message on queue '{QueueName}' in region '{Region}'.",
-                        queueName, regionName);
+                    _log.LogTrace(
+                        ex,
+                        "Suspected no message on queue '{QueueName}' in region '{Region}'.",
+                        queueName,
+                        regionName);
                 }
 #pragma warning disable CA1031
                 catch (Exception ex)
@@ -148,17 +163,28 @@ namespace JustSaying.AwsTools.MessageHandling
                         queueName, regionName);
                 }
 
+                if (sqsMessageResponse == null || sqsMessageResponse.Messages.Count < 1)
+                {
+                    continue;
+                }
+
                 try
                 {
-                    if (sqsMessageResponse != null)
+                    foreach (var message in sqsMessageResponse.Messages)
                     {
-                        foreach (var message in sqsMessageResponse.Messages)
+                        if (ct.IsCancellationRequested)
                         {
-                            if (ct.IsCancellationRequested)
-                            {
-                                return;
-                            }
-                            await HandleMessage(message, ct).ConfigureAwait(false);
+                            return;
+                        }
+
+                        if (!await TryHandleMessageAsync(message, ct).ConfigureAwait(false))
+                        {
+                            // No worker free to process any messages
+                            _log.LogWarning(
+                                "Unable to process message with Id {MessageId} for queue '{QueueName}' in region '{Region}' as no workers are available.",
+                                message.MessageId,
+                                queueName,
+                                regionName);
                         }
                     }
                 }
@@ -166,15 +192,18 @@ namespace JustSaying.AwsTools.MessageHandling
                 catch (Exception ex)
 #pragma warning restore CA1031
                 {
-                    _log.LogError(0, ex, "Error in message handling loop for queue '{QueueName}' in region '{Region}'.",
-                        queueName, regionName);
+                    _log.LogError(
+                        ex,
+                        "Error in message handling loop for queue '{QueueName}' in region '{Region}'.",
+                        queueName,
+                        regionName);
                 }
             }
         }
 
-        private async Task<ReceiveMessageResponse> GetMessagesFromSqsQueue(string queueName, string region, CancellationToken ct)
+        private async Task<ReceiveMessageResponse> GetMessagesFromSqsQueueAsync(string queueName, string region, CancellationToken ct)
         {
-            var numberOfMessagesToReadFromSqs = await GetNumberOfMessagesToReadFromSqs()
+            var numberOfMessagesToReadFromSqs = await GetNumberOfMessagesToReadFromSqsAsync()
                 .ConfigureAwait(false);
 
             var watch = System.Diagnostics.Stopwatch.StartNew();
@@ -216,29 +245,31 @@ namespace JustSaying.AwsTools.MessageHandling
             }
         }
 
-        private async Task<int> GetNumberOfMessagesToReadFromSqs()
+        private async Task<int> GetNumberOfMessagesToReadFromSqsAsync()
         {
-            var numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
+            // TODO This needs reviewing as there can be available workers here now, yet by the time
+            // they're actually used, there could be none. This would then create a backlog of messages
+            // to process waiting on the message throttle because all the workers are busy.
+            int numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
 
             if (numberOfMessagesToReadFromSqs == 0)
             {
-                await _messageProcessingStrategy.WaitForAvailableWorkers().ConfigureAwait(false);
-
-                numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
+                int availableWorkers = await _messageProcessingStrategy.WaitForAvailableWorkerAsync().ConfigureAwait(false);
+                numberOfMessagesToReadFromSqs = Math.Min(availableWorkers, MessageConstants.MaxAmazonMessageCap);
             }
 
             if (numberOfMessagesToReadFromSqs == 0)
             {
-                throw new InvalidOperationException("Cannot determine numberOfMessagesToReadFromSqs");
+                throw new InvalidOperationException("");
             }
 
             return numberOfMessagesToReadFromSqs;
         }
 
-        private Task HandleMessage(Amazon.SQS.Model.Message message, CancellationToken ct)
+        private Task<bool> TryHandleMessageAsync(Amazon.SQS.Model.Message message, CancellationToken ct)
         {
             var action = new Func<Task>(() => _messageDispatcher.DispatchMessage(message, ct));
-            return _messageProcessingStrategy.StartWorker(action, ct);
+            return _messageProcessingStrategy.StartWorkerAsync(action, ct);
         }
 
         public ICollection<ISubscriber> Subscribers { get; }

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -132,7 +132,8 @@ namespace JustSaying.AwsTools.MessageHandling
                 try
                 {
                     sqsMessageResponse = await GetMessagesFromSqsQueueAsync(queueName, regionName, ct).ConfigureAwait(false);
-                    var messageCount = sqsMessageResponse.Messages.Count;
+
+                    int messageCount = sqsMessageResponse?.Messages?.Count ?? 0;
 
                     _log.LogTrace(
                         "Polled for messages on queue '{QueueName}' in region '{Region}', and received {MessageCount} messages.",
@@ -203,15 +204,18 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private async Task<ReceiveMessageResponse> GetMessagesFromSqsQueueAsync(string queueName, string region, CancellationToken ct)
         {
-            var numberOfMessagesToReadFromSqs = await GetNumberOfMessagesToReadFromSqsAsync()
+            int maxNumberOfMessages = await GetDesiredNumberOfMessagesToRequestFromSqsAsync()
                 .ConfigureAwait(false);
 
-            var watch = System.Diagnostics.Stopwatch.StartNew();
+            if (maxNumberOfMessages < 1)
+            {
+                return null;
+            }
 
             var request = new ReceiveMessageRequest
             {
                 QueueUrl = _queue.Uri.AbsoluteUri,
-                MaxNumberOfMessages = numberOfMessagesToReadFromSqs,
+                MaxNumberOfMessages = maxNumberOfMessages,
                 WaitTimeSeconds = 20,
                 AttributeNames = _requestMessageAttributeNames
             };
@@ -219,6 +223,8 @@ namespace JustSaying.AwsTools.MessageHandling
             using (var receiveTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(300)))
             {
                 ReceiveMessageResponse sqsMessageResponse;
+
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
                 try
                 {
@@ -237,33 +243,36 @@ namespace JustSaying.AwsTools.MessageHandling
                     }
                 }
 
-                watch.Stop();
+                stopwatch.Stop();
 
-                _messagingMonitor.ReceiveMessageTime(watch.Elapsed, queueName, region);
+                _messagingMonitor.ReceiveMessageTime(stopwatch.Elapsed, queueName, region);
 
                 return sqsMessageResponse;
             }
         }
 
-        private async Task<int> GetNumberOfMessagesToReadFromSqsAsync()
+        private async Task<int> GetDesiredNumberOfMessagesToRequestFromSqsAsync()
         {
-            // TODO This needs reviewing as there can be available workers here now, yet by the time
-            // they're actually used, there could be none. This would then create a backlog of messages
-            // to process waiting on the message throttle because all the workers are busy.
-            int numberOfMessagesToReadFromSqs = Math.Min(_messageProcessingStrategy.AvailableWorkers, MessageConstants.MaxAmazonMessageCap);
+            int maximumMessagesFromAws = MessageConstants.MaxAmazonMessageCap;
+            int maximumWorkers = _messageProcessingStrategy.MaxWorkers;
 
-            if (numberOfMessagesToReadFromSqs == 0)
+            int messagesToRequest = Math.Min(maximumWorkers, maximumMessagesFromAws);
+
+            if (messagesToRequest < 1)
             {
+                // Wait for the strategy to have at least one worker available
                 int availableWorkers = await _messageProcessingStrategy.WaitForAvailableWorkerAsync().ConfigureAwait(false);
-                numberOfMessagesToReadFromSqs = Math.Min(availableWorkers, MessageConstants.MaxAmazonMessageCap);
+
+                messagesToRequest = Math.Min(availableWorkers, maximumMessagesFromAws);
             }
 
-            if (numberOfMessagesToReadFromSqs == 0)
+            if (messagesToRequest < 1)
             {
-                throw new InvalidOperationException("");
+                _log.LogWarning("No workers are available to process SQS messages.");
+                messagesToRequest = 0;
             }
 
-            return numberOfMessagesToReadFromSqs;
+            return messagesToRequest;
         }
 
         private Task<bool> TryHandleMessageAsync(Amazon.SQS.Model.Message message, CancellationToken ct)

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -34,7 +34,7 @@ namespace JustSaying
         public IMessageLockAsync MessageLock { get; set; }
         public IMessageContextAccessor MessageContextAccessor { get; set; }
 
-        private ILogger _log;
+        private readonly ILogger _log;
 
         private readonly object _syncRoot = new object();
         private readonly ICollection<IPublisher> _publishers;

--- a/JustSaying/Messaging/MessageHandling/ExactlyOnceAttribute.cs
+++ b/JustSaying/Messaging/MessageHandling/ExactlyOnceAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JustSaying.Messaging.MessageHandling
 {
@@ -7,9 +7,9 @@ namespace JustSaying.Messaging.MessageHandling
     {
         public ExactlyOnceAttribute()
         {
-            //TimeOut = int.MaxValue;
             TimeOut = (int)TimeSpan.MaxValue.TotalSeconds;
         }
+
         public int TimeOut { get; set; }
     }
 }

--- a/JustSaying/Messaging/MessageHandling/ICancellableHandlerAsync.cs
+++ b/JustSaying/Messaging/MessageHandling/ICancellableHandlerAsync.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace JustSaying.Messaging.MessageHandling
+{
+    /// <summary>
+    /// An asynchronous message handler that supports cancellation.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of the message to handle.
+    /// </typeparam>
+    public interface ICancellableHandlerAsync<in T> : IHandlerAsync<T>
+    {
+        /// <summary>
+        /// Handles a message of type <typeparamref name="T"/> as an asynchronous operation.
+        /// </summary>
+        /// <param name="message">
+        /// The message to handle.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which is cancelled when the message visibility timeout expires.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation
+        /// to process the message that returns <see langword="true"/> if the message
+        /// was processed successfully; otherwise <see langword="false"/>.
+        /// </returns>
+        Task<bool> HandleAsync(T message, CancellationToken cancellationToken);
+    }
+}

--- a/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
@@ -5,14 +5,40 @@ using Microsoft.Extensions.Logging;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
+    /// <summary>
+    /// A class representing the default implementation of <see cref="Throttled"/>.
+    /// </summary>
     public class DefaultThrottledThroughput : Throttled
     {
-        private static readonly int MaxActiveHandlersForProcessors =
-            Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultThrottledThroughput"/> class.
+        /// </summary>
+        /// <param name="options">The <see cref="ThrottledOptions"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="options"/> does not specify an <see cref="ILogger"/> or <see cref="IMessageMonitor"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The concurrency specified by <paramref name="options"/> is less than one,
+        /// or the start timeout specified by <paramref name="options"/> is zero or negative.
+        /// </exception>
         public DefaultThrottledThroughput(IMessageMonitor messageMonitor, ILogger logger)
-            : base(MaxActiveHandlersForProcessors, Timeout.InfiniteTimeSpan, messageMonitor, logger)
+            : base(CreateOptions(messageMonitor, logger))
         {
+        }
+
+        private static ThrottledOptions CreateOptions(IMessageMonitor messageMonitor, ILogger logger)
+        {
+            return new ThrottledOptions()
+            {
+                MaxConcurrency = Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore,
+                Logger = logger,
+                MessageMonitor = messageMonitor,
+                StartTimeout = Timeout.InfiniteTimeSpan,
+                UseThreadPool = true,
+            };
         }
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/DefaultThrottledThroughput.cs
@@ -1,17 +1,18 @@
-﻿using System;
+using System;
+using System.Threading;
 using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
     public class DefaultThrottledThroughput : Throttled
     {
-        public DefaultThrottledThroughput(IMessageMonitor messageMonitor) :
-            base(MaxActiveHandlersForProcessors(), messageMonitor)
+        private static readonly int MaxActiveHandlersForProcessors =
+            Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
+
+        public DefaultThrottledThroughput(IMessageMonitor messageMonitor, ILogger logger)
+            : base(MaxActiveHandlersForProcessors, Timeout.InfiniteTimeSpan, messageMonitor, logger)
         {
-
         }
-
-        private static int MaxActiveHandlersForProcessors()
-            => Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -1,39 +1,47 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace JustSaying.Messaging.MessageProcessingStrategies
 {
+    /// <summary>
+    /// Defines a strategy for processing messages asynchronously.
+    /// </summary>
     public interface IMessageProcessingStrategy
     {
         /// <summary>
-        /// The maximum number of worker tasks that will be used to run messages handlers at any one time
+        /// Gets the maximum number of workers that can be used to process messages concurrently.
         /// </summary>
         int MaxWorkers { get; }
 
         /// <summary>
-        /// The number of worker tasks that are free to run messages handlers right now,
-        /// Always in the range 0 to MaxWorkers
-        /// the number of currently running workers will be = (MaxWorkers - AvailableWorkers)
+        /// Gets the number of workers that are available to process messages.
         /// </summary>
         int AvailableWorkers { get; }
 
         /// <summary>
-        /// Launch a worker to start processing a message.
+        /// Starts a worker task to process a message as an asynchronous operation.
         /// </summary>
-        /// <param name="action"></param>
+        /// <param name="action">A delegate to a method that processes the message.</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation of queuing <paramref name="action"/>,
-        /// including waiting for a worker to become available.
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation of queueing <paramref name="action"/>,
+        /// including waiting for a worker to become available. If the task returns <see cref="false"/>
+        /// an available worker was not available and the action was not queued to be run.
         /// </returns>
-        Task StartWorker(Func<Task> action, CancellationToken cancellationToken);
+        Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken);
 
         /// <summary>
-        /// After awaiting this, you should be in a position to start another worker
-        /// i.e. AvailableWorkers should be above 0
+        /// Attempts to wait for a available worker as an asynchronous operation.
         /// </summary>
-        /// <returns></returns>
-        Task WaitForAvailableWorkers();
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to wait for an
+        /// available worker which returns the current number of available workers.
+        /// </returns>
+        /// <remarks>
+        /// The task returned by this method completing does not guarantee that a worker
+        /// will be available immediately when <see cref="StartWorkerAsync"/> is subsequently called.
+        /// </remarks>
+        Task<int> WaitForAvailableWorkerAsync();
     }
 }

--- a/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -10,9 +10,9 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
     public interface IMessageProcessingStrategy
     {
         /// <summary>
-        /// Gets the maximum number of workers that can be used to process messages concurrently.
+        /// Gets the maximum number of messages that can be processed concurrently.
         /// </summary>
-        int MaxWorkers { get; }
+        int MaxConcurrency { get; }
 
         /// <summary>
         /// Starts a worker task to process a message as an asynchronous operation.

--- a/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -15,11 +15,6 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         int MaxWorkers { get; }
 
         /// <summary>
-        /// Gets the number of workers that are available to process messages.
-        /// </summary>
-        int AvailableWorkers { get; }
-
-        /// <summary>
         /// Starts a worker task to process a message as an asynchronous operation.
         /// </summary>
         /// <param name="action">A delegate to a method that processes the message.</param>

--- a/JustSaying/Messaging/MessageProcessingStrategies/ThrottledOptions.cs
+++ b/JustSaying/Messaging/MessageProcessingStrategies/ThrottledOptions.cs
@@ -1,0 +1,38 @@
+using System;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.Messaging.MessageProcessingStrategies
+{
+    /// <summary>
+    /// A class representing options for the <see cref="Throttled"/> class.
+    /// </summary>
+    public class ThrottledOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of messages to process concurrently.
+        /// </summary>
+        public int MaxConcurrency { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to process messages by dispatching
+        /// them to the thread pool or whether to process messages before returning.
+        /// </summary>
+        public bool UseThreadPool { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout for starting to process a message.
+        /// </summary>
+        public TimeSpan StartTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IMessageMonitor"/> to use.
+        /// </summary>
+        public IMessageMonitor MessageMonitor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ILogger"/> to use.
+        /// </summary>
+        public ILogger Logger { get; set; }
+    }
+}

--- a/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
+++ b/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
@@ -1,29 +1,49 @@
+using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 
 namespace JustSaying.Messaging.Monitoring
 {
-    public class StopwatchHandler<T> : IHandlerAsync<T> where T : Message
+    public class StopwatchHandler<T> : IHandlerAsync<T>, ICancellableHandlerAsync<T>
+        where T : Message
     {
-        private readonly IHandlerAsync<T> _inner;
+        private readonly Type _handlerType;
+        private readonly Func<T, CancellationToken, Task<bool>> _inner;
         private readonly IMeasureHandlerExecutionTime _monitoring;
 
         public StopwatchHandler(IHandlerAsync<T> inner, IMeasureHandlerExecutionTime monitoring)
         {
-            _inner = inner;
+            _handlerType = inner.GetType();
             _monitoring = monitoring;
+
+            if (inner is ICancellableHandlerAsync<T> cancellable)
+            {
+                _inner = cancellable.HandleAsync;
+            }
+            else
+            {
+                _inner = async (message, _) => await inner.Handle(message).ConfigureAwait(false);
+            }
         }
 
         public async Task<bool> Handle(T message)
         {
-            var watch = Stopwatch.StartNew();
-            var result = await _inner.Handle(message).ConfigureAwait(false);
+            return await HandleAsync(message, CancellationToken.None).ConfigureAwait(false);
+        }
 
-            watch.Stop();
+        public async Task<bool> HandleAsync(T message, CancellationToken cancellationToken)
+        {
+            var stopwatch = Stopwatch.StartNew();
 
-            _monitoring.HandlerExecutionTime(_inner.GetType(), message.GetType(), watch.Elapsed);
+            bool result = await _inner(message, cancellationToken).ConfigureAwait(false);
+
+            stopwatch.Stop();
+
+            _monitoring.HandlerExecutionTime(_handlerType, message.GetType(), stopwatch.Elapsed);
+
             return result;
         }
     }


### PR DESCRIPTION
I had an idea this morning based on the changes in #546, so I thought I'd see how far I could get with it and submit a PR for discussion.

In the event that the issue that lead to #546 occurring and tasks to process messages back up, it's possible that a task to process a message may be trying to process a message that was received so long ago that the message visibility timeout has expired and it is now a potential duplicate waiting to be processed.

If the handler had a `CancellationToken` that cancels after the _approximate_ message visibility timeout expires, JustSaying could enable two behaviours:

  1) It could self-cancel trying to do anything with the message before getting to the handler and abandoning it (potentially just extending the visibility instead, but I've not done that here).
  2) The handler, when called, could observe the cancellation token itself and make a decision about what to do with the message. It could return `false` to send it back to the queue (where it could have since been handled elsewhere anyway), or it could return `true` on the basis, if this has expired I'll just ignore it and pretend I've dealt with it.

This is implemented here by adding the `ICancellableHandlerAsync<T>` interface that derives from `IHandlerAsync<T>`, and then plumbing it in appropriately so it's used if implemented by the handler for a particular message and extending things like the exactly-once handler and stopwatch wrappers.

There's also some random bits of refactoring in here that happened as I was going along, I'll pull those out into a separate PR shortly.