### PR TITLE
Fixed structured logging for publish message

### DIFF
--- a/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -55,7 +55,7 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var response = await Client.PublishAsync(request, cancellationToken).ConfigureAwait(false);
                 _eventLog.LogInformation(
-                    "Published message: '{Subject}' with content {Message} and request Id '{SnsRequestId}'",
+                    "Published message: '{SnsSubject}' with content {SnsMessage} and request Id '{SnsRequestId}'",
                     request.Subject,
                     request.Message,
                     response?.ResponseMetadata?.RequestId);


### PR DESCRIPTION
In the current code the message (not the sns event) we want to log is replaced by the content of the SNS message/event as in the structured logging is stored under the `{Message}` field of the log entry.

This PR is going to fix it