### PR TITLE
Cancellable handler

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/HandlerMapTests.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/HandlerMapTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Models;
@@ -31,7 +32,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         public void HandlerIsReturnedForMatchingType()
         {
             var map = new HandlerMap();
-            map.Add(typeof(SimpleMessage), m => Task.FromResult(true));
+            map.Add(typeof(SimpleMessage), (m, ct) => Task.FromResult(true));
 
             var handler = map.Get(typeof(SimpleMessage));
 
@@ -42,7 +43,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         public void HandlerContainsKeyForMatchingTypeOnly()
         {
             var map = new HandlerMap();
-            map.Add(typeof(SimpleMessage), m => Task.FromResult(true));
+            map.Add(typeof(SimpleMessage), (m, ct) => Task.FromResult(true));
 
             map.ContainsKey(typeof(SimpleMessage)).ShouldBeTrue();
             map.ContainsKey(typeof(AnotherSimpleMessage)).ShouldBeFalse();
@@ -52,7 +53,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         public void HandlerIsNotReturnedForNonMatchingType()
         {
             var map = new HandlerMap();
-            map.Add(typeof(SimpleMessage), m => Task.FromResult(true));
+            map.Add(typeof(SimpleMessage), (m, ct) => Task.FromResult(true));
 
             var handler = map.Get(typeof(AnotherSimpleMessage));
 
@@ -62,8 +63,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         [Fact]
         public void CorrectHandlerIsReturnedForType()
         {
-            Func<Message, Task<bool>> fn1 = m => Task.FromResult(true);
-            Func<Message, Task<bool>> fn2 = m => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn1 = SuccessfulHandler;
+            Func<Message, CancellationToken, Task<bool>> fn2 = SuccessfulHandler;
 
             var map = new HandlerMap();
             map.Add(typeof(SimpleMessage), fn1);
@@ -81,8 +82,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         [Fact]
         public void MultipleHandlersForATypeAreNotSupported()
         {
-            Func<Message, Task<bool>> fn1 = m => Task.FromResult(true);
-            Func<Message, Task<bool>> fn2 = m => Task.FromResult(true);
+            Func<Message, CancellationToken, Task<bool>> fn1 = SuccessfulHandler;
+            Func<Message, CancellationToken, Task<bool>> fn2 = SuccessfulHandler;
 
             var map = new HandlerMap();
 
@@ -93,14 +94,24 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
         [Fact]
         public void MultipleHandlersForATypeWithOtherHandlersAreNotSupported()
         {
-            Func<Message, Task<bool>> fn1 = m => Task.FromResult(true);
-            Func<Message, Task<bool>> fn2 = m => Task.FromResult(false);
-            Func<Message, Task<bool>> fn3 = m => Task.FromResult(true);
+            Task<bool> FailedHandler(Message message, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(false);
+            }
+
+            Func<Message, CancellationToken, Task<bool>> fn1 = SuccessfulHandler;
+            Func<Message, CancellationToken, Task<bool>> fn2 = FailedHandler;
+            Func<Message, CancellationToken, Task<bool>> fn3 = SuccessfulHandler;
 
             var map = new HandlerMap();
             map.Add(typeof(SimpleMessage), fn1);
             map.Add(typeof(AnotherSimpleMessage), fn3);
             new Action(() => map.Add(typeof(SimpleMessage), fn2)).ShouldThrow<ArgumentException>();
+        }
+
+        private static Task<bool> SuccessfulHandler(Message message, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
         }
     }
 }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -105,7 +105,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             protected override void Given()
             {
                 base.Given();
-                _handlerMap.Add(typeof(OrderAccepted), m => Task.FromResult(true));
+                _handlerMap.Add(typeof(OrderAccepted), (m, ct) => Task.FromResult(true));
             }
 
             [Fact]
@@ -131,7 +131,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             {
                 base.Given();
                 _messageBackoffStrategy.GetBackoffDuration(_typedMessage, 1, _expectedException).Returns(_expectedBackoffTimeSpan);
-                _handlerMap.Add(typeof(OrderAccepted), m => throw _expectedException);
+                _handlerMap.Add(typeof(OrderAccepted), (m, ct) => throw _expectedException);
                 _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, ExpectedReceiveCount.ToString(CultureInfo.InvariantCulture));
             }
 
@@ -156,7 +156,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
                 _messageBackoffStrategy.GetBackoffDuration(_typedMessage, Arg.Any<int>()).Returns(TimeSpan.FromMinutes(4));
                 _amazonSqsClient.ChangeMessageVisibilityAsync(Arg.Any<ChangeMessageVisibilityRequest>()).Throws(new AmazonServiceException("Something gone wrong"));
 
-                _handlerMap.Add(typeof(OrderAccepted), m => Task.FromResult(false));
+                _handlerMap.Add(typeof(OrderAccepted), (m, ct) => Task.FromResult(false));
                 _sqsMessage.Attributes.Add(MessageSystemAttributeName.ApproximateReceiveCount, "1");
             }
 

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageHandlerWrapperTests.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageHandlerWrapperTests.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Messaging.MessageHandling;
@@ -35,7 +36,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
             // act
             var wrapped = handlerWrapper.WrapMessageHandler(() => mockHandler);
 
-            var result = await wrapped(new SimpleMessage());
+            var result = await wrapped(new SimpleMessage(), CancellationToken.None);
 
             result.ShouldBeTrue();
         }
