### PR TITLE
[WIP] Switch to coverlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.cache
+*.coverage
 *.idea
 *.log
 *.orig
@@ -13,6 +14,7 @@ _ReSharper*
 .DS_Store
 artifacts
 bin
+coverage.*
 lint.db
 obj
 out

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <CoverletOutput>$(OutputPath)\</CoverletOutput>
+    <CoverletOutput Condition=" '$(OutputPath)' != '' ">$(OutputPath)\</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Benchmarks]*,[*Sample*]*,[*Test*]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,9 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19324-01" PrivateAssets="All" />
-    <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
@@ -43,5 +43,13 @@
     <ComVisible>false</ComVisible>
     <DebugType>embedded</DebugType>
     <EmbedAllSources Condition=" '$(IsTestProject)' != 'true' AND '$(NCrunch)' == '' ">true</EmbedAllSources>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutput>$(OutputPath)\</CoverletOutput>
+    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <Exclude>[*.Benchmarks]*,[*Sample*]*,[*Test*]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+    <MergeWith>$(CoverletOutput)coverage.json</MergeWith>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="coverlet.msbuild" Version="2.6.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19324-01" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.2.2" PrivateAssets="All" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,7 @@
     <EmbedAllSources Condition=" '$(IsTestProject)' != 'true' AND '$(NCrunch)' == '' ">true</EmbedAllSources>
   </PropertyGroup>
   <PropertyGroup>
-    <CollectCoverage>true</CollectCoverage>
+    <CollectCoverage Condition=" '$(CollectCoverage)' == '' ">true</CollectCoverage>
     <CoverletOutput Condition=" '$(OutputPath)' != '' ">$(OutputPath)\</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Benchmarks]*,[*Sample*]*,[*Test*]*,[xunit.*]*</Exclude>

--- a/JustSaying.IntegrationTests/Fluent/Subscribing/WhenTwoDifferentHandlersHandleAnExactlyOnceMessage.cs
+++ b/JustSaying.IntegrationTests/Fluent/Subscribing/WhenTwoDifferentHandlersHandleAnExactlyOnceMessage.cs
@@ -34,7 +34,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
 
                     // Act
                     await publisher.PublishAsync(new SimpleMessage(), cancellationToken);
-                    await Task.Delay(5.Seconds());
+                    await Task.Delay(10.Seconds());
 
                     // Assert
                     handler1.NumberOfTimesIHaveBeenCalled().ShouldBe(1);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build_script:
 after_build:
     - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
     - pip install codecov
-    - codecov -f "artifacts\code-coverage.xml"
+    - codecov -f "artifacts\coverage.cobertura.xml"
 
 nuget:
   disable_publish_on_pr: true

--- a/build.sh
+++ b/build.sh
@@ -25,5 +25,5 @@ dotnet build JustSaying/JustSaying.csproj --output $artifacts --configuration $c
 dotnet build JustSaying.Extensions.DependencyInjection.Microsoft/JustSaying.Extensions.DependencyInjection.Microsoft.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 dotnet build JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 
-dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj --output $artifacts '--logger:Console;verbosity=quiet' || exit 1
-dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj --output $artifacts '--logger:Console;verbosity=quiet' || exit 1
+dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj --output $artifacts || exit 1
+dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj --output $artifacts || exit 1

--- a/build.sh
+++ b/build.sh
@@ -25,5 +25,5 @@ dotnet build JustSaying/JustSaying.csproj --output $artifacts --configuration $c
 dotnet build JustSaying.Extensions.DependencyInjection.Microsoft/JustSaying.Extensions.DependencyInjection.Microsoft.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 dotnet build JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 
-dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj
-dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj --output $artifacts || exit 1
+dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj --output $artifacts || exit 1

--- a/build.sh
+++ b/build.sh
@@ -25,5 +25,5 @@ dotnet build JustSaying/JustSaying.csproj --output $artifacts --configuration $c
 dotnet build JustSaying.Extensions.DependencyInjection.Microsoft/JustSaying.Extensions.DependencyInjection.Microsoft.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 dotnet build JustSaying.Extensions.DependencyInjection.StructureMap/JustSaying.Extensions.DependencyInjection.StructureMap.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1
 
-dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj --output $artifacts || exit 1
-dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj --output $artifacts || exit 1
+dotnet test ./JustSaying.UnitTests/JustSaying.UnitTests.csproj --output $artifacts '--logger:Console;verbosity=quiet' || exit 1
+dotnet test ./JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj --output $artifacts '--logger:Console;verbosity=quiet' || exit 1

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ if [ "$CI" != "" -a "$TRAVIS_OS_NAME" == "linux" ]; then
     docker pull pafortin/goaws:$goaws_tag
     docker run -d --name goaws -p 4100:4100 pafortin/goaws:$goaws_tag
     export AWS_SERVICE_URL="http://localhost:4100"
+    export CollectCoverage="false"
 fi
 
 dotnet build JustSaying/JustSaying.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1


### PR DESCRIPTION
Switch to coverlet for code coverage from OpenCover.

coverlet is supported on non-Windows platforms, as well as being easier to configure.

Replaces #547 as that appears to have become detached from my fork somehow.
