### PR TITLE
Add support for System.Text.Json

### DIFF
--- a/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToAQueueWithSystemTextJson.cs
+++ b/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToAQueueWithSystemTextJson.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using JustSaying.Fluent;
+using JustSaying.Messaging;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing
+{
+    public class WhenAMessageIsPublishedToAQueueWithSystemTextJson : IntegrationTestBase
+    {
+        public WhenAMessageIsPublishedToAQueueWithSystemTextJson(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Message_Is_Handled()
+        {
+            // Arrange
+            var completionSource = new TaskCompletionSource<object>();
+            var handler = CreateHandler<SimpleMessage>(completionSource);
+
+            var services = GivenJustSaying()
+                .ConfigureJustSaying(
+                    (builder) =>
+                    {
+                        builder.WithLoopbackQueue<SimpleMessage>(UniqueName)
+                               .Services((configure) => configure.WithSystemTextJson());
+                    })
+                .AddSingleton(handler);
+
+            string content = Guid.NewGuid().ToString();
+
+            var message = new SimpleMessage()
+            {
+                Content = content
+            };
+
+            await WhenAsync(
+                services,
+                async (publisher, listener, cancellationToken) =>
+                {
+                    listener.Start(cancellationToken);
+
+                    // Act
+                    await publisher.PublishAsync(message, cancellationToken);
+
+                    // Assert
+                    completionSource.Task.Wait(cancellationToken);
+
+                    await handler.Received().Handle(Arg.Is<SimpleMessage>((m) => m.Content == content));
+                });
+        }
+    }
+}

--- a/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToATopicWithSystemTextJson.cs
+++ b/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToATopicWithSystemTextJson.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using JustSaying.Fluent;
+using JustSaying.Messaging;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing
+{
+    public class WhenAMessageIsPublishedToATopicWithSystemTextJson : IntegrationTestBase
+    {
+        public WhenAMessageIsPublishedToATopicWithSystemTextJson(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Message_Is_Handled()
+        {
+            // Arrange
+            var completionSource = new TaskCompletionSource<object>();
+            var handler = CreateHandler<SimpleMessage>(completionSource);
+
+            var services = GivenJustSaying()
+                .ConfigureJustSaying(
+                    (builder) =>
+                    {
+                        builder.WithLoopbackTopic<SimpleMessage>(UniqueName)
+                               .Services((configure) => configure.WithSystemTextJson());
+                    })
+                .AddSingleton(handler);
+
+            string content = Guid.NewGuid().ToString();
+
+            var message = new SimpleMessage()
+            {
+                Content = content
+            };
+
+            await WhenAsync(
+                services,
+                async (publisher, listener, cancellationToken) =>
+                {
+                    listener.Start(cancellationToken);
+
+                    // Act
+                    await publisher.PublishAsync(message, cancellationToken);
+
+                    // Assert
+                    completionSource.Task.Wait(cancellationToken);
+
+                    await handler.Received().Handle(Arg.Is<SimpleMessage>((m) => m.Content == content));
+                });
+        }
+    }
+}

--- a/JustSaying.TestingFramework/MessageStubs.cs
+++ b/JustSaying.TestingFramework/MessageStubs.cs
@@ -26,12 +26,11 @@ namespace JustSaying.TestingFramework
 
     public class MessageWithEnum : Message
     {
-        public MessageWithEnum(Value enumVal)
+        public MessageWithEnum()
         {
-            EnumVal = enumVal;
         }
 
-        public Value EnumVal { get; private set; }
+        public Value EnumVal { get; set; }
     }
 
     public enum Value

--- a/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/DealingWithPotentiallyMissingConversation.cs
@@ -13,7 +13,7 @@ namespace JustSaying.UnitTests.Messaging.Serialization.Newtonsoft
         private string _jsonMessage;
         protected override void Given()
         {
-            _messageOut = new MessageWithEnum(Value.Two);
+            _messageOut = new MessageWithEnum() { EnumVal = Value.Two };
         }
 
         protected override void WhenAction()

--- a/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenSerializingAndDeserializing.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenSerializingAndDeserializing.cs
@@ -12,7 +12,7 @@ namespace JustSaying.UnitTests.Messaging.Serialization.Newtonsoft
         private string _jsonMessage;
         protected override void Given()
         {
-            _messageOut = new MessageWithEnum(Value.Two);
+            _messageOut = new MessageWithEnum() { EnumVal = Value.Two };
         }
 
         protected override void WhenAction()

--- a/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenUsingCustomSettings.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenUsingCustomSettings.cs
@@ -18,7 +18,7 @@ namespace JustSaying.UnitTests.Messaging.Serialization.Newtonsoft
 
         protected override void Given()
         {
-            _messageOut = new MessageWithEnum(Value.Two);
+            _messageOut = new MessageWithEnum() { EnumVal = Value.Two };
         }
 
         public string GetMessageInContext(MessageWithEnum message)

--- a/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/DealingWithPotentiallyMissingConversation.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/DealingWithPotentiallyMissingConversation.cs
@@ -1,0 +1,41 @@
+using System;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Messaging.Serialization.SystemTextJson
+{
+    public class DealingWithPotentiallyMissingConversation : XBehaviourTest<SystemTextJsonSerializer>
+    {
+        private MessageWithEnum _messageOut;
+        private MessageWithEnum _messageIn;
+        private string _jsonMessage;
+
+        protected override void Given()
+        {
+            _messageOut = new MessageWithEnum() { EnumVal = Value.Two };
+        }
+
+        protected override void WhenAction()
+        {
+            _jsonMessage = SystemUnderTest.Serialize(_messageOut, false, _messageOut.GetType().Name);
+
+            // Add extra property to see what happens:
+            _jsonMessage = _jsonMessage.Replace("{__", "{\"New\":\"Property\",__", StringComparison.OrdinalIgnoreCase);
+            _messageIn = SystemUnderTest.Deserialize(_jsonMessage, typeof(MessageWithEnum)) as MessageWithEnum;
+        }
+
+        [Fact]
+        public void ItDoesNotHaveConversationPropertySerializedBecauseItIsNotSet_ThisIsForBackwardsCompatibilityWhenWeDeploy()
+        {
+            _jsonMessage.ShouldNotContain("Conversation");
+        }
+
+        [Fact]
+        public void DeserializedMessageHasEmptyConversation_ThisIsForBackwardsCompatibilityWhenWeDeploy()
+        {
+            _messageIn.Conversation.ShouldBeNull();
+        }
+    }
+}

--- a/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenAskingForANewSerializer.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenAskingForANewSerializer.cs
@@ -1,0 +1,27 @@
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Messaging.Serialization.SystemTextJson
+{
+    public class WhenAskingForANewSerializer : XBehaviourTest<SystemTextJsonSerializationFactory>
+    {
+        private IMessageSerializer _result;
+
+        protected override void Given()
+        {
+        }
+
+        protected override void WhenAction()
+        {
+            _result = SystemUnderTest.GetSerializer<SimpleMessage>();
+        }
+
+        [Fact]
+        public void OneIsProvided()
+        {
+            _result.ShouldNotBeNull();
+        }
+    }
+}

--- a/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenSerializingAndDeserializing.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenSerializingAndDeserializing.cs
@@ -1,0 +1,46 @@
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Messaging.Serialization.SystemTextJson
+{
+    public class WhenSerializingAndDeserializing : XBehaviourTest<SystemTextJsonSerializer>
+    {
+        private MessageWithEnum _messageOut;
+        private MessageWithEnum _messageIn;
+        private string _jsonMessage;
+
+        protected override void Given()
+        {
+            _messageOut = new MessageWithEnum() { EnumVal = Value.Two };
+        }
+
+        protected override void WhenAction()
+        {
+            _jsonMessage = SystemUnderTest.Serialize(_messageOut, false, _messageOut.GetType().Name);
+            _messageIn = SystemUnderTest.Deserialize(_jsonMessage, typeof(MessageWithEnum)) as MessageWithEnum;
+        }
+
+        [Fact]
+        public void MessageHasBeenCreated()
+        {
+            _messageOut.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void MessagesContainSameDetails()
+        {
+            _messageOut.EnumVal.ShouldBe(_messageIn.EnumVal);
+            _messageOut.RaisingComponent.ShouldBe(_messageIn.RaisingComponent);
+            _messageOut.TimeStamp.ShouldBe(_messageIn.TimeStamp);
+        }
+
+        [Fact]
+        public void EnumsAreRepresentedAsStrings()
+        {
+            _jsonMessage.ShouldContain("EnumVal");
+            _jsonMessage.ShouldContain("Two");
+        }
+    }
+}

--- a/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenUsingCustomSettings.cs
+++ b/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenUsingCustomSettings.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Messaging.Serialization.SystemTextJson
+{
+    public class WhenUsingCustomSettings : XBehaviourTest<SystemTextJsonSerializer>
+    {
+        private MessageWithEnum _messageOut;
+        private string _jsonMessage;
+
+        protected override SystemTextJsonSerializer CreateSystemUnderTest()
+        {
+            return new SystemTextJsonSerializer(new JsonSerializerOptions());
+        }
+
+        protected override void Given()
+        {
+            _messageOut = new MessageWithEnum() { EnumVal = Value.Two };
+        }
+
+        public string GetMessageInContext(MessageWithEnum message)
+        {
+            var context = new { Subject = message.GetType().Name, Message = SystemUnderTest.Serialize(message, false, message.GetType().Name) };
+            return JsonConvert.SerializeObject(context);
+        }
+
+        protected override void WhenAction()
+        {
+            _jsonMessage = GetMessageInContext(_messageOut);
+        }
+
+        [Fact]
+        public void MessageHasBeenCreated()
+        {
+            _messageOut.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void EnumsAreNotRepresentedAsStrings()
+        {
+            _jsonMessage.ShouldContain("EnumVal");
+            _jsonMessage.ShouldNotContain("Two");
+        }
+    }
+}

--- a/JustSaying/AwsTools/QueueCreation/RedrivePolicy.cs
+++ b/JustSaying/AwsTools/QueueCreation/RedrivePolicy.cs
@@ -1,13 +1,16 @@
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace JustSaying.AwsTools.QueueCreation
 {
     public class RedrivePolicy
     {
-        [JsonProperty(PropertyName = "maxReceiveCount")]
+        [JsonProperty("maxReceiveCount")]
+        [JsonPropertyName("maxReceiveCount")]
         public int MaximumReceives { get; set; }
 
-        [JsonProperty(PropertyName = "deadLetterTargetArn")]
+        [JsonProperty("deadLetterTargetArn")]
+        [JsonPropertyName("deadLetterTargetArn")]
         public string DeadLetterQueue { get; set; }
 
         public RedrivePolicy(int maximumReceives, string deadLetterQueue)
@@ -16,10 +19,14 @@ namespace JustSaying.AwsTools.QueueCreation
             DeadLetterQueue = deadLetterQueue;
         }
 
-        protected RedrivePolicy() { }
+        protected RedrivePolicy()
+        {
+        }
+
+        // Cannot use System.Text.Json below as no public parameterless constructor. Change for v7?
 
         public override string ToString()
-            => "{\"maxReceiveCount\":\"" + MaximumReceives + "\", \"deadLetterTargetArn\":\"" + DeadLetterQueue + "\"}";
+            => JsonConvert.SerializeObject(this);
 
         public static RedrivePolicy ConvertFromString(string policy)
             => JsonConvert.DeserializeObject<RedrivePolicy>(policy);

--- a/JustSaying/AwsTools/QueueCreation/ServerSideEncryption.cs
+++ b/JustSaying/AwsTools/QueueCreation/ServerSideEncryption.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace JustSaying.AwsTools.QueueCreation
@@ -10,10 +11,12 @@ namespace JustSaying.AwsTools.QueueCreation
             KmsDataKeyReusePeriodSeconds = JustSayingConstants.DefaultAttributeEncryptionKeyReusePeriodSecond;
         }
 
-        [JsonProperty(PropertyName = "kmsMasterKeyId")]
+        [JsonProperty("kmsMasterKeyId")]
+        [JsonPropertyName("kmsMasterKeyId")]
         public string KmsMasterKeyId { get; set; }
 
-        [JsonProperty(PropertyName = "kmsDataKeyReusePeriodSeconds")]
+        [JsonProperty("kmsDataKeyReusePeriodSeconds")]
+        [JsonPropertyName("kmsDataKeyReusePeriodSeconds")]
         public string KmsDataKeyReusePeriodSeconds { get; set; }
     }
 }

--- a/JustSaying/Fluent/ServicesBuilderExtensions.cs
+++ b/JustSaying/Fluent/ServicesBuilderExtensions.cs
@@ -1,0 +1,145 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using Newtonsoft.Json;
+
+namespace JustSaying.Fluent
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="ServicesBuilder"/> class.  This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ServicesBuilderExtensions
+    {
+        /// <summary>
+        /// Configures JustSaying to use <see cref="Newtonsoft.Json.JsonSerializer"/> for serialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="ServicesBuilder"/> to configure.</param>
+        /// <returns>
+        /// The <see cref="ServicesBuilder"/> passed as the value of <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static ServicesBuilder WithNewtonsoftJson(this ServicesBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.WithNewtonsoftJson(null as JsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Configures JustSaying to use <see cref="Newtonsoft.Json.JsonSerializer"/> for serialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="ServicesBuilder"/> to configure.</param>
+        /// <param name="settings">The JSON serialization settings to use.</param>
+        /// <returns>
+        /// The <see cref="ServicesBuilder"/> passed as the value of <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static ServicesBuilder WithNewtonsoftJson(this ServicesBuilder builder, JsonSerializerSettings settings)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.WithNewtonsoftJson(() => settings);
+        }
+
+        /// <summary>
+        /// Configures JustSaying to use <see cref="Newtonsoft.Json.JsonSerializer"/> for serialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="ServicesBuilder"/> to configure.</param>
+        /// <param name="factory">A delegate to a method to use to get the JSON serializer settings to use.</param>
+        /// <returns>
+        /// The <see cref="ServicesBuilder"/> passed as the value of <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="factory"/> is <see langword="null"/>.
+        /// </exception>
+        public static ServicesBuilder WithNewtonsoftJson(this ServicesBuilder builder, Func<JsonSerializerSettings> factory)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            return builder.WithMessageSerializationFactory(
+                () => new Messaging.MessageSerialization.NewtonsoftSerializationFactory(factory()));
+        }
+
+        /// <summary>
+        /// Configures JustSaying to use <see cref="System.Text.Json.JsonSerializer"/> for serialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="ServicesBuilder"/> to configure.</param>
+        /// <returns>
+        /// The <see cref="ServicesBuilder"/> passed as the value of <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static ServicesBuilder WithSystemTextJson(this ServicesBuilder builder)
+        {
+            return builder.WithSystemTextJson(null as JsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Configures JustSaying to use <see cref="System.Text.Json.JsonSerializer"/> for serialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="ServicesBuilder"/> to configure.</param>
+        /// <param name="settings">The JSON serialization options to use.</param>
+        /// <returns>
+        /// The <see cref="ServicesBuilder"/> passed as the value of <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static ServicesBuilder WithSystemTextJson(this ServicesBuilder builder, JsonSerializerOptions options)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.WithSystemTextJson(() => options);
+        }
+
+        /// <summary>
+        /// Configures JustSaying to use <see cref="System.Text.Json.JsonSerializer"/> for serialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="ServicesBuilder"/> to configure.</param>
+        /// <param name="factory">A delegate to a method to use to get the JSON serializer options to use.</param>
+        /// <returns>
+        /// The <see cref="ServicesBuilder"/> passed as the value of <paramref name="builder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="builder"/> or <paramref name="factory"/> is <see langword="null"/>.
+        /// </exception>
+        public static ServicesBuilder WithSystemTextJson(this ServicesBuilder builder, Func<JsonSerializerOptions> factory)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            return builder.WithMessageSerializationFactory(
+                () => new Messaging.MessageSerialization.SystemTextJsonSerializationFactory(factory()));
+        }
+    }
+}

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0-rc1.19456.4" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -9,7 +9,8 @@
     <PackageReference Include="AWSSDK.Core" Version="3.3.25.3" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.11" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-preview8.19405.3" />
   </ItemGroup>
 </Project>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0-preview9.19421.4" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-rc1.19456.4" />
   </ItemGroup>
 </Project>

