### PR TITLE
ISSUE-839 Add support for tagging queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ sqs:GetQueueUrl
 sqs:ListQueues
 sqs:ReceiveMessage
 sqs:SetQueueAttributes
+sqs:TagQueue
 ```
 
 An example policy would look like;
@@ -256,7 +257,8 @@ An example policy would look like;
                 "sqs:GetQueueAttributes",
                 "sqs:ReceiveMessage",
                 "sqs:SendMessage",
-                "sqs:SetQueueAttributes"
+                "sqs:SetQueueAttributes",
+                "sqs:TagQueue"
             ],
             "Resource": "arn:aws:sqs:aws-region:aws-account-id:uk-myfeature-orderaccepted"
         },

--- a/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Program.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Program.cs
@@ -85,12 +85,17 @@ namespace JustSaying.Sample.Restaurant.KitchenConsole
                             //  - a SQS queue of name `orderplacedevent`
                             //  - a SQS queue of name `orderplacedevent_error`
                             //  - a SNS topic of name `orderplacedevent`
-                            //  - a SNS topic subscription on topic 'orderplacedevent' and queue 'orderplacedevent'
-                            x.ForTopic<OrderPlacedEvent>(c =>
-                                c.WithReadConfiguration(rc  =>
-                                    rc.WithSubscriptionGroup("GroupA")));
-                            x.ForTopic<OrderOnItsWayEvent>(c =>
-                                c.WithReadConfiguration(rc =>
+                            //  - a SNS topic subscription on topic 'orderplacedevent' and queue 'orderplacedevent' with two tags
+                            //      - "IsOrderEvent" with no value
+                            //      - "Subscriber" with the value "KitchenConsole"
+                            //  - a SNS topic subscription on topic 'orderonitswayevent' and queue 'orderonitswayevent'
+                            x.ForTopic<OrderPlacedEvent>(cfg =>
+                                cfg.WithTag("IsOrderEvent")
+                                    .WithTag("Subscriber", nameof(KitchenConsole))
+                                    .WithReadConfiguration(rc  =>
+                                        rc.WithSubscriptionGroup("GroupA")));
+                            x.ForTopic<OrderOnItsWayEvent>(cfg =>
+                                cfg.WithReadConfiguration(rc =>
                                     rc.WithSubscriptionGroup("GroupB")));
                         });
 

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -142,7 +142,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             var tagRequest = new TagQueueRequest
             {
-                QueueUrl = Uri.ToString(),
+                QueueUrl = queue.Uri.ToString(),
                 Tags = tags
             };
 

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -105,7 +105,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 await UpdateQueueAttributeAsync(queueConfig).ConfigureAwait(false);
             }
 
-            await ApplyTagsAsync(this, queueConfig.Tags);
+            await ApplyTagsAsync(this, queueConfig.Tags).ConfigureAwait(false);
 
             //Create an error queue for existing queues if they don't already have one
             if (ErrorQueue != null && NeedErrorQueue(queueConfig))
@@ -129,7 +129,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 await UpdateRedrivePolicyAsync(
                     new RedrivePolicy(queueConfig.RetryCountBeforeSendingToErrorQueue, ErrorQueue.Arn)).ConfigureAwait(false);
 
-                await ApplyTagsAsync(ErrorQueue, queueConfig.Tags);
+                await ApplyTagsAsync(ErrorQueue, queueConfig.Tags).ConfigureAwait(false);
             }
         }
 

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -135,7 +135,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
         private async Task ApplyTagsAsync(ISqsQueue queue, Dictionary<string, string> tags)
         {
-            if (!tags.Any())
+            if (tags is null || !tags.Any())
             {
                 return;
             }

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Amazon;
@@ -90,7 +91,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }
         }
 
-        public async Task EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(SqsBasicConfiguration queueConfig)
+        public async Task EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(SqsReadConfiguration queueConfig)
         {
             if (queueConfig == null) throw new ArgumentNullException(nameof(queueConfig));
 
@@ -103,6 +104,8 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 await UpdateQueueAttributeAsync(queueConfig).ConfigureAwait(false);
             }
+
+            await ApplyTagsAsync(this, queueConfig.Tags);
 
             //Create an error queue for existing queues if they don't already have one
             if (ErrorQueue != null && NeedErrorQueue(queueConfig))
@@ -125,7 +128,27 @@ namespace JustSaying.AwsTools.MessageHandling
 
                 await UpdateRedrivePolicyAsync(
                     new RedrivePolicy(queueConfig.RetryCountBeforeSendingToErrorQueue, ErrorQueue.Arn)).ConfigureAwait(false);
+
+                await ApplyTagsAsync(ErrorQueue, queueConfig.Tags);
             }
+        }
+
+        private async Task ApplyTagsAsync(ISqsQueue queue, Dictionary<string, string> tags)
+        {
+            if (!tags.Any())
+            {
+                return;
+            }
+
+            var tagRequest = new TagQueueRequest
+            {
+                QueueUrl = Uri.ToString(),
+                Tags = tags
+            };
+
+            await queue.Client.TagQueueAsync(tagRequest).ConfigureAwait(false);
+
+            Logger.LogInformation("Added {TagCount} tags to queue {QueueName}", tagRequest.Tags.Count, QueueName);
         }
 
         protected override Dictionary<string, string> GetCreateQueueAttributes(SqsBasicConfiguration queueConfig)

--- a/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -92,11 +92,11 @@ namespace JustSaying.AwsTools.QueueCreation
             SqsReadConfiguration queueConfig)
         {
             var regionEndpoint = RegionEndpoint.GetBySystemName(region);
-            var sqsclient = _awsClientFactory.GetAwsClientFactory().GetSqsClient(regionEndpoint);
+            var sqsClient = _awsClientFactory.GetAwsClientFactory().GetSqsClient(regionEndpoint);
 
             var queue = new SqsQueueByName(regionEndpoint,
                 queueConfig.QueueName,
-                sqsclient,
+                sqsClient,
                 queueConfig.RetryCountBeforeSendingToErrorQueue,
                 _loggerFactory);
 

--- a/src/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.Middleware;
 using JustSaying.Naming;
@@ -20,6 +22,7 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public string TopicName { get; set; }
         public string PublishEndpoint { get; set; }
+        public Dictionary<string, string> Tags { get; set; }
 
         public string TopicSourceAccount { get; set; }
         public IMessageBackoffStrategy MessageBackoffStrategy { get; set; }

--- a/src/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.Middleware;

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging.Middleware;
 using JustSaying.Models;
@@ -31,6 +32,11 @@ namespace JustSaying.Fluent
         /// Gets or sets a delegate to a method to use to configure SNS reads.
         /// </summary>
         private Action<SqsReadConfiguration> ConfigureReads { get; set; }
+
+        /// <summary>
+        /// Gets the tags to add to the queue.
+        /// </summary>
+        private Dictionary<string, string> Tags { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Configures that the <see cref="ITopicNamingConvention"/> will create the topic name that should be used.
@@ -99,6 +105,43 @@ namespace JustSaying.Fluent
             return this;
         }
 
+        /// <summary>
+        /// Creates a tag with no value that will be assigned to the SQS queue.
+        /// </summary>
+        /// <param name="key">The key for the tag.</param>
+        /// <returns>
+        /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
+        /// </returns>
+        /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
+        /// </exception>
+        public TopicSubscriptionBuilder<T> WithTag(string key) => WithTag(key, null);
+
+        /// <summary>
+        /// Creates a tag with a value that will be assigned to the SQS queue.
+        /// </summary>
+        /// <param name="key">The key for the tag.</param>
+        /// <param name="value">The value associated with this tag.</param>
+        /// <returns>
+        /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
+        /// </returns>
+        /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
+        /// </exception>
+        public TopicSubscriptionBuilder<T> WithTag(string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("A queue tag key cannot be null or only whitespace", nameof(key));
+            }
+
+            Tags.Add(key, value ?? string.Empty);
+
+            return this;
+        }
+
         /// <inheritdoc />
         void ISubscriptionBuilder<T>.Configure(
             JustSayingBus bus,
@@ -111,7 +154,8 @@ namespace JustSaying.Fluent
 
             var subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic)
             {
-                QueueName = TopicName
+                QueueName = TopicName,
+                Tags = Tags
             };
 
             var config = bus.Config;

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenRegisteringASubscriberWithTags.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenRegisteringASubscriberWithTags.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SQS.Model;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Fluent;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class WhenRegisteringASubscriberWithTags : IntegrationTestBase
+    {
+        private const string QueueName = "simple-message-queue-with-tags";
+
+        public WhenRegisteringASubscriberWithTags(ITestOutputHelper outputHelper) : base(outputHelper)
+        { }
+
+        [Fact]
+        public async Task Then_A_Queue_For_Topic_Subscription_Is_Created_With_The_Correct_Tags()
+        {
+            // Arrange
+            var tags = new Dictionary<string, string>
+            {
+                [Guid.NewGuid().ToString()] = null,
+                [Guid.NewGuid().ToString()] = "Value"
+            };
+
+            await AssertQueueTagsExist(tags,
+                builder =>
+                    builder.ForTopic<SimpleMessage>((queueBuilder) =>
+                    {
+                        foreach ((string key, string value) in tags)
+                        {
+                            queueBuilder.WithTag(key, value);
+                        }
+
+                        queueBuilder.WithReadConfiguration(ReadConfig);
+                    }));
+        }
+
+        [Fact]
+        public async Task Then_A_Queue_Subscription_Is_Created_With_The_Correct_Tags()
+        {
+            // Arrange
+            var tags = new Dictionary<string, string>
+            {
+                [Guid.NewGuid().ToString()] = "Testing-One",
+                [Guid.NewGuid().ToString()] = "Testing-Two"
+            };
+
+            await AssertQueueTagsExist(tags,
+                builder =>
+                    builder.ForQueue<SimpleMessage>((queueBuilder) =>
+                    {
+                        foreach ((string key, string value) in tags)
+                        {
+                            queueBuilder.WithTag(key, value);
+                        }
+
+                        queueBuilder.WithReadConfiguration(ReadConfig);
+                    }));
+        }
+
+        private async Task AssertQueueTagsExist(Dictionary<string, string> expectedQueueTags, Action<SubscriptionsBuilder> subscriptionBuilder)
+        {
+            var serviceProvider = GivenJustSaying()
+                .ConfigureJustSaying((builder) =>
+                    builder.Subscriptions(subscriptionBuilder))
+                .AddJustSayingHandler<SimpleMessage, NullOpHandler<SimpleMessage>>()
+                .BuildServiceProvider();
+
+            // Act
+            var messageBus = serviceProvider.GetRequiredService<IMessagingBus>();
+            await messageBus.StartAsync(CancellationToken.None);
+
+            // Assert
+            var busBuilder = serviceProvider.GetRequiredService<MessagingBusBuilder>();
+            var clientFactory = busBuilder.BuildClientFactory();
+
+            var client = clientFactory.GetSqsClient(RegionEndpoint.EUWest1);
+
+            var queueUrl = (await client.GetQueueUrlAsync(QueueName)).QueueUrl;
+
+            var queueTags = (await client.ListQueueTagsAsync(new ListQueueTagsRequest { QueueUrl = queueUrl })).Tags;
+
+            foreach ((string key, string value) in expectedQueueTags)
+            {
+                queueTags.ShouldContain((t) => t.Key == key && t.Value == CleanTagValue(value));
+            }
+        }
+
+        private static void ReadConfig(SqsReadConfiguration readConfig) => readConfig.QueueName = QueueName;
+
+        private static string CleanTagValue(string tagValue) => string.IsNullOrEmpty(tagValue) ? null : tagValue;
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenRegisteringASubscriberWithTags.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenRegisteringASubscriberWithTags.cs
@@ -73,7 +73,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
             var serviceProvider = GivenJustSaying()
                 .ConfigureJustSaying((builder) =>
                     builder.Subscriptions(subscriptionBuilder))
-                .AddJustSayingHandler<SimpleMessage, NullOpHandler<SimpleMessage>>()
+                .AddJustSayingHandler<SimpleMessage, NoOpHandler<SimpleMessage>>()
                 .BuildServiceProvider();
 
             // Act

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenRegisteringASubscriberWithTags.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenRegisteringASubscriberWithTags.cs
@@ -21,7 +21,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
         public WhenRegisteringASubscriberWithTags(ITestOutputHelper outputHelper) : base(outputHelper)
         { }
 
-        [Fact]
+        [NotSimulatorFact]
         public async Task Then_A_Queue_For_Topic_Subscription_Is_Created_With_The_Correct_Tags()
         {
             // Arrange
@@ -44,7 +44,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                     }));
         }
 
-        [Fact]
+        [NotSimulatorFact]
         public async Task Then_A_Queue_Subscription_Is_Created_With_The_Correct_Tags()
         {
             // Arrange

--- a/tests/JustSaying.TestingFramework/NoOpHandler.cs
+++ b/tests/JustSaying.TestingFramework/NoOpHandler.cs
@@ -4,7 +4,7 @@ using JustSaying.Models;
 
 namespace JustSaying.TestingFramework
 {
-    public class NullOpHandler<T> : IHandlerAsync<T> where T : Message
+    public class NoOpHandler<T> : IHandlerAsync<T> where T : Message
     {
         public Task<bool> Handle(T message) => Task.FromResult(true);
     }

--- a/tests/JustSaying.TestingFramework/NullOpHandler.cs
+++ b/tests/JustSaying.TestingFramework/NullOpHandler.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Models;
+
+namespace JustSaying.TestingFramework
+{
+    public class NullOpHandler<T> : IHandlerAsync<T> where T : Message
+    {
+        public Task<bool> Handle(T message) => Task.FromResult(true);
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.AwsTools.QueueCreation;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
+{
+    public class WhenApplyingQueueTags
+    {
+        private const string QueueName = "my-queue-name";
+        private const string QueueArn = "my-queue-arn";
+        private const string QueueUrl = "http://my-queue-name/";
+        private const string ErrorQueueName = "my-queue-name_error";
+        private const string ErrorQueueArn = "my-queue-arn-error";
+        private const string ErrorQueueUrl = "http://my-queue-name-error/";
+
+        private readonly IAmazonSQS _client;
+
+        public WhenApplyingQueueTags()
+        {
+            _client = Substitute.For<IAmazonSQS>();
+
+            _client.GetQueueUrlAsync(Arg.Any<string>())
+                .Returns(callInfo =>
+                {
+                    string queueUrl = callInfo.Arg<string>() switch
+                    {
+                        QueueName => QueueUrl,
+                        ErrorQueueName => ErrorQueueUrl,
+                        _ => throw new QueueDoesNotExistException("Not found")
+                    };
+
+                    return new GetQueueUrlResponse { QueueUrl = queueUrl };
+                });
+
+            _client.GetQueueAttributesAsync(Arg.Any<GetQueueAttributesRequest>())
+                .Returns(callInfo =>
+                {
+                    string queueArn = callInfo.Arg<GetQueueAttributesRequest>().QueueUrl switch
+                    {
+                        QueueUrl => QueueArn,
+                        ErrorQueueUrl => ErrorQueueArn,
+                        _ => throw new QueueDoesNotExistException("Not found")
+                    };
+
+                    return new GetQueueAttributesResponse
+                    {
+                        Attributes = new Dictionary<string, string>
+                        {
+                            ["QueueArn"] = queueArn
+                        }
+                    };
+                });
+
+            _client.SetQueueAttributesAsync(Arg.Any<SetQueueAttributesRequest>()).Returns(new SetQueueAttributesResponse
+            {
+                HttpStatusCode = HttpStatusCode.OK
+            });
+        }
+
+        [Fact]
+        public async Task TagsAreAppliedToParentAndErrorQueues()
+        {
+            // Arrange
+            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, _client, 3, NullLoggerFactory.Instance);
+
+            var config = new SqsReadConfiguration(SubscriptionType.ToTopic)
+            {
+                Tags = new Dictionary<string, string>
+                {
+                    ["TagOne"] = "tag-one",
+                    ["TagTwo"] = "tag-two"
+                }
+            };
+
+            // Act
+            await sut.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(config);
+
+            // Assert
+            await _client.Received(1).TagQueueAsync(Arg.Is<TagQueueRequest>(req => req.QueueUrl == QueueUrl && req.Tags == config.Tags));
+        }
+
+        [Fact]
+        public async Task TagsAreNotAppliedIfNoneAreProvided()
+        {
+            // Arrange
+            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, _client, 3, NullLoggerFactory.Instance);
+
+            // Act
+            await sut.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(new SqsReadConfiguration(SubscriptionType.ToTopic));
+
+            // Assert
+            await _client.Received(0).TagQueueAsync(Arg.Any<TagQueueRequest>());
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/Fluent/WhenUsingQueueSubscriptionBuilder.cs
+++ b/tests/JustSaying.UnitTests/Fluent/WhenUsingQueueSubscriptionBuilder.cs
@@ -1,0 +1,42 @@
+using System;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Fluent;
+using JustSaying.TestingFramework;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Fluent
+{
+    public class WhenUsingQueueSubscriptionBuilder
+    {
+        private readonly QueueSubscriptionBuilder<Order> _sut;
+
+        public WhenUsingQueueSubscriptionBuilder()
+        {
+            _sut = new QueueSubscriptionBuilder<Order>();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ShouldThrowArgumentExceptionWhenAddingInvalidTag(string actualTagKey)
+        {
+            // Act + Assert
+            Should.Throw<ArgumentException>(() => _sut.WithTag(actualTagKey));
+        }
+
+        [Fact]
+        public void ShouldThrowArgumentExceptionWhenWriteConfigurationBuilderIsNull()
+        {
+            // Act + Assert
+            Should.Throw<ArgumentNullException>(() => _sut.WithReadConfiguration((Action<SqsReadConfigurationBuilder>) null));
+        }
+
+        [Fact]
+        public void ShouldThrowArgumentExceptionWhenWriteConfigurationIsNull()
+        {
+            // Act + Assert
+            Should.Throw<ArgumentNullException>(() => _sut.WithReadConfiguration((Action<SqsReadConfiguration>) null));
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/Fluent/WhenUsingTopicSubscriberBuilder.cs
+++ b/tests/JustSaying.UnitTests/Fluent/WhenUsingTopicSubscriberBuilder.cs
@@ -1,0 +1,42 @@
+using System;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.Fluent;
+using JustSaying.TestingFramework;
+using Shouldly;
+using Xunit;
+
+namespace JustSaying.UnitTests.Fluent
+{
+    public class WhenUsingTopicSubscriberBuilder
+    {
+        private readonly TopicSubscriptionBuilder<Order> _sut;
+
+        public WhenUsingTopicSubscriberBuilder()
+        {
+            _sut = new TopicSubscriptionBuilder<Order>();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ShouldThrowArgumentExceptionWhenAddingInvalidTag(string actualTagKey)
+        {
+            // Act + Assert
+            Should.Throw<ArgumentException>(() => _sut.WithTag(actualTagKey));
+        }
+
+        [Fact]
+        public void ShouldThrowArgumentExceptionWhenWriteConfigurationBuilderIsNull()
+        {
+            // Act + Assert
+            Should.Throw<ArgumentNullException>(() => _sut.WithReadConfiguration((Action<SqsReadConfigurationBuilder>) null));
+        }
+
+        [Fact]
+        public void ShouldThrowArgumentExceptionWhenWriteConfigurationIsNull()
+        {
+            // Act + Assert
+            Should.Throw<ArgumentNullException>(() => _sut.WithReadConfiguration((Action<SqsReadConfiguration>) null));
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/justeat/JustSaying/issues/839 - Following on from topic tagging, this PR introduces the same capability for queues.

I've opted to apply the tags to both parent and error queue but open to changing it if that doesn't seem appropriate.