### PR TITLE
Remove MSBuildAllProjects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,6 @@
     <!-- Disable Source Link on Mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
     <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
     <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/1516790?s=64</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/justeat/JustSaying</PackageProjectUrl>


### PR DESCRIPTION
Following guidance from here:
http://www.panopticoncentral.net/2019/07/12/msbuildallprojects-considered-harmful/
Given we have pinned the SDK we can be sure we are using MSBuild 16+, so it's a safe change.