--- a/JustSaying/JustSaying.csproj
+++ b/JustSaying/JustSaying.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.19" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0-preview8.19405.3" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-preview9.19421.4" />
   </ItemGroup>
 </Project>

--- a/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializationFactory.cs
+++ b/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializationFactory.cs
@@ -4,6 +4,8 @@ namespace JustSaying.Messaging.MessageSerialization
 {
     public class NewtonsoftSerializationFactory : IMessageSerializationFactory
     {
-        public IMessageSerializer GetSerializer<T>() where T : Message => new NewtonsoftSerializer();
+        private readonly NewtonsoftSerializer _serializer = new NewtonsoftSerializer();
+
+        public IMessageSerializer GetSerializer<T>() where T : Message => _serializer;
     }
 }

--- a/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializationFactory.cs
+++ b/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializationFactory.cs
@@ -1,10 +1,21 @@
 using JustSaying.Models;
+using Newtonsoft.Json;
 
 namespace JustSaying.Messaging.MessageSerialization
 {
     public class NewtonsoftSerializationFactory : IMessageSerializationFactory
     {
-        private readonly NewtonsoftSerializer _serializer = new NewtonsoftSerializer();
+        private readonly NewtonsoftSerializer _serializer;
+
+        public NewtonsoftSerializationFactory()
+            : this(null)
+        {
+        }
+
+        public NewtonsoftSerializationFactory(JsonSerializerSettings settings)
+        {
+            _serializer = new NewtonsoftSerializer(settings);
+        }
 
         public IMessageSerializer GetSerializer<T>() where T : Message => _serializer;
     }

--- a/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializer.cs
+++ b/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializer.cs
@@ -31,7 +31,7 @@ namespace JustSaying.Messaging.MessageSerialization
         public Message Deserialize(string message, Type type)
         {
             var document = JObject.Parse(message);
-            string json = document.Value<string>("Message");
+            string json = document["Message"].ToString();
 
             return (Message)JsonConvert.DeserializeObject(json, type, _settings);
         }

--- a/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializer.cs
+++ b/JustSaying/Messaging/MessageSerialization/NewtonsoftSerializer.cs
@@ -10,55 +10,52 @@ namespace JustSaying.Messaging.MessageSerialization
         private readonly JsonSerializerSettings _settings;
 
         public NewtonsoftSerializer()
+            : this(null)
         {
-            _settings = null;
         }
 
-        public NewtonsoftSerializer(JsonSerializerSettings settings) : this()
+        public NewtonsoftSerializer(JsonSerializerSettings settings)
         {
+            if (settings == null)
+            {
+                settings = new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    Converters = new JsonConverter[] { new Newtonsoft.Json.Converters.StringEnumConverter() }
+                };
+            }
+
             _settings = settings;
         }
 
         public Message Deserialize(string message, Type type)
         {
-            var jsqsMessage = JObject.Parse(message);
-            var messageBody = jsqsMessage["Message"].ToString();
-            return (Message)JsonConvert.DeserializeObject(messageBody, type, GetJsonSettings());
+            var document = JObject.Parse(message);
+            string json = document.Value<string>("Message");
+
+            return (Message)JsonConvert.DeserializeObject(json, type, _settings);
         }
 
         public string Serialize(Message message, bool serializeForSnsPublishing, string subject)
         {
-            var settings = GetJsonSettings();
-
-            var msg = JsonConvert.SerializeObject(message, settings);
+            var json = JsonConvert.SerializeObject(message, _settings);
 
             // AWS SNS service will add Subject and Message properties automatically, 
             // so just return plain message
             if (serializeForSnsPublishing)
             {
-                return msg;
+                return json;
             }
 
-            // for direct publishing to SQS, add Subject and Message properties manually
-            var context = new { Subject = subject, Message = msg };
-            return JsonConvert.SerializeObject(context);
-        }
-
-        private JsonSerializerSettings GetJsonSettings()
-        {
-            return _settings ?? new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                Converters = new JsonConverter[] { new Newtonsoft.Json.Converters.StringEnumConverter() }
-            };
+            // For direct publishing to SQS, add Subject and Message properties manually
+            var context = new { Subject = subject, Message = json };
+            return JsonConvert.SerializeObject(context, _settings);
         }
 
         public string GetMessageSubject(string sqsMessge)
         {
             var body = JObject.Parse(sqsMessge);
-
-            var type = body["Subject"] ?? string.Empty;
-            return type.ToString();
+            return body.Value<string>("Subject") ?? string.Empty;
         }
     }
 }