@@ -55,7 +56,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling
             // act
             var wrapped = handlerWrapper.WrapMessageHandler(() => mockHandler);
 
-            await wrapped(testMessage);
+            await wrapped(testMessage, CancellationToken.None);
 
             await mockHandler.Received().Handle(testMessage);
         }

--- a/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenListeningStartsAndStops.cs
@@ -43,10 +43,12 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         {
             await base.WhenAsync();
 
-            var cts = new CancellationTokenSource();
-            SystemUnderTest.Listen(cts.Token);
+            using (var cts = new CancellationTokenSource())
+            {
+                SystemUnderTest.Listen(cts.Token);
 
-            cts.Cancel();
+                cts.Cancel();
+            }
         }
 
         [Fact]

--- a/JustSaying.UnitTests/Messaging/Monitoring/StopwatchHandlerTests.cs
+++ b/JustSaying.UnitTests/Messaging/Monitoring/StopwatchHandlerTests.cs
@@ -43,8 +43,6 @@ namespace JustSaying.UnitTests.Messaging.Monitoring
         public async Task WhenHandlerIsWrappedinStopWatch_MonitoringIsCalledWithCorrectTypes()
         {
             var handler = MockHandler();
-            var innnerHandlerName = handler.GetType().Name.ToLowerInvariant();
-
             var monitoring = Substitute.For<IMeasureHandlerExecutionTime>();
 
             var stopWatchHandler = new StopwatchHandler<OrderAccepted>(handler, monitoring);
@@ -73,8 +71,10 @@ namespace JustSaying.UnitTests.Messaging.Monitoring
         private static IHandlerAsync<OrderAccepted> MockHandler()
         {
             var handler = Substitute.For<IHandlerAsync<OrderAccepted>>();
+
             handler.Handle(Arg.Any<OrderAccepted>())
-                .Returns(true);
+                   .Returns(true);
+
             return handler;
         }
     }

--- a/JustSaying/AwsTools/MessageHandling/HandlerMap.cs
+++ b/JustSaying/AwsTools/MessageHandling/HandlerMap.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using HandlerFunc = System.Func<JustSaying.Models.Message, System.Threading.Tasks.Task<bool>>;
+using HandlerFunc = System.Func<JustSaying.Models.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>;
 
 namespace JustSaying.AwsTools.MessageHandling
 {

--- a/JustSaying/AwsTools/MessageHandling/MessageHandlerWrapper.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageHandlerWrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.Monitoring;
@@ -17,21 +18,36 @@ namespace JustSaying.AwsTools.MessageHandling
             _messagingMonitor = messagingMonitor;
         }
 
-        public Func<Message, Task<bool>> WrapMessageHandler<T>(Func<IHandlerAsync<T>> futureHandler) where T : Message
+        public Func<Message, CancellationToken, Task<bool>> WrapMessageHandler<T>(Func<ICancellableHandlerAsync<T>> futureHandler) where T : Message
         {
-            return async message =>
+            return async (message, cancellationToken) =>
             {
-                var handler = futureHandler();
-                handler = MaybeWrapWithExactlyOnce(handler);
+                ICancellableHandlerAsync<T> rootHandler = futureHandler();
+                ICancellableHandlerAsync<T> handler = rootHandler;
+
+                handler = MaybeWrapWithExactlyOnce(handler, rootHandler.GetType());
                 handler = MaybeWrapWithStopwatch(handler);
 
-                return await handler.Handle((T)message).ConfigureAwait(false);
+                return await handler.HandleAsync((T)message, cancellationToken).ConfigureAwait(false);
             };
         }
 
