### PR TITLE
Fixes and refactors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19324-01" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="4.1.9" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />

--- a/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -79,7 +79,7 @@ namespace JustSaying.IntegrationTests.Fluent
 
             handler.Handle(Arg.Any<T>())
                    .Returns(true)
-                   .AndDoes((_) => completionSource.SetResult(null));
+                   .AndDoes((_) => completionSource.TrySetResult(null));
 
             return handler;
         }

--- a/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -12,11 +12,11 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.102" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.17" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.28" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.103.5" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.30" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.41" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="StructureMap" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\JustSaying.Extensions.DependencyInjection.StructureMap\JustSaying.Extensions.DependencyInjection.StructureMap.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.10.0" />
     <PackageReference Include="JustBehave" Version="2.0.0-beta-62" />
     <PackageReference Include="JustBehave.xUnit" Version="2.0.0-beta-62" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -12,7 +12,6 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 {
     public class WhenExactlyOnceIsAppliedWithoutSpecificTimeout : BaseQueuePollingTest
     {
-        //private readonly int _maximumTimeout = int.MaxValue;
         private readonly int _maximumTimeout = (int)TimeSpan.MaxValue.TotalSeconds;
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         private ExactlyOnceSignallingHandler _handler;

--- a/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
@@ -12,10 +12,10 @@
     <ProjectReference Include="..\JustSaying.TestingFramework\JustSaying.TestingFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.102" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.17" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.28" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.103.5" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.30" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.41" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/JustSaying.UnitTests/Messaging/MessageHandling/WhenEnsuringMessageIsOnlyHandledExactlyOnce.cs
+++ b/JustSaying.UnitTests/Messaging/MessageHandling/WhenEnsuringMessageIsOnlyHandledExactlyOnce.cs
@@ -15,7 +15,7 @@ namespace JustSaying.UnitTests.Messaging.MessageHandling
         {
             var messageLock = Substitute.For<IMessageLockAsync>();
             messageLock.TryAquireLockAsync(Arg.Any<string>(), Arg.Any<TimeSpan>()).Returns(new MessageLockResponse { DoIHaveExclusiveLock = false });
-            var sut = new ExactlyOnceHandler<OrderAccepted>(Substitute.For<IHandlerAsync<OrderAccepted>>(), messageLock, 1, "handlerName");
+            var sut = new ExactlyOnceHandler<OrderAccepted>(Substitute.For<IHandlerAsync<OrderAccepted>>(), messageLock, TimeSpan.FromSeconds(1), "handlerName");
 
             var result = await sut.Handle(new OrderAccepted());
 

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -123,12 +123,17 @@ namespace JustSaying.AwsTools.MessageHandling
             }
             finally
             {
-                if (!handlingSucceeded && _messageBackoffStrategy != null)
+                try
                 {
-                    await UpdateMessageVisibilityTimeout(message, message.ReceiptHandle, typedMessage, lastException).ConfigureAwait(false);
+                    if (!handlingSucceeded && _messageBackoffStrategy != null)
+                    {
+                        await UpdateMessageVisibilityTimeout(message, message.ReceiptHandle, typedMessage, lastException).ConfigureAwait(false);
+                    }
                 }
-
-                _messageContextAccessor.MessageContext = null;
+                finally
+                {
+                    _messageContextAccessor.MessageContext = null;
+                }
             }
         }
 
@@ -206,7 +211,8 @@ namespace JustSaying.AwsTools.MessageHandling
         {
             approxReceiveCount = 0;
 
-            return attributes.TryGetValue(MessageSystemAttributeName.ApproximateReceiveCount, out string rawApproxReceiveCount) && int.TryParse(rawApproxReceiveCount, out approxReceiveCount);
+            return attributes.TryGetValue(MessageSystemAttributeName.ApproximateReceiveCount, out string rawApproxReceiveCount) &&
+                   int.TryParse(rawApproxReceiveCount, out approxReceiveCount);
         }
     }
 }

--- a/JustSaying/AwsTools/MessageHandling/MessageHandlerWrapper.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageHandlerWrapper.cs
@@ -44,7 +44,9 @@ namespace JustSaying.AwsTools.MessageHandling
             }
 
             var handlerName = handlerType.FullName.ToLowerInvariant();