--- a/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializationFactory.cs
+++ b/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializationFactory.cs
@@ -1,0 +1,11 @@
+using JustSaying.Models;
+
+namespace JustSaying.Messaging.MessageSerialization
+{
+    public class SystemTextJsonSerializationFactory : IMessageSerializationFactory
+    {
+        private readonly SystemTextJsonSerializer _serializer = new SystemTextJsonSerializer();
+
+        public IMessageSerializer GetSerializer<T>() where T : Message => _serializer;
+    }
+}

--- a/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializationFactory.cs
+++ b/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializationFactory.cs
@@ -1,10 +1,21 @@
+using System.Text.Json;
 using JustSaying.Models;
 
 namespace JustSaying.Messaging.MessageSerialization
 {
     public class SystemTextJsonSerializationFactory : IMessageSerializationFactory
     {
-        private readonly SystemTextJsonSerializer _serializer = new SystemTextJsonSerializer();
+        private readonly SystemTextJsonSerializer _serializer;
+
+        public SystemTextJsonSerializationFactory()
+            : this(null)
+        {
+        }
+
+        public SystemTextJsonSerializationFactory(JsonSerializerOptions options)
+        {
+            _serializer = new SystemTextJsonSerializer(options);
+        }
 
         public IMessageSerializer GetSerializer<T>() where T : Message => _serializer;
     }

--- a/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializer.cs
+++ b/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializer.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Text.Json;
+using JustSaying.Models;
+
+namespace JustSaying.Messaging.MessageSerialization
+{
+    /// <summary>
+    /// A class representing an implementation of <see cref="IMessageSerializer"/> for the <c>System.Text.Json</c> serializer.
+    /// </summary>
+    public class SystemTextJsonSerializer : IMessageSerializer
+    {
+        private readonly JsonSerializerOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SystemTextJsonSerializer"/> class.
+        /// </summary>
+        public SystemTextJsonSerializer()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SystemTextJsonSerializer"/> class.
+        /// </summary>
+        /// <param name="options">The optional <see cref="JsonSerializerOptions"/> to use.</param>
+        public SystemTextJsonSerializer(JsonSerializerOptions options)
+        {
+            if (options == null)
+            {
+                options = new JsonSerializerOptions()
+                {
+                    IgnoreNullValues = true,
+                };
+
+                options.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+            }
+
+            _options = options;
+        }
+
+        /// <inheritdoc />
+        public string GetMessageSubject(string sqsMessge)
+        {
+            using (var body = JsonDocument.Parse(sqsMessge))
+            {
+                string subject = string.Empty;
+
+                if (body.RootElement.TryGetProperty("Subject", out var value))
+                {
+                    subject = value.GetString() ?? string.Empty;
+                }
+
+                return subject;
+            }
+        }
+
+        /// <inheritdoc />
+        public Message Deserialize(string message, Type type)
+        {
+            using (var document = JsonDocument.Parse(message))
+            {
+                string json = document.RootElement.GetProperty("Message").GetString();
+                return (Message)JsonSerializer.Deserialize(json, type, _options);
+            }
+        }
+
+        /// <inheritdoc />
+        public string Serialize(Message message, bool serializeForSnsPublishing, string subject)
+        {
+            string json = JsonSerializer.Serialize(message, message.GetType(), _options);
+
+            // AWS SNS service will add Subject and Message properties automatically, 
+            // so just return plain message
+            if (serializeForSnsPublishing)
+            {
+                return json;
+            }
+
+            // For direct publishing to SQS, add Subject and Message properties manually
+            var context = new { Subject = subject, Message = json };
+            return JsonSerializer.Serialize(context, _options);
+        }
+    }
+}

--- a/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializer.cs
+++ b/JustSaying/Messaging/MessageSerialization/SystemTextJsonSerializer.cs
@@ -59,7 +59,9 @@ namespace JustSaying.Messaging.MessageSerialization
         {
             using (var document = JsonDocument.Parse(message))
             {
-                string json = document.RootElement.GetProperty("Message").GetString();
+                JsonElement element = document.RootElement.GetProperty("Message");
+                string json = element.ToString();
+
                 return (Message)JsonSerializer.Deserialize(json, type, _options);
             }
         }


### PR DESCRIPTION
This PR adds support for the new System.Text.Json serializer being released with .NET Core 3.0. It also does some refactoring to the existing JSON.NET serializer to be a bit more memory efficient.

The new serializer is available as a [NuGet package](https://www.nuget.org/packages/System.Text.Json) targeting various target frameworks we already support, so doesn't require explicit .NET Core 3.0 targeting or SDK support.

The support is opt-in for two reasons:
  1) It's brand new;
  2) It is not compatible with all existing usage scenarios of Newtonsoft.Json. For example, it requires types to have a parameterless constructor in order to deserialize them. This is why I've changed one of the test message types.

I've left the PR as WIP until the final `4.6.0` NuGet package nversion is released in September.