### PR TITLE
Add SNS request Id to log message when message is published

### DIFF
--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -44,7 +44,7 @@ namespace JustSaying.AwsTools.MessageHandling
         }
 
         public abstract Task<bool> ExistsAsync();
-        
+
         public Task PublishAsync(Message message) => PublishAsync(message, CancellationToken.None);
 
         public async Task PublishAsync(Message message, CancellationToken cancellationToken)
@@ -54,7 +54,11 @@ namespace JustSaying.AwsTools.MessageHandling
             try
             {
                 var response = await Client.PublishAsync(request, cancellationToken).ConfigureAwait(false);
-                _eventLog.LogInformation($"Published message: '{request.Subject}' with content {request.Message}");
+                _eventLog.LogInformation(
+                    "Published message: '{Subject}' with content {Message} and request Id '{SnsRequestId}'",
+                    request.Subject,
+                    request.Message,
+                    response?.ResponseMetadata?.RequestId);
 
                 MessageResponseLogger?.Invoke(new MessageResponse
                 {
@@ -92,7 +96,7 @@ namespace JustSaying.AwsTools.MessageHandling
                         DataType = source.Value.DataType
                     };
                 });
-            
+
             return new PublishRequest
             {
                 TopicArn = Arn,


### PR DESCRIPTION
We are currently experiencing some SNS issues in production and AWS always ask us to provide them with some SNS Request Ids related to the problematic publish operations. Unfortunately JustSaying is not returning it.

This PR is to simply add the returned request Id (if present) to the message logged when a message is published.
I know V6 is currently in maintenance mode but this could help us investigate a bit better on any issue we might have on AWS.