### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: build
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ v* ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        include:
+          - os: macos-latest
+            os_name: macos
+          - os: ubuntu-latest
+            os_name: linux
+          - os: windows-latest
+            os_name: windows
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1
+
+    - name: Build, Test and Package
+      shell: pwsh
+      run: ./Build.ps1
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        NUGET_XMLDOC_MODE: skip
+
+    - uses: codecov/codecov-action@v1
+      name: Upload coverage to Codecov
+      with:
+        file: ./artifacts/coverage.netcoreapp3.1.cobertura.xml
+        flags: ${{ matrix.os_name }}
+
+    - name: Publish NuGet packages
+      uses: actions/upload-artifact@v1
+      with:
+        name: packages-${{ matrix.os_name }}
+        path: ./artifacts/packages
+
+    - name: Push NuGet packages to NuGet.org
+      run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json
+      if: ${{ github.repository_owner == 'justeat' && startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows' }}

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,3 +1,5 @@
+#! /usr/bin/pwsh
+
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
     [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
@@ -43,7 +45,7 @@ if ($null -ne $env:CI) {
 
 $installDotNetSdk = $false;
 
-if (($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue))) {
+if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
     Write-Host "The .NET Core SDK is not installed."
     $installDotNetSdk = $true
 }
@@ -69,17 +71,26 @@ if ($installDotNetSdk -eq $true) {
         if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
             mkdir $env:DOTNET_INSTALL_DIR | Out-Null
         }
-        $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
-        Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
-        & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
+        
+        if (($PSVersionTable.PSVersion.Major -ge 6) -And !$IsWindows) {
+            $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.sh"
+            Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile $installScript -UseBasicParsing
+            chmod +x $installScript
+            & $installScript --version "$dotnetVersion" --install-dir "$env:DOTNET_INSTALL_DIR" --no-path
+        }
+        else {
+            $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
+            Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
+            & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
+        }
     }
 }
 else {
-    $env:DOTNET_INSTALL_DIR = Split-Path -Path (Get-Command dotnet.exe).Path
+    $env:DOTNET_INSTALL_DIR = Split-Path -Path (Get-Command dotnet).Path
 }
 
-$dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet.exe"
+$dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet"
 
 if (($installDotNetSdk -eq $true) -And ($null -eq $env:TF_BUILD)) {
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
@@ -89,10 +100,10 @@ function DotNetPack {
     param([string]$Project)
 
     if ($VersionSuffix) {
-        & $dotnet pack $Project --output $OutputPath --configuration $Configuration --version-suffix "$VersionSuffix"
+        & $dotnet pack $Project --output (Join-Path $OutputPath "packages") --configuration $Configuration --version-suffix "$VersionSuffix"
     }
     else {
-        & $dotnet pack $Project --output $OutputPath --configuration $Configuration
+        & $dotnet pack $Project --output (Join-Path $OutputPath "packages") --configuration $Configuration
     }
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet pack failed with exit code $LASTEXITCODE"
@@ -102,20 +113,18 @@ function DotNetPack {
 function DotNetTest {
     param([string]$Project)
 
-    $nugetPath = Join-Path $env:USERPROFILE ".nuget\packages"
+    $nugetPath = Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages"
     $propsFile = Join-Path $solutionPath "Directory.Build.props"
 
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageReference[@Include='ReportGenerator']/@Version").Node.'#text'
-    $reportGeneratorPath = Join-Path $nugetPath "ReportGenerator\$reportGeneratorVersion\tools\netcoreapp2.0\ReportGenerator.dll"
+    $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\netcoreapp3.0\ReportGenerator.dll"
 
     $coverageOutput = Join-Path $OutputPath "coverage.cobertura.xml"
     $reportOutput = Join-Path $OutputPath "coverage"
 
     & $dotnet test $Project --output $OutputPath --configuration $Configuration
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet test failed with exit code $LASTEXITCODE"
-    }
+    $dotNetTestExitCode = $LASTEXITCODE
 
     if ((Test-Path $coverageOutput)) {
       & $dotnet `
@@ -125,6 +134,11 @@ function DotNetTest {
           -reporttypes:HTML `
           -verbosity:Warning
     }
+
+    if ($dotNetTestExitCode -ne 0) {
+        throw "dotnet test failed with exit code $dotNetTestExitCode"
+    }
+
 }
 
 Write-Host "Creating packages..." -ForegroundColor Green

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,7 @@
     <Description>A light-weight message bus on top of AWS SNS and SQS</Description>
     <MinVerMinimumMajorMinor>7.0</MinVerMinimumMajorMinor>
     <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerSkip Condition=" '$(Configuration)' == 'Debug' ">true</MinVerSkip>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     <NoWarn>$(NoWarn);CA1062;CA1303</NoWarn>

--- a/Directory.build.targets
+++ b/Directory.build.targets
@@ -1,5 +1,5 @@
 <Project>
-    <Target Name="AppVeyorPR" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''" >
+    <Target Name="AppVeyorPR" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != '' AND '$(MinVerSkip)' != 'true' " >
         <PropertyGroup>
             <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(APPVEYOR_PULL_REQUEST_NUMBER)</PackageVersion>
             <PackageVersion Condition="'$(MinVerPreRelease)' != ''">$(PackageVersion).$(MinVerPreRelease)</PackageVersion>
@@ -7,7 +7,7 @@
             <Version>$(PackageVersion)</Version>
         </PropertyGroup>
     </Target>
-    <Target Name="AppVeyorFileVersion" AfterTargets="MinVer">
+    <Target Name="AppVeyorFileVersion" AfterTargets="MinVer" Condition=" '$(MinVerSkip)' != 'true' ">
         <PropertyGroup>
             <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">0</APPVEYOR_BUILD_NUMBER>
             <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(APPVEYOR_BUILD_NUMBER)</FileVersion>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   MINVERBUILDMETADATA: build.%APPVEYOR_BUILD_NUMBER%
 
 build_script:
-  - ps: .\Build.ps1
+  - pwsh: .\Build.ps1
 
 after_build:
     - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,6 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    # Install 2.2 until https://github.com/adamralph/minver/pull/287 is released
-    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "2.2.402" --install-dir "$DOTNET_INSTALL_DIR"
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 


### PR DESCRIPTION
This is a first cut, I haven't done the NuGet related stuff as I don't have permissions on this repo to setup secrets.

This PR adds:
- A GitHub Action to build, run tests of each platform, integration tests on linux only, and collects artifacts
- Enables deterministic builds under GitHub Actions, I had to swap out some acceptance test code as it expects a full path in the symbols, this may already be fixed in Shouldy master (Acceptance tests implementation have been removed in favour of a new library), but we are waiting on a pre-release build to try it.
- Disables MinVer when running locally in debug, just for speed