### PR TITLE
Update SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         run: ./Build.ps1
         env:
           DOTNET_CLI_TELEMETRY_OPTOUT: true
+          DOTNET_NOLOGO: true
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
           NUGET_XMLDOC_MODE: skip
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,18 +2,18 @@
   <PropertyGroup>
     <AnalyzersPackageVersion>3.3.0</AnalyzersPackageVersion>
     <DotNetTestSdkVersion>16.7.1</DotNetTestSdkVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>3.1.7</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>3.1.8</MicrosoftExtensionsDependencyInjectionVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AwsSdkSnsVersion>3.3.101.122</AwsSdkSnsVersion>
-    <AwsSdkSqsVersion>3.3.102.65</AwsSdkSqsVersion>
+    <AwsSdkSnsVersion>3.5.0.9</AwsSdkSnsVersion>
+    <AwsSdkSqsVersion>3.5.0.9</AwsSdkSqsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="4.6.6" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.6.7" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
+    "version": "3.1.402",
     "allowPrerelease": false
   }
 }

--- a/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/JustSaying.Sample.Restaurant.KitchenConsole.csproj
+++ b/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/JustSaying.Sample.Restaurant.KitchenConsole.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
   </ItemGroup>
 

--- a/samples/src/JustSaying.Sample.Restaurant.OrderingApi/JustSaying.Sample.Restaurant.OrderingApi.csproj
+++ b/samples/src/JustSaying.Sample.Restaurant.OrderingApi/JustSaying.Sample.Restaurant.OrderingApi.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
   </ItemGroup>
 

--- a/tests/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/tests/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.13.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/JustSaying.UnitTests/Messaging/Channels/Fakes/FakeAmazonSqs.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/Fakes/FakeAmazonSqs.cs
@@ -39,6 +39,8 @@ namespace JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests
 
         public IClientConfig Config { get; }
 
+        public ISQSPaginatorFactory Paginators { get; }
+
         public Task<string> AuthorizeS3ToSendMessageAsync(string queueUrl, string bucket)
         {
             return Task.FromResult("");


### PR DESCRIPTION
  * Update to the latest .NET Core SDK.
  * Set `DOTNET_NOLOGO` to reduce build logs noise.
  * Update various NuGet packages to their latest versions for 3.1.8.