-            return new ExactlyOnceHandler<T>(handler, _messageLock, exactlyOnceMetadata.GetTimeOut(), handlerName);
+            var timeout = TimeSpan.FromSeconds(exactlyOnceMetadata.GetTimeOut());
+
+            return new ExactlyOnceHandler<T>(handler, _messageLock, timeout, handlerName);
         }
 
         private IHandlerAsync<T> MaybeWrapWithStopwatch<T>(IHandlerAsync<T> handler) where T : Message

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -237,8 +237,12 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private Task HandleMessage(Amazon.SQS.Model.Message message, CancellationToken ct)
         {
-            var action = new Func<Task>(() => _messageDispatcher.DispatchMessage(message, ct));
-            return _messageProcessingStrategy.StartWorker(action, ct);
+            async Task DispatchAsync()
+            {
+                await _messageDispatcher.DispatchMessage(message, ct);
+            }
+
+            return _messageProcessingStrategy.StartWorker(DispatchAsync, ct);
         }
 
         public ICollection<ISubscriber> Subscribers { get; }

--- a/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -132,20 +132,29 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
                 catch (InvalidOperationException ex)
                 {
-                    _log.LogTrace(0, ex, "Could not determine number of messages to read from queue '{QueueName}' in '{Region}'.",
-                        queueName, regionName);
+                    _log.LogTrace(
+                        ex,
+                        "Could not determine number of messages to read from queue '{QueueName}' in '{Region}'.",
+                        queueName,
+                        regionName);
                 }
                 catch (OperationCanceledException ex)
                 {
-                    _log.LogTrace(0, ex, "Suspected no message on queue '{QueueName}' in region '{Region}'.",
-                        queueName, regionName);
+                    _log.LogTrace(
+                        ex,
+                        "Suspected no message on queue '{QueueName}' in region '{Region}'.",
+                        queueName,
+                        regionName);
                 }
 #pragma warning disable CA1031
                 catch (Exception ex)
 #pragma warning restore CA1031
                 {
-                    _log.LogError(0, ex, "Error receiving messages on queue '{QueueName}' in region '{Region}'.",
-                        queueName, regionName);
+                    _log.LogError(
+                        ex,
+                        "Error receiving messages on queue '{QueueName}' in region '{Region}'.",
+                        queueName,
+                        regionName);
                 }
 
                 try
@@ -166,8 +175,11 @@ namespace JustSaying.AwsTools.MessageHandling
                 catch (Exception ex)
 #pragma warning restore CA1031
                 {
-                    _log.LogError(0, ex, "Error in message handling loop for queue '{QueueName}' in region '{Region}'.",
-                        queueName, regionName);
+                    _log.LogError(
+                        ex,
+                        "Error in message handling loop for queue '{QueueName}' in region '{Region}'.",
+                        queueName,
+                        regionName);
                 }
             }
         }

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -34,7 +34,7 @@ namespace JustSaying
         public IMessageLockAsync MessageLock { get; set; }
         public IMessageContextAccessor MessageContextAccessor { get; set; }
 
-        private ILogger _log;
+        private readonly ILogger _log;
 
         private readonly object _syncRoot = new object();
         private readonly ICollection<IPublisher> _publishers;

--- a/JustSaying/JustSayingBus.cs
+++ b/JustSaying/JustSayingBus.cs
@@ -170,14 +170,18 @@ namespace JustSaying
                 throw new InvalidOperationException($"Error publishing message. No publishers registered for active region '{activeRegion}'.");
             }
 
-            var topic = message.GetType().ToTopicName();
+            var messageType = message.GetType();
+            var topic = messageType.ToTopicName();
             var publisherFound = publishersForRegion.TryGetValue(topic, out var publisher);
 
             if (!publisherFound)
             {
-                _log.LogError("Error publishing message. No publishers registered for message type '{MessageType}' in active region '{Region}'.",
-                    message.GetType(), activeRegion);
-                throw new InvalidOperationException($"Error publishing message, no publishers registered for message type '{message.GetType()}' in active region '{activeRegion}'.");
+                _log.LogError(
+                    "Error publishing message. No publishers registered for message type '{MessageType}' in active region '{Region}'.",
+                    messageType,
+                    activeRegion);
+
+                throw new InvalidOperationException($"Error publishing message, no publishers registered for message type '{messageType}' in active region '{activeRegion}'.");
             }
 
             return publisher;
