### PR TITLE
Fix bug identified in diagnosis of production incident

### DIFF
--- a/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -90,12 +90,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
             [Fact]
             public void ShouldLogError()
             {
-                _logger.Received().Log(
-                    LogLevel.Error,
-                    0,
-                    Arg.Is<FormattedLogValues>(x => x.ToString() == "Handler for message of type 'JustSaying.TestingFramework.OrderAccepted' not found in handler map. Returning message to queue."),
-                    null,
-                    Arg.Any<Func<object, Exception, string>>());
+                _logger.ReceivedWithAnyArgs().LogError(0, null, "msg");
             }
 
             [Fact]

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -108,7 +108,9 @@ namespace JustSaying.AwsTools.MessageHandling
 
             if (handler == null)
             {
-                return true;
+                _log.LogError($"Handler for message of type '{message.GetType().FullName}' not found in handler map. Returning message to queue.");
+                // Return false so that we give other queue subscribers a chance to handle the message
+                return false;
             }
 
             var watch = System.Diagnostics.Stopwatch.StartNew();

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -108,8 +108,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             if (handler == null)
             {
-                _log.LogError("Handler for message of type '{MessageTypeName}' not found in handler map. Returning message to queue.", message.GetType().FullName);
-                // Return false so that we give other queue subscribers a chance to handle the message
+                _log.LogError("Failed to dispatch. Handler for message of type '{MessageTypeName}' not found in handler map.", message.GetType().FullName);
                 return false;
             }
 

--- a/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -108,7 +108,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             if (handler == null)
             {
-                _log.LogError($"Handler for message of type '{message.GetType().FullName}' not found in handler map. Returning message to queue.");
+                _log.LogError("Handler for message of type '{MessageTypeName}' not found in handler map. Returning message to queue.", message.GetType().FullName);
                 // Return false so that we give other queue subscribers a chance to handle the message
                 return false;
             }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.0.2</VersionPrefix>
+    <VersionPrefix>6.0.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
* Log when we don't have a matching handler for the given message type.
* If two consumers are subscribed to a queue that has multiple message types in it, one of them may not be able to handle all the messages (each handled a subset). So we need to return the message to the queue for the other subscriber to try handling it.
