### PR TITLE
Fix bug identified in diagnosis of production incident

### DIFF
--- a/src/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/MessageDispatcher.cs
@@ -145,7 +145,8 @@ namespace JustSaying.AwsTools.MessageHandling
 
             if (handler == null)
             {
-                return true;
+                _logger.LogError("Failed to dispatch. Handler for message of type '{MessageTypeName}' not found in handler map.", message.GetType().FullName);
+                return false;
             }
 
             var watch = System.Diagnostics.Stopwatch.StartNew();


### PR DESCRIPTION
* Log when we don't have a matching handler for the given message type.
* If two consumers are subscribed to a queue that has multiple message types in it, one of them may not be able to handle all the messages (each handled a subset). So we need to return the message to the queue for the other subscriber to try handling it.

This is just copying the bugfix from #727 