@@ -236,16 +240,27 @@ namespace JustSaying
             }
             catch (Exception ex)
             {
+                var messageType = message.GetType();
+
                 if (attemptCount >= Config.PublishFailureReAttempts)
                 {
                     Monitor.IssuePublishingMessage();
-                    _log.LogError(0, ex, "Failed to publish a message of type '{MessageType}'. Halting after attempt number {PublishAttemptCount}.",
-                        message.GetType(), attemptCount);
+
+                    _log.LogError(
+                        ex,
+                        "Failed to publish a message of type '{MessageType}'. Halting after attempt number {PublishAttemptCount}.",
+                        messageType,
+                        attemptCount);
+
                     throw;
                 }
 
-                _log.LogWarning(0, ex, "Failed to publish a message of type '{MessageType}'. Retrying after attempt number {PublishAttemptCount} of {PublishFailureReattempts}.",
-                    message.GetType(), attemptCount, Config.PublishFailureReAttempts);
+                _log.LogWarning(
+                    ex,
+                    "Failed to publish a message of type '{MessageType}'. Retrying after attempt number {PublishAttemptCount} of {PublishFailureReattempts}.",
+                    messageType,
+                    attemptCount,
+                    Config.PublishFailureReAttempts);
 
                 var delayForAttempt = TimeSpan.FromMilliseconds(Config.PublishFailureBackoff.TotalMilliseconds * attemptCount);
                 await Task.Delay(delayForAttempt, cancellationToken).ConfigureAwait(false);

--- a/JustSaying/Messaging/MessageHandling/ExactlyOnceAttribute.cs
+++ b/JustSaying/Messaging/MessageHandling/ExactlyOnceAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JustSaying.Messaging.MessageHandling
 {
@@ -7,9 +7,9 @@ namespace JustSaying.Messaging.MessageHandling
     {
         public ExactlyOnceAttribute()
         {
-            //TimeOut = int.MaxValue;
             TimeOut = (int)TimeSpan.MaxValue.TotalSeconds;
         }
+
         public int TimeOut { get; set; }
     }
 }

--- a/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
+++ b/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
@@ -9,21 +10,25 @@ namespace JustSaying.Messaging.Monitoring
     {
         private readonly IHandlerAsync<T> _inner;
         private readonly IMeasureHandlerExecutionTime _monitoring;
+        private readonly Type _handlerType;
 
         public StopwatchHandler(IHandlerAsync<T> inner, IMeasureHandlerExecutionTime monitoring)
         {
             _inner = inner;
             _monitoring = monitoring;
+            _handlerType = _inner.GetType();
         }
 
         public async Task<bool> Handle(T message)
         {
-            var watch = Stopwatch.StartNew();
-            var result = await _inner.Handle(message).ConfigureAwait(false);
+            var stopwatch = Stopwatch.StartNew();
 
-            watch.Stop();
+            bool result = await _inner.Handle(message).ConfigureAwait(false);
 
-            _monitoring.HandlerExecutionTime(_inner.GetType(), message.GetType(), watch.Elapsed);
+            stopwatch.Stop();
+
+            _monitoring.HandlerExecutionTime(_handlerType, message.GetType(), stopwatch.Elapsed);
+
             return result;
         }
     }


### PR DESCRIPTION
Cherry-pick changes from #546 and #549 to:

  * Remove leftover code from previous refactors.
  * Fix integration tests failing if tasks transition so they're already completed.
  * Update various NuGet pacakges to their latest versions.
  * Change timeout constructor parameter on `ExactlyOnceHandler` to a `TimeSpan`. This makes the unit clearer and removes the need to create a new `TimeSpan` for every message invocation.
  * Compute the message lock key suffix in `ExactlyOnceHandler` once, rather than per message invocation, as it does not change for the lifetime of the handler.
  * Do a reflection call in `StopwatchHandler` to get the inner handler's type once per instance, rather than once per message.
  * Use a local function for the worker task, rather than explicitly creating a `Func<Task>`.
  * Make logger field `readonly` as its value is never reassigned.
  * Reduce the number of calls to `message.GetType()` in various places.
  * Change logger overloads to not specify an event Id of zero.
  * Include receipt handle in log message.
  * Ensure that the `MessageContext` is reset to `null` if an exception is thrown when updating the message visibility timeout.