-        private IHandlerAsync<T> MaybeWrapWithExactlyOnce<T>(IHandlerAsync<T> handler) where T : Message
+        public Func<Message, CancellationToken, Task<bool>> WrapMessageHandler<T>(Func<IHandlerAsync<T>> futureHandler) where T : Message
         {
-            var handlerType = handler.GetType();
+            return async (message, cancellationToken) =>
+            {
+                IHandlerAsync<T> rootHandler = futureHandler();
+                ICancellableHandlerAsync<T> handler = new CancellableHandlerAdapter<T>(rootHandler);
+
+                handler = MaybeWrapWithExactlyOnce(handler, rootHandler.GetType());
+                handler = MaybeWrapWithStopwatch(handler);
+
+                return await handler.HandleAsync((T)message, CancellationToken.None).ConfigureAwait(false);
+            };
+        }
+
+        private ICancellableHandlerAsync<T> MaybeWrapWithExactlyOnce<T>(ICancellableHandlerAsync<T> handler, Type handlerType) where T : Message
+        {
             var exactlyOnceMetadata = new ExactlyOnceReader(handlerType);
             if (!exactlyOnceMetadata.Enabled)
             {
@@ -49,7 +65,7 @@ namespace JustSaying.AwsTools.MessageHandling
             return new ExactlyOnceHandler<T>(handler, _messageLock, timeout, handlerName);
         }
 
-        private IHandlerAsync<T> MaybeWrapWithStopwatch<T>(IHandlerAsync<T> handler) where T : Message
+        private ICancellableHandlerAsync<T> MaybeWrapWithStopwatch<T>(ICancellableHandlerAsync<T> handler) where T : Message
         {
             if (!(_messagingMonitor is IMeasureHandlerExecutionTime executionTimeMonitoring))
             {
@@ -57,6 +73,26 @@ namespace JustSaying.AwsTools.MessageHandling
             }
 
             return new StopwatchHandler<T>(handler, executionTimeMonitoring);
+        }
+
+        private sealed class CancellableHandlerAdapter<T> : ICancellableHandlerAsync<T>
+        {
+            private readonly IHandlerAsync<T> _inner;
+
+            internal CancellableHandlerAdapter(IHandlerAsync<T> inner)
+            {
+                _inner = inner;
+            }
+
+            public async Task<bool> Handle(T message)
+            {
+                return await _inner.Handle(message).ConfigureAwait(false);
+            }
+
+            public async Task<bool> HandleAsync(T message, CancellationToken cancellationToken)
+            {
+                return await _inner.Handle(message).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/JustSaying/Messaging/MessageHandling/ICancellableHandlerAsync.cs
+++ b/JustSaying/Messaging/MessageHandling/ICancellableHandlerAsync.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace JustSaying.Messaging.MessageHandling
+{
+    /// <summary>
+    /// An asynchronous message handler that supports cancellation.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of the message to handle.
+    /// </typeparam>
+    public interface ICancellableHandlerAsync<in T> : IHandlerAsync<T>
+    {
+        /// <summary>
+        /// Handles a message of type <typeparamref name="T"/> as an asynchronous operation.
+        /// </summary>
+        /// <param name="message">
+        /// The message to handle.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which is cancelled when the message visibility timeout expires.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation
+        /// to process the message that returns <see langword="true"/> if the message
+        /// was processed successfully; otherwise <see langword="false"/>.
+        /// </returns>
+        Task<bool> HandleAsync(T message, CancellationToken cancellationToken);
+    }
+}

--- a/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
+++ b/JustSaying/Messaging/Monitoring/StopwatchHandler.cs
@@ -1,29 +1,44 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;
 
 namespace JustSaying.Messaging.Monitoring
 {
-    public class StopwatchHandler<T> : IHandlerAsync<T> where T : Message
+    public class StopwatchHandler<T> : IHandlerAsync<T>, ICancellableHandlerAsync<T>
+        where T : Message
     {
-        private readonly IHandlerAsync<T> _inner;
+        private readonly Func<T, CancellationToken, Task<bool>> _inner;
         private readonly IMeasureHandlerExecutionTime _monitoring;
         private readonly Type _handlerType;
 
         public StopwatchHandler(IHandlerAsync<T> inner, IMeasureHandlerExecutionTime monitoring)
         {
-            _inner = inner;
+            _handlerType = inner.GetType();
             _monitoring = monitoring;
-            _handlerType = _inner.GetType();
+
+            if (inner is ICancellableHandlerAsync<T> cancellable)
+            {
+                _inner = cancellable.HandleAsync;
+            }
+            else
+            {
+                _inner = async (message, _) => await inner.Handle(message).ConfigureAwait(false);
+            }
         }
 
         public async Task<bool> Handle(T message)
         {
+            return await HandleAsync(message, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<bool> HandleAsync(T message, CancellationToken cancellationToken)
+        {
             var stopwatch = Stopwatch.StartNew();
 
-            bool result = await _inner.Handle(message).ConfigureAwait(false);
+            bool result = await _inner(message, cancellationToken).ConfigureAwait(false);
 
             stopwatch.Stop();
 


### PR DESCRIPTION
I had an idea this morning based on the changes in #546, so I thought I'd see how far I could get with it and submit a PR for discussion.

In the event that the issue that lead to #546 occurring and tasks to process messages back up, it's possible that a task to process a message may be trying to process a message that was received so long ago that the message visibility timeout has expired and it is now a potential duplicate waiting to be processed.

If the handler had a `CancellationToken` that cancels after the _approximate_ message visibility timeout expires, JustSaying could enable two behaviours:

  1) It could self-cancel trying to do anything with the message before getting to the handler and abandoning it (potentially just extending the visibility instead, but I've not done that here).
  2) The handler, when called, could observe the cancellation token itself and make a decision about what to do with the message. It could return `false` to send it back to the queue (where it could have since been handled elsewhere anyway), or it could return `true` on the basis, if this has expired I'll just ignore it and pretend I've dealt with it.

This is implemented here by adding the `ICancellableHandlerAsync<T>` interface that derives from `IHandlerAsync<T>`, and then plumbing it in appropriately so it's used if implemented by the handler for a particular message and extending things like the exactly-once handler and stopwatch wrappers.

Replaces #549.