### PR TITLE
Add GitHub Actions Logger

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -122,7 +122,12 @@ function DotNetTest {
     $coverageOutput = Join-Path $OutputPath "coverage.cobertura.xml"
     $reportOutput = Join-Path $OutputPath "coverage"
 
-    & $dotnet test $Project --output $OutputPath --configuration $Configuration
+    if ([string]::IsNullOrEmpty($env:GITHUB_SHA)) {
+        & $dotnet test $Project --output $OutputPath --configuration $Configuration
+    }
+    else {
+        & $dotnet test $Project --output $OutputPath --configuration $Configuration --logger GitHubActions
+    }
 
     $dotNetTestExitCode = $LASTEXITCODE
 

--- a/tests/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/tests/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="$(AwsSdkSnsVersion)" />
     <PackageReference Include="AWSSDK.SQS" Version="$(AwsSdkSqsVersion)" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(DotNetTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/tests/JustSaying.UnitTests/JustSaying.UnitTests.csproj
+++ b/tests/JustSaying.UnitTests/JustSaying.UnitTests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="$(AwsSdkSnsVersion)" />
     <PackageReference Include="AWSSDK.SQS" Version="$(AwsSdkSqsVersion)" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(DotNetTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Polly" Version="7.2.1" />


### PR DESCRIPTION
This test logger will output GitHub Action annotations (using https://github.com/Tyrrrz/GitHubActionsTestLogger) so that we can quickly see where tests are failing.

Example here:
https://github.com/slang25/JustSaying/actions/runs/231421514