### PR TITLE
[WIP] Allow more control around the SqsNotificationListener loop

### DIFF
--- a/src/JustSaying/AwsTools/MessageHandling/IMessageCoordinator.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageCoordinator.cs
@@ -4,7 +4,7 @@ using JustSaying.Messaging.MessageProcessingStrategies;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
-    public interface IMessageCoordinator
+    internal interface IMessageCoordinator
     {
         Task ListenAsync(CancellationToken cancellationToken);
         void WithMessageProcessingStrategy(IMessageProcessingStrategy messageProcessingStrategy);

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageCoordinator.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageCoordinator.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+using JustSaying.Messaging.MessageProcessingStrategies;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    public interface IMessageCoordinator
+    {
+        Task ListenAsync(CancellationToken cancellationToken);
+        void WithMessageProcessingStrategy(IMessageProcessingStrategy messageProcessingStrategy);
+        string QueueName { get; }
+        string Region { get; }
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageDispatcher.cs
@@ -1,11 +1,15 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.SQS.Model;
+using JustSaying.Messaging.MessageHandling;
+using Message = JustSaying.Models.Message;
+using SQSMessage = Amazon.SQS.Model.Message;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
     public interface IMessageDispatcher
     {
-        Task DispatchMessage(Message message, CancellationToken cancellationToken);
+        Task DispatchMessage(SQSMessage message, CancellationToken cancellationToken);
+        bool AddMessageHandler<T>(Func<IHandlerAsync<T>> futureHandler) where T : Message;
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageDispatcher.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    public interface IMessageDispatcher
+    {
+        Task DispatchMessage(Message message, CancellationToken cancellationToken);
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageReceiver.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageReceiver.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
-    public interface IMessageRequester
+    internal interface IMessageReceiver
     {
         Task<ReceiveMessageResponse> GetMessages(int maxNumberOfMessages, CancellationToken ct);
         string QueueName { get; }

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageReceiver.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageReceiver.cs
@@ -6,7 +6,7 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     public interface IMessageReceiver
     {
-        Task<ReceiveMessageResponse> GetMessages(int maxNumberOfMessages, CancellationToken ct);
+        Task<ReceiveMessageResponse> GetMessagesAsync(int maxNumberOfMessages, CancellationToken ct);
         string QueueName { get; }
         string Region { get; }
     }

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageReceiver.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageReceiver.cs
@@ -4,7 +4,7 @@ using Amazon.SQS.Model;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
-    internal interface IMessageReceiver
+    public interface IMessageReceiver
     {
         Task<ReceiveMessageResponse> GetMessages(int maxNumberOfMessages, CancellationToken ct);
         string QueueName { get; }

--- a/src/JustSaying/AwsTools/MessageHandling/IMessageRequester.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/IMessageRequester.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    public interface IMessageRequester
+    {
+        Task<ReceiveMessageResponse> GetMessages(int maxNumberOfMessages, CancellationToken ct);
+        string QueueName { get; }
+        string Region { get; }
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/ISqsQueue.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/ISqsQueue.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SQS;
+using JustSaying.AwsTools.QueueCreation;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    public interface ISqsQueue
+    {
+        IAmazonSQS Client { get; }
+        string QueueName { get; }
+        RegionEndpoint Region { get; }
+        Uri Uri { get; }
+
+        // todo: why aren't these used?/where can they be used externally?
+        // Task DeleteAsync();
+        // Task<bool> ExistsAsync();
+        // Task UpdateQueueAttributeAsync(SqsBasicConfiguration queueConfig);
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/MessageCoordinator.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageCoordinator.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    public class MessageCoordinator : IMessageCoordinator
+    {
+        private readonly ILogger _log;
+        private readonly IMessageRequester _messageRequester;
+        private readonly IMessageDispatcher _messageDispatcher;
+        private IMessageProcessingStrategy _messageProcessingStrategy;
+
+        public MessageCoordinator(
+            ILogger log,
+            IMessageRequester messageRequester,
+            IMessageDispatcher messageDispatcher,
+            IMessageProcessingStrategy messageProcessingStrategy)
+        {
+            _log = log;
+            _messageRequester = messageRequester;
+            _messageDispatcher = messageDispatcher;
+            _messageProcessingStrategy = messageProcessingStrategy;
+        }
+
+        public string QueueName => _messageRequester.QueueName;
+        public string Region => _messageRequester.Region;
+
+        public void WithMessageProcessingStrategy(IMessageProcessingStrategy messageProcessingStrategy)
+        {
+            _messageProcessingStrategy = messageProcessingStrategy;
+        }
+
+        public async Task ListenAsync(CancellationToken cancellationToken)
+        {
+            await ListenLoopAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task ListenLoopAsync(CancellationToken ct)
+        {
+            ReceiveMessageResponse sqsMessageResponse = null;
+
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    sqsMessageResponse = await GetMessagesFromSqsQueueAsync(ct).ConfigureAwait(false);
+
+                    int messageCount = sqsMessageResponse?.Messages?.Count ?? 0;
+
+                    _log.LogTrace(
+                        "Polled for messages on queue '{QueueName}' in region '{Region}', and received {MessageCount} messages.",
+                        _messageRequester.QueueName,
+                        _messageRequester.Region,
+                        messageCount);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    _log.LogTrace(
+                        ex,
+                        "Could not determine number of messages to read from queue '{QueueName}' in '{Region}'.",
+                        _messageRequester.QueueName,
+                        _messageRequester.Region);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _log.LogTrace(
+                        ex,
+                        "Suspected no message on queue '{QueueName}' in region '{Region}'.",
+                        _messageRequester.QueueName,
+                        _messageRequester.Region);
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    _log.LogError(
+                        ex,
+                        "Error receiving messages on queue '{QueueName}' in region '{Region}'.",
+                        _messageRequester.QueueName,
+                        _messageRequester.Region);
+                }
+
+                if (sqsMessageResponse == null || sqsMessageResponse.Messages.Count < 1)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    foreach (var message in sqsMessageResponse.Messages)
+                    {
+                        if (ct.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        if (!await TryHandleMessageAsync(message, ct).ConfigureAwait(false))
+                        {
+                            // No worker free to process any messages
+                            _log.LogWarning(
+                                "Unable to process message with Id {MessageId} for queue '{QueueName}' in region '{Region}' as no workers are available.",
+                                message.MessageId,
+                                _messageRequester.QueueName,
+                        _messageRequester.Region);
+                        }
+                    }
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    _log.LogError(
+                        ex,
+                        "Error in message handling loop for queue '{QueueName}' in region '{Region}'.",
+                        _messageRequester.QueueName,
+                        _messageRequester.Region);
+                }
+            }
+        }
+
+        private async Task<ReceiveMessageResponse> GetMessagesFromSqsQueueAsync(CancellationToken ct)
+        {
+            int maxNumberOfMessages = await GetDesiredNumberOfMessagesToRequestFromSqsAsync()
+                .ConfigureAwait(false);
+
+            if (maxNumberOfMessages < 1)
+            {
+                return null;
+            }
+
+            var sqsMessageResponse = await _messageRequester.GetMessages(maxNumberOfMessages, ct).ConfigureAwait(false);
+
+            return sqsMessageResponse;
+        }
+
+        private async Task<int> GetDesiredNumberOfMessagesToRequestFromSqsAsync()
+        {
+            int maximumMessagesFromAws = MessageConstants.MaxAmazonMessageCap;
+            int maximumWorkers = _messageProcessingStrategy.MaxConcurrency;
+
+            int messagesToRequest = Math.Min(maximumWorkers, maximumMessagesFromAws);
+
+            if (messagesToRequest < 1)
+            {
+                // Wait for the strategy to have at least one worker available
+                int availableWorkers = await _messageProcessingStrategy.WaitForAvailableWorkerAsync().ConfigureAwait(false);
+
+                messagesToRequest = Math.Min(availableWorkers, maximumMessagesFromAws);
+            }
+
+            if (messagesToRequest < 1)
+            {
+                _log.LogWarning("No workers are available to process SQS messages.");
+                messagesToRequest = 0;
+            }
+
+            return messagesToRequest;
+        }
+
+        private Task<bool> TryHandleMessageAsync(Amazon.SQS.Model.Message message, CancellationToken ct)
+        {
+            async Task DispatchAsync()
+            {
+                await _messageDispatcher.DispatchMessage(message, ct).ConfigureAwait(false);
+            }
+
+            return _messageProcessingStrategy.StartWorkerAsync(DispatchAsync, ct);
+        }
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/MessageCoordinator.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageCoordinator.cs
@@ -41,48 +41,9 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public async Task ListenLoopAsync(CancellationToken ct)
         {
-            ReceiveMessageResponse sqsMessageResponse = null;
-
             while (!ct.IsCancellationRequested)
             {
-                try
-                {
-                    sqsMessageResponse = await GetMessagesFromSqsQueueAsync(ct).ConfigureAwait(false);
-
-                    int messageCount = sqsMessageResponse?.Messages?.Count ?? 0;
-
-                    _log.LogTrace(
-                        "Polled for messages on queue '{QueueName}' in region '{Region}', and received {MessageCount} messages.",
-                        _messageReceiver.QueueName,
-                        _messageReceiver.Region,
-                        messageCount);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    _log.LogTrace(
-                        ex,
-                        "Could not determine number of messages to read from queue '{QueueName}' in '{Region}'.",
-                        _messageReceiver.QueueName,
-                        _messageReceiver.Region);
-                }
-                catch (OperationCanceledException ex)
-                {
-                    _log.LogTrace(
-                        ex,
-                        "Suspected no message on queue '{QueueName}' in region '{Region}'.",
-                        _messageReceiver.QueueName,
-                        _messageReceiver.Region);
-                }
-#pragma warning disable CA1031
-                catch (Exception ex)
-#pragma warning restore CA1031
-                {
-                    _log.LogError(
-                        ex,
-                        "Error receiving messages on queue '{QueueName}' in region '{Region}'.",
-                        _messageReceiver.QueueName,
-                        _messageReceiver.Region);
-                }
+                ReceiveMessageResponse sqsMessageResponse = await GetMessagesFromSqsQueueAsync(ct).ConfigureAwait(false);
 
                 if (sqsMessageResponse == null || sqsMessageResponse.Messages.Count < 1)
                 {
@@ -105,7 +66,7 @@ namespace JustSaying.AwsTools.MessageHandling
                                 "Unable to process message with Id {MessageId} for queue '{QueueName}' in region '{Region}' as no workers are available.",
                                 message.MessageId,
                                 _messageReceiver.QueueName,
-                        _messageReceiver.Region);
+                                _messageReceiver.Region);
                         }
                     }
                 }
@@ -132,7 +93,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 return null;
             }
 
-            var sqsMessageResponse = await _messageReceiver.GetMessages(maxNumberOfMessages, ct).ConfigureAwait(false);
+            var sqsMessageResponse = await _messageReceiver.GetMessagesAsync(maxNumberOfMessages, ct).ConfigureAwait(false);
 
             return sqsMessageResponse;
         }

--- a/src/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -15,7 +15,7 @@ using SQSMessage = Amazon.SQS.Model.Message;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
-    public class MessageDispatcher
+    public class MessageDispatcher : IMessageDispatcher
     {
         private readonly ISqsQueue _queue;
         private readonly IMessageSerializationRegister _serializationRegister;

--- a/src/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -17,7 +17,7 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     public class MessageDispatcher
     {
-        private readonly SqsQueueBase _queue;
+        private readonly ISqsQueue _queue;
         private readonly IMessageSerializationRegister _serializationRegister;
         private readonly IMessageMonitor _messagingMonitor;
         private readonly Action<Exception, SQSMessage> _onError;
@@ -28,7 +28,7 @@ namespace JustSaying.AwsTools.MessageHandling
         private static ILogger _logger;
 
         public MessageDispatcher(
-            SqsQueueBase queue,
+            ISqsQueue queue,
             IMessageSerializationRegister serializationRegister,
             IMessageMonitor messagingMonitor,
             Action<Exception, SQSMessage> onError,

--- a/src/JustSaying/AwsTools/MessageHandling/MessageReceiver.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageReceiver.cs
@@ -10,18 +10,17 @@ using Microsoft.Extensions.Logging;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
-    // todo: internal?
-    public class MessageRequester : IMessageRequester
+    internal class MessageReceiver : IMessageReceiver
     {
         private readonly ISqsQueue _queue;
         private readonly IMessageMonitor _messagingMonitor;
-        private readonly ILogger<MessageRequester> _logger;
+        private readonly ILogger _logger;
         private readonly List<string> _requestMessageAttributeNames = new List<string>();
 
-        public MessageRequester(
+        public MessageReceiver(
             ISqsQueue queue,
             IMessageMonitor messagingMonitor,
-            ILogger<MessageRequester> logger,
+            ILogger<MessageReceiver> logger,
             IMessageBackoffStrategy messageBackoffStrategy)
         {
             _queue = queue;

--- a/src/JustSaying/AwsTools/MessageHandling/MessageReceiver.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageReceiver.cs
@@ -38,6 +38,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
         public async Task<ReceiveMessageResponse> GetMessages(int maxNumberOfMessages, CancellationToken ct)
         {
+            // todo: configurable wait time?
             var request = new ReceiveMessageRequest
             {
                 QueueUrl = _queue.Uri.AbsoluteUri,

--- a/src/JustSaying/AwsTools/MessageHandling/MessageRequester.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageRequester.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace JustSaying.AwsTools.MessageHandling
+{
+    // todo: internal?
+    public class MessageRequester : IMessageRequester
+    {
+        private readonly ISqsQueue _queue;
+        private readonly IMessageMonitor _messagingMonitor;
+        private readonly ILogger<MessageRequester> _logger;
+        private readonly List<string> _requestMessageAttributeNames = new List<string>();
+
+        public MessageRequester(
+            ISqsQueue queue,
+            IMessageMonitor messagingMonitor,
+            ILogger<MessageRequester> logger,
+            IMessageBackoffStrategy messageBackoffStrategy)
+        {
+            _queue = queue;
+            _messagingMonitor = messagingMonitor;
+            _logger = logger;
+
+            if (messageBackoffStrategy != null)
+            {
+                _requestMessageAttributeNames.Add(MessageSystemAttributeName.ApproximateReceiveCount);
+            }
+        }
+
+        public string QueueName => _queue?.QueueName;
+        public string Region => _queue?.Region?.SystemName;
+
+        public async Task<ReceiveMessageResponse> GetMessages(int maxNumberOfMessages, CancellationToken ct)
+        {
+            var request = new ReceiveMessageRequest
+            {
+                QueueUrl = _queue.Uri.AbsoluteUri,
+                MaxNumberOfMessages = maxNumberOfMessages,
+                WaitTimeSeconds = 20,
+                AttributeNames = _requestMessageAttributeNames
+            };
+
+            using var receiveTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+            ReceiveMessageResponse sqsMessageResponse;
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            try
+            {
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, receiveTimeout.Token);
+
+                sqsMessageResponse = await _queue.Client.ReceiveMessageAsync(request, linkedCts.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (receiveTimeout.Token.IsCancellationRequested)
+                {
+                    _logger.LogInformation("Timed out while receiving messages from queue '{QueueName}' in region '{Region}'.",
+                        QueueName, Region);
+                }
+            }
+
+            stopwatch.Stop();
+
+            _messagingMonitor.ReceiveMessageTime(stopwatch.Elapsed, QueueName, Region);
+
+            return sqsMessageResponse;
+        }
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsNotificationListener.cs
@@ -18,7 +18,7 @@ namespace JustSaying.AwsTools.MessageHandling
 {
     public class SqsNotificationListener : INotificationSubscriber
     {
-        private readonly SqsQueueBase _queue;
+        private readonly ISqsQueue _queue;
         private readonly IMessageMonitor _messagingMonitor;
         private readonly List<string> _requestMessageAttributeNames = new List<string>();
 
@@ -32,7 +32,7 @@ namespace JustSaying.AwsTools.MessageHandling
         public bool IsListening { get; private set; }
 
         public SqsNotificationListener(
-            SqsQueueBase queue,
+            ISqsQueue queue,
             IMessageSerializationRegister serializationRegister,
             IMessageMonitor messagingMonitor,
             ILoggerFactory loggerFactory,
@@ -135,7 +135,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 try
                 {
-                    sqsMessageResponse = await GetMessagesFromSqsQueueAsync(queueName, regionName, ct).ConfigureAwait(false);
+                  sqsMessageResponse = await GetMessagesFromSqsQueueAsync(queueName, regionName, ct).ConfigureAwait(false);
 
                     int messageCount = sqsMessageResponse?.Messages?.Count ?? 0;
 

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -10,7 +10,7 @@ using JustSaying.Extensions;
 
 namespace JustSaying.AwsTools.MessageHandling
 {
-    public abstract class SqsQueueBase
+    public abstract class SqsQueueBase : ISqsQueue
     {
         public string Arn { get; protected set; }
         public Uri Uri { get; protected set; }

--- a/src/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/src/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -38,5 +38,10 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         /// will be available immediately when <see cref="StartWorkerAsync"/> is subsequently called.
         /// </remarks>
         Task<int> WaitForAvailableWorkerAsync();
+
+        /// <summary>
+        /// Notifies of a successful message received, waits for any debounce/circuit break logic.
+        /// </summary>
+        Task ReportMessageReceived(bool success);
     }
 }

--- a/src/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
+++ b/src/JustSaying/Messaging/MessageProcessingStrategies/IMessageProcessingStrategy.cs
@@ -42,6 +42,8 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
         /// <summary>
         /// Notifies of a successful message received, waits for any debounce/circuit break logic.
         /// </summary>
-        Task ReportMessageReceived(bool success);
+        /// <param name="wasMessageRetrieved">Indicates whether the last request to SQS was successful.</param>
+        /// <returns>The caller waits for the returned task to complete before requesting the next messages.</returns>
+        Task WaitForThrottlingAsync(bool anyMessagesRetrieved);
     }
 }

--- a/src/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/src/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
@@ -146,7 +146,7 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             return _semaphore.CurrentCount;
         }
 
-        public Task ReportMessageReceived(bool success)
+        public Task WaitForThrottlingAsync(bool anyMessagesRetrieved)
         {
             return Task.CompletedTask;
         }

--- a/src/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
+++ b/src/JustSaying/Messaging/MessageProcessingStrategies/Throttled.cs
@@ -146,6 +146,11 @@ namespace JustSaying.Messaging.MessageProcessingStrategies
             return _semaphore.CurrentCount;
         }
 
+        public Task ReportMessageReceived(bool success)
+        {
+            return Task.CompletedTask;
+        }
+
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/BaseQueuePollingTest.cs
@@ -7,6 +7,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.Messaging.Monitoring;
 using JustSaying.TestingFramework;
@@ -68,9 +69,14 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         {
             var queue = new SqsQueueByUrl(RegionEndpoint.EUWest1, new Uri(QueueUrl), Sqs);
             var listener = new JustSaying.AwsTools.MessageHandling.SqsNotificationListener(
-                queue, SerializationRegister, Monitor, LoggerFactory,
+                queue,
+                SerializationRegister,
+                Monitor,
+                LoggerFactory,
                 Substitute.For<IMessageContextAccessor>(),
-                null, MessageLock);
+                new DefaultThrottledThroughput(Monitor, LoggerFactory.CreateLogger("test")),
+                onError: null,
+                messageLock: MessageLock);
             return listener;
         }
 

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -52,5 +52,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             TaskHelpers.DelaySendDone(_doneSignal);
             throw new TestException("Thrown by test ProcessMessage");
         }
+
+        public Task ReportMessageReceived(bool success)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingBeforeMessageProcessingStrategy.cs
@@ -53,7 +53,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             throw new TestException("Thrown by test ProcessMessage");
         }
 
-        public Task ReportMessageReceived(bool success)
+        public Task WaitForThrottlingAsync(bool anyMessagesRetrieved)
         {
             return Task.CompletedTask;
         }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -39,5 +39,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             TaskHelpers.DelaySendDone(_doneSignal);
             throw new TestException("Thrown by test ProcessMessage");
         }
+
+        public Task ReportMessageReceived(bool success)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/Support/ThrowingDuringMessageProcessingStrategy.cs
@@ -40,7 +40,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener.
             throw new TestException("Thrown by test ProcessMessage");
         }
 
-        public Task ReportMessageReceived(bool success)
+        public Task WaitForThrottlingAsync(bool anyMessagesRetrieved)
         {
             return Task.CompletedTask;
         }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JustSaying.Messaging.MessageProcessingStrategies;
+
+namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
+{
+    public class TestMessageProcessingStrategy : IMessageProcessingStrategy
+    {
+        public int MaxConcurrency => 1;
+
+        public async Task<bool> StartWorkerAsync(Func<Task> action, CancellationToken cancellationToken)
+        {
+            await action();
+            return true;
+        }
+
+        public Task<int> WaitForAvailableWorkerAsync()
+        {
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
@@ -20,7 +20,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
             return Task.FromResult(MaxConcurrency);
         }
 
-        public Task ReportMessageReceived(bool success)
+        public Task WaitForThrottlingAsync(bool anyMessagesRetrieved)
         {
             return Task.CompletedTask;
         }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
@@ -19,5 +19,10 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
         {
             return Task.FromResult(MaxConcurrency);
         }
+
+        public Task ReportMessageReceived(bool success)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/TestMessageProcessingStrategy.cs
@@ -17,7 +17,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
 
         public Task<int> WaitForAvailableWorkerAsync()
         {
-            return Task.FromResult(1);
+            return Task.FromResult(MaxConcurrency);
         }
     }
 }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreExceptionsInMessageProcessing.cs
@@ -7,6 +7,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.Messaging.Monitoring;
 using JustSaying.TestingFramework;
@@ -54,7 +55,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
                 _serializationRegister,
                 Substitute.For<IMessageMonitor>(),
                 Substitute.For<ILoggerFactory>(),
-                Substitute.For<IMessageContextAccessor>());
+                Substitute.For<IMessageContextAccessor>(),
+                new TestMessageProcessingStrategy());
 
             return listener;
         }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/SqsNotificationListener/WhenThereAreNoMessagesToProcess.cs
@@ -7,6 +7,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using JustSaying.AwsTools.MessageHandling;
 using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.Monitoring;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -28,7 +29,8 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener
                 null,
                 Substitute.For<IMessageMonitor>(),
                 Substitute.For<ILoggerFactory>(),
-                Substitute.For<IMessageContextAccessor>());
+                Substitute.For<IMessageContextAccessor>(),
+                new TestMessageProcessingStrategy());
             return listener;
         }
 

--- a/tests/JustSaying.UnitTests/NotificationListener/CanListenToMultipleQueues.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/CanListenToMultipleQueues.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SQS;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Monitoring;
+using JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+using static JustSaying.UnitTests.NotificationListener.CanSubscribeAndListen;
+
+namespace JustSaying.UnitTests.NotificationListener
+{
+    public class CanCreateMultipleListeners
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public CanCreateMultipleListeners(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public void CanListen_StopsListeningWhenTokenCancelled()
+        {
+            // Arrange
+            var sqsClient1 = CreateSqsClient();
+            var sqsClient2 = CreateSqsClient();
+            var listeners = CreateListeners(_outputHelper.ToLoggerFactory(), new[] { sqsClient1, sqsClient2 });
+            Assert.Equal(2, listeners.Count);
+
+            // Act
+            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+            foreach (var listener in listeners)
+            {
+                listener.Listen(cts.Token);
+            }
+
+            // Assert
+            foreach (var listener in listeners)
+            {
+                Assert.True(listener.IsListening);
+            }
+        }
+
+        [Fact]
+        public async Task OneQueueThrowingErrors_OtherContinuesToProcessMessages()
+        {
+            // Arrange
+            var myProperty = "hello-just-saying";
+            var message = new TestMessage { MyProperty = myProperty };
+            var serializationRegister = CreateSerializationRegister(message);
+
+            var sqsClient1 = CreateSqsClient();
+            var sqsClient2 = CreateSqsClient();
+            var listeners = CreateListeners(
+                _outputHelper.ToLoggerFactory(), new[] { sqsClient1, sqsClient2 }, serializationRegister);
+            Assert.Equal(2, listeners.Count);
+
+            var successfulHandler = CreateHandler<TestMessage>(true);
+            var handlerWithException = CreateHandlerWithException<TestMessage>();
+
+            var listener1 = listeners[0];
+            var listener2 = listeners[1];
+
+            listener1.AddMessageHandler<TestMessage>(() => successfulHandler);
+            listener2.AddMessageHandler<TestMessage>(() => handlerWithException);
+
+            // Act
+            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+            foreach (var listener in listeners)
+            {
+                listener.Listen(cts.Token);
+            }
+
+            // Assert
+            await successfulHandler.Received()
+                .Handle(Arg.Is<TestMessage>(msg => msg.MyProperty == myProperty));
+
+            await sqsClient1.Received()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+
+            await handlerWithException.Received()
+                .Handle(Arg.Is<TestMessage>(msg => msg.MyProperty == myProperty));
+
+            await sqsClient2.DidNotReceive()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        private static List<INotificationSubscriber> CreateListeners(
+            ILoggerFactory loggerFactory,
+            IEnumerable<IAmazonSQS> sqsClients,
+            IMessageSerializationRegister messageSerializationRegister = null)
+        {
+            loggerFactory ??= Substitute.For<ILoggerFactory>();
+            messageSerializationRegister ??= CreateSerializationRegister();
+            var messageMonitor = Substitute.For<IMessageMonitor>();
+            var messageContextAccessor = Substitute.For<IMessageContextAccessor>();
+            var messageProcessingStrategy = new TestMessageProcessingStrategy();
+            var onError = Substitute.For<Action<Exception, Amazon.SQS.Model.Message>>();
+            var messageLockAsync = Substitute.For<IMessageLockAsync>();
+            var messageBackoffStrategy = Substitute.For<IMessageBackoffStrategy>();
+
+            var listeners = new List<INotificationSubscriber>();
+            foreach (var sqsClient in sqsClients)
+            {
+                var queue = Substitute.For<ISqsQueue>();
+                queue.Region.Returns(RegionEndpoint.EUWest2);
+                queue.QueueName.Returns("test-queue");
+                queue.Uri.Returns(new Uri("http://localhost"));
+                queue.Client.Returns(sqsClient);
+
+                var listener = new SqsNotificationListener(
+                   queue,
+                   messageSerializationRegister,
+                   messageMonitor,
+                   loggerFactory,
+                   messageContextAccessor,
+                   messageProcessingStrategy,
+                   onError,
+                   messageLockAsync,
+                   messageBackoffStrategy);
+
+                listeners.Add(listener);
+            }
+            return listeners;
+        }
+
+        private static IAmazonSQS CreateSqsClient()
+        {
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            sqsClient.ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>())
+                .ReturnsForAnyArgs(new Amazon.SQS.Model.ReceiveMessageResponse
+                {
+                    Messages = new List<Amazon.SQS.Model.Message>
+                    {
+                        new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" },
+                    }
+                });
+
+            return sqsClient;
+        }
+
+        private static IMessageSerializationRegister CreateSerializationRegister(Models.Message message = null)
+        {
+            var register = Substitute.For<IMessageSerializationRegister>();
+
+            register.DeserializeMessage(Arg.Any<string>())
+               .Returns(message);
+
+            return register;
+        }
+
+        private static IHandlerAsync<T> CreateHandler<T>(bool returns) where T : Models.Message
+        {
+            var handler = Substitute.For<IHandlerAsync<T>>();
+            handler.Handle(Arg.Any<T>()).Returns(returns);
+
+            return handler;
+        }
+
+        private static IHandlerAsync<T> CreateHandlerWithException<T>() where T : Models.Message
+        {
+            var handler = Substitute.For<IHandlerAsync<T>>();
+            handler.Handle(Arg.Any<T>())
+                .Returns<Task<bool>>(x => throw new Exception("oh no!"));
+
+            return handler;
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
@@ -159,6 +159,7 @@ namespace JustSaying.UnitTests.NotificationListener
             await sqsClient.Received()
                  .ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>());
             sqsClient.ClearReceivedCalls();
+            await Task.Delay(500);
             await sqsClient.Received()
                  .ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>());
 
@@ -183,6 +184,7 @@ namespace JustSaying.UnitTests.NotificationListener
         // allow debounce
         // allow circuit break?
         // allow batched processing?
+        // allow buffering if sqs throws exceptions
 
         private static INotificationSubscriber CreateListener(
             ILoggerFactory loggerFactory,

--- a/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SQS;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.UnitTests.NotificationListener
+{
+    public class CanSubscribeAndListen
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public CanSubscribeAndListen(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public async Task CanListen_StopsListeningWhenTokenCancelled()
+        {
+            var listener = CreateListener(_outputHelper.ToLoggerFactory());
+            var cts = new CancellationTokenSource(500);
+            listener.Listen(cts.Token);
+            Assert.True(listener.IsListening);
+
+            await Task.Delay(1000);
+
+            Assert.False(listener.IsListening);
+        }
+
+        [Fact]
+        public async Task MessageResponseCannotBeDeserialized_MessageIsRemovedFromQueue()
+        {
+            // Arrange
+            var sqsClient = CreateSqsClient();
+            var serializationRegister = CreateSerializationRegisterWithException();
+            var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            listener.Listen(cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await sqsClient.Received()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        [Fact]
+        public async Task MessageResponseIsValid_MessageIsHandledAndRemovedFromQueue()
+        {
+            // Arrange
+            var myProperty = "hello-just-saying";
+            var message = new TestMessage { MyProperty = myProperty };
+            var sqsClient = CreateSqsClient();
+            var serializationRegister = CreateSerializationRegister(message);
+            var handler = CreateHandler<TestMessage>(true);
+
+            var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+            listener.AddMessageHandler<TestMessage>(() => handler);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            listener.Listen(cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await handler.Received()
+                .Handle(Arg.Is<TestMessage>(msg => msg.MyProperty == myProperty));
+
+            await sqsClient.Received()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        [Fact]
+        public async Task MessageResponseIsValid_HandlerFails_NotRemovedFromQueue()
+        {
+            // Arrange
+            var myProperty = "hello-just-saying";
+            var message = new TestMessage { MyProperty = myProperty };
+            var sqsClient = CreateSqsClient();
+            var serializationRegister = CreateSerializationRegister(message);
+            var handler = CreateHandler<TestMessage>(false);
+
+            var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+            listener.AddMessageHandler<TestMessage>(() => handler);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            listener.Listen(cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await handler.Received()
+                .Handle(Arg.Is<TestMessage>(msg => msg.MyProperty == myProperty));
+
+            await sqsClient.DidNotReceive()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        [Fact]
+        public async Task MessageResponseIsValid_HandlerThrowsError_NotRemovedFromQueue()
+        {
+            // Arrange
+            var myProperty = "hello-just-saying";
+            var message = new TestMessage { MyProperty = myProperty };
+            var sqsClient = CreateSqsClient();
+            var serializationRegister = CreateSerializationRegister(message);
+            var handler = CreateHandlerWithException<TestMessage>();
+
+            var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+            listener.AddMessageHandler<TestMessage>(() => handler);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            listener.Listen(cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await handler.Received()
+                .Handle(Arg.Is<TestMessage>(msg => msg.MyProperty == myProperty));
+
+            await sqsClient.DidNotReceive()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        [Fact]
+        public async Task SqsRequestThrowsException_ContinuesToRequestMessages()
+        {
+            // Arrange
+            var myProperty = "hello-just-saying";
+            var message = new TestMessage { MyProperty = myProperty };
+            var sqsClient = CreateSqsClientWithException();
+            var serializationRegister = CreateSerializationRegister(message);
+            var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            listener.Listen(cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await sqsClient.Received()
+                 .ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>());
+            sqsClient.ClearReceivedCalls();
+            await sqsClient.Received()
+                 .ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>());
+
+            await sqsClient.DidNotReceive()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        public class TestMessage : Models.Message
+        {
+            public string MyProperty { get; set; }
+        }
+
+        // tests
+        // check correct handler is called
+        // what happens when handler throws exception
+        // what happens if there is no handler
+        // what happens if sqs throws exception
+        // handled message is deleted from queue
+        // - message that cant be deserialised is also deleted
+
+        // ideas for features
+        // allow debounce
+        // allow circuit break?
+        // allow batched processing?
+
+        private static INotificationSubscriber CreateListener(
+            ILoggerFactory loggerFactory,
+            IAmazonSQS sqsClient = null,
+            IMessageSerializationRegister serializationRegister = null)
+        {
+            sqsClient ??= CreateSqsClient();
+            serializationRegister ??= CreateSerializationRegister();
+            loggerFactory ??= Substitute.For<ILoggerFactory>();
+
+            var queue = Substitute.For<ISqsQueue>();
+            queue.Region.Returns(RegionEndpoint.EUWest2);
+            queue.QueueName.Returns("test-queue");
+            queue.Uri.Returns(new Uri("http://localhost"));
+            queue.Client.Returns(sqsClient);
+
+            return new SqsNotificationListener(
+                queue,
+                serializationRegister,
+                Substitute.For<IMessageMonitor>(),
+                Substitute.For<ILoggerFactory>(),
+                Substitute.For<IMessageContextAccessor>(),
+                Substitute.For<Action<Exception, Amazon.SQS.Model.Message>>(),
+                Substitute.For<IMessageLockAsync>(),
+                Substitute.For<IMessageBackoffStrategy>());
+        }
+
+        private static IAmazonSQS CreateSqsClient()
+        {
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            sqsClient.ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>())
+                .ReturnsForAnyArgs(new Amazon.SQS.Model.ReceiveMessageResponse
+                {
+                    Messages = new List<Amazon.SQS.Model.Message>
+                    {
+                        new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" },
+                    }
+                });
+
+            return sqsClient;
+        }
+
+        private static IAmazonSQS CreateSqsClientWithException()
+        {
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            sqsClient.ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>())
+                .ReturnsForAnyArgs<Amazon.SQS.Model.ReceiveMessageResponse>(x => throw new Exception("Test exception"));
+
+            return sqsClient;
+        }
+
+        private static IMessageSerializationRegister CreateSerializationRegister(Models.Message message = null)
+        {
+            var register = Substitute.For<IMessageSerializationRegister>();
+
+            register.DeserializeMessage(Arg.Any<string>())
+               .Returns(message);
+
+            return register;
+        }
+
+        private static IMessageSerializationRegister CreateSerializationRegisterWithException()
+        {
+            var register = Substitute.For<IMessageSerializationRegister>();
+
+            register.DeserializeMessage(Arg.Any<string>())
+                .Returns<Models.Message>(x => throw new MessageFormatNotSupportedException("Test exception"));
+
+            return register;
+        }
+
+        private static IHandlerAsync<T> CreateHandler<T>(bool returns) where T : Models.Message
+        {
+            var handler = Substitute.For<IHandlerAsync<T>>();
+            handler.Handle(Arg.Any<T>()).Returns(returns);
+
+            return handler;
+        }
+
+        private static IHandlerAsync<T> CreateHandlerWithException<T>() where T : Models.Message
+        {
+            var handler = Substitute.For<IHandlerAsync<T>>();
+            handler.Handle(Arg.Any<T>())
+                .Returns<Task<bool>>(x => throw new Exception("oh no!"));
+
+            return handler;
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
@@ -30,13 +30,16 @@ namespace JustSaying.UnitTests.NotificationListener
         [Fact]
         public async Task CanListen_StopsListeningWhenTokenCancelled()
         {
+            // Arrange
             var listener = CreateListener(_outputHelper.ToLoggerFactory());
-            var cts = new CancellationTokenSource(500);
+
+            // Act
+            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
             listener.Listen(cts.Token);
+
+            // Assert
             Assert.True(listener.IsListening);
-
             await Task.Delay(1000);
-
             Assert.False(listener.IsListening);
         }
 
@@ -49,7 +52,7 @@ namespace JustSaying.UnitTests.NotificationListener
             var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             listener.Listen(cts.Token);
 
             await Task.Delay(500);
@@ -73,7 +76,7 @@ namespace JustSaying.UnitTests.NotificationListener
             listener.AddMessageHandler<TestMessage>(() => handler);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             listener.Listen(cts.Token);
 
             await Task.Delay(500);
@@ -100,7 +103,7 @@ namespace JustSaying.UnitTests.NotificationListener
             listener.AddMessageHandler<TestMessage>(() => handler);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             listener.Listen(cts.Token);
 
             await Task.Delay(500);
@@ -127,7 +130,7 @@ namespace JustSaying.UnitTests.NotificationListener
             listener.AddMessageHandler<TestMessage>(() => handler);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             listener.Listen(cts.Token);
 
             await Task.Delay(500);
@@ -151,7 +154,7 @@ namespace JustSaying.UnitTests.NotificationListener
             var listener = CreateListener(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             listener.Listen(cts.Token);
 
             await Task.Delay(500);

--- a/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
@@ -10,6 +10,7 @@ using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.Messaging.Monitoring;
+using JustSaying.UnitTests.AwsTools.MessageHandling.SqsNotificationListener;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -207,6 +208,7 @@ namespace JustSaying.UnitTests.NotificationListener
                 Substitute.For<IMessageMonitor>(),
                 Substitute.For<ILoggerFactory>(),
                 Substitute.For<IMessageContextAccessor>(),
+                new TestMessageProcessingStrategy(),
                 Substitute.For<Action<Exception, Amazon.SQS.Model.Message>>(),
                 Substitute.For<IMessageLockAsync>(),
                 Substitute.For<IMessageBackoffStrategy>());

--- a/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/CanSubscribeAndListen.cs
@@ -34,12 +34,13 @@ namespace JustSaying.UnitTests.NotificationListener
             var listener = CreateListener(_outputHelper.ToLoggerFactory());
 
             // Act
-            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+            var cts = new CancellationTokenSource();
             listener.Listen(cts.Token);
 
             // Assert
             Assert.True(listener.IsListening);
-            await Task.Delay(1000);
+            cts.Cancel();
+            await Task.Delay(500);
             Assert.False(listener.IsListening);
         }
 
@@ -209,7 +210,7 @@ namespace JustSaying.UnitTests.NotificationListener
                 queue,
                 serializationRegister,
                 Substitute.For<IMessageMonitor>(),
-                Substitute.For<ILoggerFactory>(),
+                loggerFactory,
                 Substitute.For<IMessageContextAccessor>(),
                 new TestMessageProcessingStrategy(),
                 Substitute.For<Action<Exception, Amazon.SQS.Model.Message>>(),

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanListenToMultipleQueues.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanListenToMultipleQueues.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.UnitTests.NotificationListener.MessageCoordination
+{
+    public class CanCreateMultipleListeners
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public CanCreateMultipleListeners(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public async Task OneQueueNoMessages_OtherContinuesToProcessMessages()
+        {
+            // Arrange
+            var receiptHandle = "ReceiptHandle";
+            var messageBody = "Body";
+            var receiver1 = CreateMessageReceiver(receiptHandle, messageBody);
+            var messageDispatcher1 = Substitute.For<IMessageDispatcher>();
+            messageDispatcher1.DispatchMessage(Arg.Any<Amazon.SQS.Model.Message>(), Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(true));
+            var coordinator1 = CreateMessageCoordinator(_outputHelper.ToLoggerFactory(), receiver1, messageDispatcher1);
+
+            var receiver2 = CreateEmptyMessageReceiver();
+            var messageDispatcher2 = Substitute.For<IMessageDispatcher>();
+            messageDispatcher2.DispatchMessage(Arg.Any<Amazon.SQS.Model.Message>(), Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(true));
+            var coordinator2 = CreateMessageCoordinator(_outputHelper.ToLoggerFactory(), receiver1, messageDispatcher1);
+
+            // Act
+            var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000));
+            _ = coordinator1.ListenAsync(cts.Token);
+            _ = coordinator2.ListenAsync(cts.Token);
+
+            // Assert
+            await messageDispatcher1.Received()
+                .DispatchMessage(Arg.Is<Amazon.SQS.Model.Message>(msg => msg.ReceiptHandle == receiptHandle), Arg.Any<CancellationToken>());
+
+            await messageDispatcher2.DidNotReceive()
+                .DispatchMessage(Arg.Any<Amazon.SQS.Model.Message>(), Arg.Any<CancellationToken>());
+        }
+
+        private static IMessageCoordinator CreateMessageCoordinator(
+           ILoggerFactory loggerFactory,
+           IMessageReceiver messageReceiver,
+           IMessageDispatcher messageDispatcher = null,
+           IMessageProcessingStrategy messageProcessingStrategy = null)
+        {
+            var logger = loggerFactory.CreateLogger("test-logger");
+            messageDispatcher ??= Substitute.For<IMessageDispatcher>();
+
+            var messageMonitor = Substitute.For<IMessageMonitor>();
+            messageProcessingStrategy ??= new DefaultThrottledThroughput(messageMonitor, logger);
+
+            return new MessageCoordinator(
+                logger,
+                messageReceiver,
+                messageDispatcher,
+                messageProcessingStrategy);
+        }
+
+        private static IMessageReceiver CreateEmptyMessageReceiver()
+        {
+            var messageReceiver = Substitute.For<IMessageReceiver>();
+            messageReceiver.GetMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(EmptyResponse());
+
+            return messageReceiver;
+        }
+
+        private static async Task<Amazon.SQS.Model.ReceiveMessageResponse> EmptyResponse()
+        {
+            await Task.Delay(500);
+            return new Amazon.SQS.Model.ReceiveMessageResponse
+            {
+                Messages = new List<Amazon.SQS.Model.Message> { }
+            };
+        }
+
+        private static IMessageReceiver CreateMessageReceiver(string receiptHandle, string messageBody)
+        {
+            var messageReceiver = Substitute.For<IMessageReceiver>();
+            messageReceiver.GetMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new Amazon.SQS.Model.ReceiveMessageResponse
+                {
+                    Messages = new List<Amazon.SQS.Model.Message>
+                    {
+                        new Amazon.SQS.Model.Message { ReceiptHandle = receiptHandle, Body = messageBody },
+                    }
+                });
+
+            return messageReceiver;
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanSubscribeAndListen.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.UnitTests.NotificationListener.MessageCoordination
+{
+    public class CanSubscribeAndListen
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public CanSubscribeAndListen(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public async Task CanListen_StopsListeningWhenTokenCancelled()
+        {
+            var coordinator = CreateMessageCoordinator(_outputHelper.ToLoggerFactory());
+            var cts = new CancellationTokenSource(1000);
+            var listening = false;
+            _ = Task.Run(async () =>
+            {
+                await coordinator.ListenAsync(cts.Token).ConfigureAwait(false);
+                listening = false;
+            });
+            listening = true;
+
+            Assert.True(listening);
+
+            await Task.Delay(2000);
+
+            Assert.False(listening);
+        }
+
+        [Fact]
+        public async Task MessageResponseIsValid_MessageIsHandled()
+        {
+            // Arrange
+            var receiptHandle = "ReceiptHandle";
+            var messageBody = "Body";
+            var messageRequester = Substitute.For<IMessageRequester>();
+            messageRequester.GetMessages(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(new Amazon.SQS.Model.ReceiveMessageResponse
+                {
+                    Messages = new List<Amazon.SQS.Model.Message>
+                    {
+                        new Amazon.SQS.Model.Message { ReceiptHandle = receiptHandle, Body = messageBody },
+                    }
+                });
+            var messageDispatcher = Substitute.For<IMessageDispatcher>();
+
+            var coordinator = CreateMessageCoordinator(_outputHelper.ToLoggerFactory(), messageRequester, messageDispatcher);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            _ = coordinator.ListenAsync(cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await messageDispatcher.Received()
+                .DispatchMessage(
+                    Arg.Is<Amazon.SQS.Model.Message>(
+                        msg => msg.ReceiptHandle == receiptHandle && msg.Body == messageBody),
+                    Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task SqsRequestThrowsException_ContinuesToRequestMessages()
+        {
+            // Arrange
+            var messageDispatcher = Substitute.For<IMessageDispatcher>();
+            var messageRequester = Substitute.For<IMessageRequester>();
+            messageRequester.GetMessages(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns<Task<Amazon.SQS.Model.ReceiveMessageResponse>>(_ => throw new Exception("Cannot retrieve messages!"));
+            var coordinator = CreateMessageCoordinator(_outputHelper.ToLoggerFactory(), messageRequester, messageDispatcher);
+
+            // Act
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(1000);
+            _ = Task.Run(() => coordinator.ListenAsync(cts.Token));
+
+            await Task.Delay(500);
+
+            // Assert
+            await messageRequester.Received()
+                 .GetMessages(Arg.Any<int>(), Arg.Any<CancellationToken>());
+            messageRequester.ClearReceivedCalls();
+            await Task.Delay(500);
+            await messageRequester.Received()
+                 .GetMessages(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            await messageDispatcher.DidNotReceive()
+                 .DispatchMessage(Arg.Any<Amazon.SQS.Model.Message>(), Arg.Any<CancellationToken>());
+        }
+
+        private static IMessageCoordinator CreateMessageCoordinator(
+            ILoggerFactory loggerFactory,
+            IMessageRequester messageRequester = null,
+            IMessageDispatcher messageDispatcher = null)
+        {
+            var logger = loggerFactory.CreateLogger("test-logger");
+            messageRequester ??= Substitute.For<IMessageRequester>();
+            messageDispatcher ??= Substitute.For<IMessageDispatcher>();
+
+            var messageMonitor = Substitute.For<IMessageMonitor>();
+            var messageProcessingStrategy = new DefaultThrottledThroughput(messageMonitor, logger);
+
+            return new MessageCoordinator(
+                logger,
+                messageRequester,
+                messageDispatcher,
+                messageProcessingStrategy);
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanSubscribeAndListen.cs
@@ -111,7 +111,7 @@ namespace JustSaying.UnitTests.NotificationListener.MessageCoordination
             var messageProcessingStrategy = Substitute.For<IMessageProcessingStrategy>();
             messageProcessingStrategy.WaitForAvailableWorkerAsync()
                 .Returns(1);
-            messageProcessingStrategy.ReportMessageReceived(Arg.Any<bool>())
+            messageProcessingStrategy.WaitForThrottlingAsync(Arg.Any<bool>())
                 .Returns(ci => completionSource.Task);
             var coordinator = CreateMessageCoordinator(
                 _outputHelper.ToLoggerFactory(),

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanSubscribeAndListen.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageCoordination/CanSubscribeAndListen.cs
@@ -25,7 +25,7 @@ namespace JustSaying.UnitTests.NotificationListener.MessageCoordination
         public async Task CanListen_StopsListeningWhenTokenCancelled()
         {
             var coordinator = CreateMessageCoordinator(_outputHelper.ToLoggerFactory());
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             var listening = false;
             _ = Task.Run(async () =>
             {
@@ -61,7 +61,7 @@ namespace JustSaying.UnitTests.NotificationListener.MessageCoordination
             var coordinator = CreateMessageCoordinator(_outputHelper.ToLoggerFactory(), messageReceiver, messageDispatcher);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             _ = coordinator.ListenAsync(cts.Token);
 
             await Task.Delay(500);
@@ -85,8 +85,7 @@ namespace JustSaying.UnitTests.NotificationListener.MessageCoordination
             var coordinator = CreateMessageCoordinator(_outputHelper.ToLoggerFactory(), messageReceiver, messageDispatcher);
 
             // Act
-            var cts = new CancellationTokenSource();
-            cts.CancelAfter(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             _ = Task.Run(() => coordinator.ListenAsync(cts.Token));
 
             await Task.Delay(500);

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageProcessing/ProcessesMessages.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageProcessing/ProcessesMessages.cs
@@ -41,7 +41,7 @@ namespace JustSaying.UnitTests.NotificationListener.MessageProcessing
             dispatcher.AddMessageHandler<TestMessage>(() => handler);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             await dispatcher.DispatchMessage(sqsmessage, cts.Token);
 
             await Task.Delay(500);
@@ -64,7 +64,7 @@ namespace JustSaying.UnitTests.NotificationListener.MessageProcessing
             var dispatcher = CreateMessageDispatcher(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
 
             // Act
-            var cts = new CancellationTokenSource(1000);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             await dispatcher.DispatchMessage(message, cts.Token);
 
             await Task.Delay(500);

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageProcessing/ProcessesMessages.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageProcessing/ProcessesMessages.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SQS;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.UnitTests.NotificationListener.MessageProcessing
+{
+    public class ProcessesMessages
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public ProcessesMessages(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Theory]
+        [InlineData(true, 1)]
+        [InlineData(false, 0)]
+        public async Task MessageResponseIsValid_MessageIsHandledAndRemovedFromQueue(bool handlerSuccess, int deleteCount)
+        {
+            // Arrange
+            var myProperty = "hello-just-saying";
+            var message = new TestMessage { MyProperty = myProperty };
+            var serializationRegister = CreateSerializationRegister(message);
+            var sqsmessage = new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" };
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            var handler = CreateHandler<TestMessage>(handlerSuccess);
+
+            var dispatcher = CreateMessageDispatcher(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+            dispatcher.AddMessageHandler<TestMessage>(() => handler);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            await dispatcher.DispatchMessage(sqsmessage, cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await handler.Received()
+                .Handle(Arg.Is<TestMessage>(msg => msg.MyProperty == myProperty));
+
+            await sqsClient.Received(deleteCount)
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        [Fact]
+        public async Task MessageResponseCannotBeDeserialized_MessageIsRemovedFromQueue()
+        {
+            // Arrange
+            var serializationRegister = CreateSerializationRegisterWithException();
+            var message = new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" };
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            var dispatcher = CreateMessageDispatcher(_outputHelper.ToLoggerFactory(), sqsClient, serializationRegister);
+
+            // Act
+            var cts = new CancellationTokenSource(1000);
+            await dispatcher.DispatchMessage(message, cts.Token);
+
+            await Task.Delay(500);
+
+            // Assert
+            await sqsClient.Received()
+                 .DeleteMessageAsync(Arg.Is<Amazon.SQS.Model.DeleteMessageRequest>(r => r.ReceiptHandle == "hello"));
+        }
+
+        private static IMessageDispatcher CreateMessageDispatcher(
+            ILoggerFactory loggerFactory,
+            IAmazonSQS sqsClient,
+            IMessageSerializationRegister messageSerializationRegister = null)
+        {
+            sqsClient ??= Substitute.For<IAmazonSQS>();
+            messageSerializationRegister ??= Substitute.For<IMessageSerializationRegister>();
+
+            var queue = Substitute.For<ISqsQueue>();
+            queue.Region.Returns(RegionEndpoint.EUWest2);
+            queue.QueueName.Returns("test-queue");
+            queue.Uri.Returns(new Uri("http://localhost"));
+            queue.Client.Returns(sqsClient);
+
+            var messageDispatcher = new MessageDispatcher(
+                queue,
+                messageSerializationRegister,
+                Substitute.For<IMessageMonitor>(),
+                Substitute.For<Action<Exception, Amazon.SQS.Model.Message>>(),
+                loggerFactory,
+                Substitute.For<IMessageBackoffStrategy>(),
+                Substitute.For<IMessageContextAccessor>(),
+                Substitute.For<IMessageLockAsync>());
+
+            return messageDispatcher;
+        }
+
+        public class TestMessage : Models.Message
+        {
+            public string MyProperty { get; set; }
+        }
+
+        private static IHandlerAsync<T> CreateHandler<T>(bool returns) where T : Models.Message
+        {
+            var handler = Substitute.For<IHandlerAsync<T>>();
+            handler.Handle(Arg.Any<T>()).Returns(returns);
+
+            return handler;
+        }
+
+        private static IMessageSerializationRegister CreateSerializationRegister(Models.Message message = null)
+        {
+            var register = Substitute.For<IMessageSerializationRegister>();
+
+            register.DeserializeMessage(Arg.Any<string>())
+               .Returns(message);
+
+            return register;
+        }
+
+        private static IMessageSerializationRegister CreateSerializationRegisterWithException()
+        {
+            var register = Substitute.For<IMessageSerializationRegister>();
+
+            register.DeserializeMessage(Arg.Any<string>())
+                .Returns<Models.Message>(x => throw new MessageFormatNotSupportedException("Test exception"));
+
+            return register;
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageRetreival/CanRequestMessagesFromQueue.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageRetreival/CanRequestMessagesFromQueue.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Amazon;
+using Amazon.SQS;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging.MessageProcessingStrategies;
+using JustSaying.Messaging.Monitoring;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace JustSaying.UnitTests.NotificationListener.MessageRetreival
+{
+    public class CanRequestMessagesFromQueue
+    {
+        private static IMessageReceiver CreateMessageReceiver(ILoggerFactory loggerFactory, IAmazonSQS sqsClient = null)
+        {
+            loggerFactory ??= Substitute.For<ILoggerFactory>();
+
+            sqsClient ??= CreateSqsClient();
+
+            var queue = Substitute.For<ISqsQueue>();
+            queue.Region.Returns(RegionEndpoint.EUWest2);
+            queue.QueueName.Returns("test-queue");
+            queue.Uri.Returns(new Uri("http://localhost"));
+            queue.Client.Returns(sqsClient);
+
+            var messagingMonitor = Substitute.For<IMessageMonitor>();
+            var logger = loggerFactory.CreateLogger<MessageReceiver>();
+            var messageBackoffStrategy = Substitute.For<IMessageBackoffStrategy>();
+
+            return new MessageReceiver(queue, messagingMonitor, logger, messageBackoffStrategy);
+        }
+
+        private static IAmazonSQS CreateSqsClient()
+        {
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            sqsClient.ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>())
+                .ReturnsForAnyArgs(new Amazon.SQS.Model.ReceiveMessageResponse
+                {
+                    Messages = new List<Amazon.SQS.Model.Message>
+                    {
+                        new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" },
+                    }
+                });
+
+            return sqsClient;
+        }
+
+        private static IAmazonSQS CreateSqsClientWithException()
+        {
+            var sqsClient = Substitute.For<IAmazonSQS>();
+            sqsClient.ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>())
+                .ReturnsForAnyArgs<Amazon.SQS.Model.ReceiveMessageResponse>(x => throw new Exception("Test exception"));
+
+            return sqsClient;
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/NotificationListener/MessageRetreival/CanRequestMessagesFromQueue.cs
+++ b/tests/JustSaying.UnitTests/NotificationListener/MessageRetreival/CanRequestMessagesFromQueue.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Amazon;
 using Amazon.SQS;
 using JustSaying.AwsTools.MessageHandling;
@@ -9,16 +9,47 @@ using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.Monitoring;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace JustSaying.UnitTests.NotificationListener.MessageRetreival
 {
     public class CanRequestMessagesFromQueue
     {
-        private static IMessageReceiver CreateMessageReceiver(ILoggerFactory loggerFactory, IAmazonSQS sqsClient = null)
+        private readonly ITestOutputHelper _outputHelper;
+
+        public CanRequestMessagesFromQueue(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public async Task RequestToSqsSucceeds_ResponseIsReturned()
+        {
+            var response = CreateResponse();
+            var sqsClient = CreateSqsClient(response);
+            var receiver = CreateMessageReceiver(_outputHelper.ToLoggerFactory(), sqsClient);
+
+            var messages = await receiver.GetMessagesAsync(1, CancellationToken.None);
+
+            Assert.Equal(response, messages);
+        }
+
+        [Fact]
+        public async Task RequestToSqsFails_ResponseIsNull()
+        {
+            var sqsClient = CreateSqsClientWithException();
+            var receiver = CreateMessageReceiver(_outputHelper.ToLoggerFactory(), sqsClient);
+
+            var messages = await receiver.GetMessagesAsync(1, CancellationToken.None);
+
+            Assert.Null(messages);
+        }
+
+        private static IMessageReceiver CreateMessageReceiver(
+            ILoggerFactory loggerFactory, IAmazonSQS sqsClient)
         {
             loggerFactory ??= Substitute.For<ILoggerFactory>();
-
-            sqsClient ??= CreateSqsClient();
 
             var queue = Substitute.For<ISqsQueue>();
             queue.Region.Returns(RegionEndpoint.EUWest2);
@@ -33,17 +64,11 @@ namespace JustSaying.UnitTests.NotificationListener.MessageRetreival
             return new MessageReceiver(queue, messagingMonitor, logger, messageBackoffStrategy);
         }
 
-        private static IAmazonSQS CreateSqsClient()
+        private static IAmazonSQS CreateSqsClient(Amazon.SQS.Model.ReceiveMessageResponse response)
         {
             var sqsClient = Substitute.For<IAmazonSQS>();
             sqsClient.ReceiveMessageAsync(Arg.Any<Amazon.SQS.Model.ReceiveMessageRequest>(), Arg.Any<CancellationToken>())
-                .ReturnsForAnyArgs(new Amazon.SQS.Model.ReceiveMessageResponse
-                {
-                    Messages = new List<Amazon.SQS.Model.Message>
-                    {
-                        new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" },
-                    }
-                });
+                .ReturnsForAnyArgs(response);
 
             return sqsClient;
         }
@@ -55,6 +80,17 @@ namespace JustSaying.UnitTests.NotificationListener.MessageRetreival
                 .ReturnsForAnyArgs<Amazon.SQS.Model.ReceiveMessageResponse>(x => throw new Exception("Test exception"));
 
             return sqsClient;
+        }
+
+        private static Amazon.SQS.Model.ReceiveMessageResponse CreateResponse()
+        {
+            return new Amazon.SQS.Model.ReceiveMessageResponse
+            {
+                Messages = new List<Amazon.SQS.Model.Message>
+                {
+                    new Amazon.SQS.Model.Message { ReceiptHandle = "hello", Body = "Not testing this" },
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
I would like to have more control over the way just saying listens to queues and then calls the handlers. The current IMessageProcessingStrategy currently only allows throttling of the listener when there is no available workers.

In this PR I would like to address
- [ ] Adding tests around the SqsNotificationListener
- [ ] Fix race condition in IMessageProcessingStrategy (mentioned in #546 and #422)
- [ ] Allow debounce/circuit break logic to be added around the call to SQS
- [ ] More control over how the messages are queued for processing