### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,10 @@ updates:
   ignore:
   - dependency-name: AWSSDK.SimpleNotificationService
     versions:
-    - "> 3.3.100.1, < 3.4"
+    - "> 3.3.100.1, < 3.6"
   - dependency-name: AWSSDK.SQS
     versions:
-    - "> 3.3.100.1, < 3.4"
+    - "> 3.3.100.1, < 3.6"
   - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
     versions:
     - "> 1.1.0"


### PR DESCRIPTION
Ignore AWS 3.5.x package versions from Dependabot updates.
