### PR TITLE
Add benchmark utility

### DIFF
--- a/JustSaying.sln
+++ b/JustSaying.sln
@@ -74,6 +74,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustSaying.Sample.Restauran
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustSaying.Extensions.DependencyInjection.StructureMap.Tests", "tests\JustSaying.Extensions.DependencyInjection.StructureMap.Tests\JustSaying.Extensions.DependencyInjection.StructureMap.Tests.csproj", "{6AF4E086-6784-489C-9AB1-36F637A30094}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustSaying.Benchmark", "tests\JustSaying.Benchmark\JustSaying.Benchmark.csproj", "{83B43FC1-1F1C-4838-B67B-CE70D16870AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -128,6 +130,10 @@ Global
 		{6AF4E086-6784-489C-9AB1-36F637A30094}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6AF4E086-6784-489C-9AB1-36F637A30094}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6AF4E086-6784-489C-9AB1-36F637A30094}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83B43FC1-1F1C-4838-B67B-CE70D16870AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83B43FC1-1F1C-4838-B67B-CE70D16870AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83B43FC1-1F1C-4838-B67B-CE70D16870AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83B43FC1-1F1C-4838-B67B-CE70D16870AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,6 +155,7 @@ Global
 		{B42B2446-00F6-407E-8C62-E3831B61C8B6} = {77C93C37-DE5B-448F-9A23-6C9D0C8465CA}
 		{A4D0E032-3AF1-437F-AF6B-4B602B8D4C49} = {77C93C37-DE5B-448F-9A23-6C9D0C8465CA}
 		{6AF4E086-6784-489C-9AB1-36F637A30094} = {E22A50F2-9952-4483-8AD1-09BE354FB3E4}
+		{83B43FC1-1F1C-4838-B67B-CE70D16870AF} = {E22A50F2-9952-4483-8AD1-09BE354FB3E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {18FBDF85-C124-4444-9F03-D0D4F2B3A612}

--- a/tests/JustSaying.Benchmark/Analytics.cs
+++ b/tests/JustSaying.Benchmark/Analytics.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace JustSaying.Benchmark
+{
+    // Borrowed with ❤ from https://github.com/MassTransit/MassTransit-Benchmark/blob/a04a0235e13cd25e898a4238bad24ab5476d52d0/src/MassTransit-Benchmark/Analytics.cs
+    public static class Analytics
+    {
+        public static double? Median<TColl, TValue>(
+            this IEnumerable<TColl> source,
+            Func<TColl, TValue> selector)
+            where TValue : struct
+        {
+            return source.Select(selector).Median();
+        }
+
+        public static double? Percentile<TColl, TValue>(
+            this IEnumerable<TColl> source,
+            Func<TColl, TValue> selector, int percentile = 95)
+            where TValue : struct
+        {
+            return source.Select(selector).Percentile(percentile);
+        }
+
+        public static double? Median<T>(
+            this IEnumerable<T> source)
+            where T : struct
+        {
+            int count = source.Count();
+            if (count == 0)
+                return null;
+
+            source = source.OrderBy(n => n);
+
+            int midpoint = count / 2;
+            if (count % 2 == 0)
+            {
+                return (Convert.ToDouble(source.ElementAt(midpoint - 1)) + Convert.ToDouble(source.ElementAt(midpoint)))
+                    / 2.0;
+            }
+
+            return Convert.ToDouble(source.ElementAt(midpoint));
+        }
+
+        public static double? Percentile<T>(
+            this IEnumerable<T> source, int percentile)
+            where T : struct
+        {
+            int count = source.Count();
+            if (count == 0)
+                return null;
+
+            source = source.OrderBy(n => n);
+
+            int point = count * percentile / 100;
+            if (count % 2 == 0)
+            {
+                return (Convert.ToDouble(source.ElementAt(point - 1)) + Convert.ToDouble(source.ElementAt(point)))
+                    / 2.0;
+            }
+
+            return Convert.ToDouble(source.ElementAt(point));
+        }
+    }
+}

--- a/tests/JustSaying.Benchmark/BenchmarkMessage.cs
+++ b/tests/JustSaying.Benchmark/BenchmarkMessage.cs
@@ -1,0 +1,17 @@
+using System;
+using JustSaying.Models;
+
+namespace JustSaying.Benchmark
+{
+    public class BenchmarkMessage : Message
+    {
+        public BenchmarkMessage(TimeSpan sentAtOffset, int sequenceId)
+        {
+            SentAtOffset = sentAtOffset;
+            SequenceId = sequenceId;
+        }
+
+        public TimeSpan SentAtOffset { get; }
+        public int SequenceId { get; }
+    }
+}

--- a/tests/JustSaying.Benchmark/BenchmarkMessageHander.cs
+++ b/tests/JustSaying.Benchmark/BenchmarkMessageHander.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using JustSaying.Messaging.MessageHandling;
+
+namespace JustSaying.Benchmark
+{
+    public class BenchmarkMessageHander : IHandlerAsync<BenchmarkMessage>
+    {
+        private readonly IReportConsumerMetric _reporter;
+
+        public BenchmarkMessageHander(IReportConsumerMetric reporter)
+        {
+            _reporter = reporter;
+        }
+
+        public Task<bool> Handle(BenchmarkMessage message)
+        {
+            _reporter.Consumed<BenchmarkMessage>(message.Id);
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/tests/JustSaying.Benchmark/IReportConsumerMetric.cs
+++ b/tests/JustSaying.Benchmark/IReportConsumerMetric.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace JustSaying.Benchmark
+{
+    public interface IReportConsumerMetric
+    {
+        Task Consumed<T>(Guid messageId)
+            where T : class;
+
+        Task Sent(Guid messageId, Task sendTask);
+    }
+}

--- a/tests/JustSaying.Benchmark/JustSaying.Benchmark.csproj
+++ b/tests/JustSaying.Benchmark/JustSaying.Benchmark.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CommandLineParser" Version="2.8.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+      <PackageReference Include="morelinq" Version="3.3.2" />
+      <PackageReference Include="Serilog" Version="2.9.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+      <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+      <PackageReference Include="SerilogTimings" Version="2.3.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\JustSaying.Extensions.DependencyInjection.Microsoft\JustSaying.Extensions.DependencyInjection.Microsoft.csproj" />
+      <ProjectReference Include="..\..\src\JustSaying.Models\JustSaying.Models.csproj" />
+      <ProjectReference Include="..\..\src\JustSaying\JustSaying.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/JustSaying.Benchmark/JustSayingBenchmark.cs
+++ b/tests/JustSaying.Benchmark/JustSayingBenchmark.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using CommandLine;
+using JustSaying.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using MoreLinq;
+using Serilog;
+using SerilogTimings;
+
+namespace JustSaying.Benchmark
+{
+    [Verb("benchmark", HelpText = "Runs a benchmark against an SQS queue to test queue throughput")]
+    public class JustSayingBenchmark
+    {
+        [Option(HelpText = "The number of messages to send and receive in this test",
+            Required = false, Default = 1000)]
+        public int MessageCount { get; set; }
+
+        public static async Task RunTest(JustSayingBenchmark options)
+        {
+            Console.WriteLine("Running benchmark with message count of {0}", options.MessageCount);
+
+            var capture = new MessageMetricCapture(options.MessageCount);
+
+            var services = new ServiceCollection()
+                .AddSingleton<IReportConsumerMetric>(capture)
+                .AddLogging(lg => lg.AddSerilog());
+
+            RegisterJustSaying(services);
+
+            var provider = services.BuildServiceProvider();
+            var publisher = provider.GetService<IMessagePublisher>();
+
+            using (Operation.Time("Executing startup work"))
+            {
+                await publisher.StartAsync(CancellationToken.None);
+                var bus = provider.GetService<IMessagingBus>();
+                await bus.StartAsync(CancellationToken.None);
+            }
+
+            Console.WriteLine("Completed startup, beginning benchmark");
+
+            var watch = new Stopwatch();
+
+            var taskBatches = Enumerable.Range(0, options.MessageCount).Batch(20)
+                .Select(async batch =>
+                {
+                    var messageTasks =
+                        batch.Select(id => new BenchmarkMessage(watch.Elapsed, id))
+                            .Select(async x => await capture.Sent(x.Id, publisher.PublishAsync(x)));
+
+                    await Task.WhenAll(messageTasks);
+                }).ToList();
+
+            var batchId = 1;
+            var batchCount = taskBatches.Count;
+            foreach (var taskBatch in taskBatches)
+            {
+                using (Operation.Time("Sending batch id {BatchId} of {BatchCount}",
+                    batchId,
+                    batchCount))
+                {
+                    await taskBatch;
+                }
+            }
+
+            Log.Information("Waiting for sends to complete...");
+            await capture.SendCompleted;
+
+            Log.Information("Waiting for consumes to complete...");
+            await capture.ConsumeCompleted;
+
+            Log.Information("Sends and Consumes completed!");
+
+            var messageMetrics = capture.GetMessageMetrics();
+
+            Console.WriteLine("Avg Ack Time: {0:F0}ms",
+                messageMetrics.Average(x => x.AckLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("Min Ack Time: {0:F0}ms",
+                messageMetrics.Min(x => x.AckLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("Max Ack Time: {0:F0}ms",
+                messageMetrics.Max(x => x.AckLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("Med Ack Time: {0:F0}ms",
+                messageMetrics.Median(x => x.AckLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("95t Ack Time: {0:F0}ms",
+                messageMetrics.Percentile(x => x.AckLatency) * 1000 / Stopwatch.Frequency);
+
+            Console.WriteLine("Avg Consume Time: {0:F0}ms",
+                messageMetrics.Average(x => x.ConsumeLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("Min Consume Time: {0:F0}ms",
+                messageMetrics.Min(x => x.ConsumeLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("Max Consume Time: {0:F0}ms",
+                messageMetrics.Max(x => x.ConsumeLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("Med Consume Time: {0:F0}ms",
+                messageMetrics.Median(x => x.ConsumeLatency) * 1000 / Stopwatch.Frequency);
+            Console.WriteLine("95t Consume Time: {0:F0}ms",
+                messageMetrics.Percentile(x => x.ConsumeLatency) * 1000 / Stopwatch.Frequency);
+
+            DrawResponseTimeGraph(messageMetrics, m => m.ConsumeLatency);
+        }
+
+        static void RegisterJustSaying(IServiceCollection services)
+        {
+            services.AddJustSaying(config =>
+            {
+                config.Messaging(x => { x.WithRegion(RegionEndpoint.EUWest1); });
+
+                config.Publications(x => { x.WithTopic<BenchmarkMessage>(); });
+
+                config.Subscriptions(x => { x.ForTopic<BenchmarkMessage>("justsaying-benchmark"); });
+            });
+
+            services.AddJustSayingHandler<BenchmarkMessage, BenchmarkMessageHander>();
+        }
+
+        static void DrawResponseTimeGraph(MessageMetric[] metrics, Func<MessageMetric, long> selector)
+        {
+            long maxTime = metrics.Max(selector);
+            long minTime = metrics.Min(selector);
+
+            const int segments = 10;
+
+            long span = maxTime - minTime;
+            long increment = span / segments;
+
+            var histogram = (from x in metrics.Select(selector)
+                let key = ((x - minTime) * segments / span)
+                where key >= 0 && key < segments
+                let groupKey = key
+                group x by groupKey
+                into segment
+                orderby segment.Key
+                select new { Value = segment.Key, Count = segment.Count() }).ToList();
+
+            int maxCount = histogram.Max(x => x.Count);
+
+            foreach (var item in histogram)
+            {
+                int barLength = item.Count * 60 / maxCount;
+                Console.WriteLine("{0,5}ms {2,-60} ({1,7})",
+                    (minTime + increment * item.Value) * 1000 / Stopwatch.Frequency,
+                    item.Count,
+                    new string('*', barLength));
+            }
+        }
+    }
+}

--- a/tests/JustSaying.Benchmark/MessageMetric.cs
+++ b/tests/JustSaying.Benchmark/MessageMetric.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace JustSaying.Benchmark
+{
+    public class MessageMetric
+    {
+        public MessageMetric(Guid messageId, long ackLatency, long consumeLatency)
+        {
+            MessageId = messageId;
+            AckLatency = ackLatency;
+            ConsumeLatency = consumeLatency;
+        }
+
+        public Guid MessageId { get; }
+        public long AckLatency { get; set; }
+        public long ConsumeLatency { get; set; }
+    }
+}

--- a/tests/JustSaying.Benchmark/MessageMetricCapture.cs
+++ b/tests/JustSaying.Benchmark/MessageMetricCapture.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace JustSaying.Benchmark
+{
+    // Borrowed with ❤ from https://github.com/MassTransit/MassTransit-Benchmark/blob/a04a0235e1/src/MassTransit-Benchmark/Latency/MessageMetricCapture.cs
+    public class MessageMetricCapture :
+        IReportConsumerMetric
+    {
+        readonly TaskCompletionSource<TimeSpan> _consumeCompleted;
+        readonly ConcurrentBag<ConsumedMessage> _consumedMessages;
+        readonly long _messageCount;
+        readonly TaskCompletionSource<TimeSpan> _sendCompleted;
+        readonly ConcurrentBag<SentMessage> _sentMessages;
+        readonly Stopwatch _stopwatch;
+        long _consumed;
+        long _sent;
+
+        public MessageMetricCapture(long messageCount)
+        {
+            _messageCount = messageCount;
+
+            _consumedMessages = new ConcurrentBag<ConsumedMessage>();
+            _sentMessages = new ConcurrentBag<SentMessage>();
+            _sendCompleted = new TaskCompletionSource<TimeSpan>();
+            _consumeCompleted = new TaskCompletionSource<TimeSpan>();
+
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        public Task<TimeSpan> SendCompleted => _sendCompleted.Task;
+        public Task<TimeSpan> ConsumeCompleted => _consumeCompleted.Task;
+
+        Task IReportConsumerMetric.Consumed<T>(Guid messageId)
+        {
+            _consumedMessages.Add(new ConsumedMessage(messageId, _stopwatch.ElapsedTicks));
+
+            long consumed = Interlocked.Increment(ref _consumed);
+            if (consumed == _messageCount)
+                _consumeCompleted.TrySetResult(_stopwatch.Elapsed);
+
+            return Task.CompletedTask;
+        }
+
+        public async Task Sent(Guid messageId, Task sendTask)
+        {
+            long sendTimestamp = _stopwatch.ElapsedTicks;
+
+            await sendTask.ConfigureAwait(false);
+
+            long ackTimestamp = _stopwatch.ElapsedTicks;
+
+            _sentMessages.Add(new SentMessage(messageId, sendTimestamp, ackTimestamp));
+
+            long sent = Interlocked.Increment(ref _sent);
+            if (sent == _messageCount)
+                _sendCompleted.TrySetResult(_stopwatch.Elapsed);
+        }
+
+        public MessageMetric[] GetMessageMetrics()
+        {
+            return _sentMessages.Join(_consumedMessages,
+                    x => x.MessageId,
+                    x => x.MessageId,
+                    (sent, consumed) =>
+                        new MessageMetric(sent.MessageId,
+                            sent.AckTimestamp - sent.SendTimestamp,
+                            consumed.Timestamp - sent.SendTimestamp))
+                .ToArray();
+        }
+
+
+        struct SentMessage
+        {
+            public readonly Guid MessageId;
+            public readonly long SendTimestamp;
+            public readonly long AckTimestamp;
+
+            public SentMessage(Guid messageId, long sendTimestamp, long ackTimestamp)
+            {
+                MessageId = messageId;
+                SendTimestamp = sendTimestamp;
+                AckTimestamp = ackTimestamp;
+            }
+        }
+
+
+        struct ConsumedMessage
+        {
+            public readonly Guid MessageId;
+            public readonly long Timestamp;
+
+            public ConsumedMessage(Guid messageId, long timestamp)
+            {
+                MessageId = messageId;
+                Timestamp = timestamp;
+            }
+        }
+    }
+}

--- a/tests/JustSaying.Benchmark/Program.cs
+++ b/tests/JustSaying.Benchmark/Program.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using CommandLine;
+using Serilog;
+
+namespace JustSaying.Benchmark
+{
+    public class Program
+    {
+        static async Task Main(string[] args)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.Console()
+                .MinimumLevel.Warning()
+                .WriteTo.Seq("http://localhost:5341")
+                .Enrich.WithProperty("AppName", "JustSaying.Benchmark")
+                .CreateLogger();
+
+            try
+            {
+                await Parser.Default.ParseArguments<JustSayingBenchmark>(args)
+                    .MapResult(async a => await JustSayingBenchmark.RunTest(a),
+                        errs => Task.CompletedTask);
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a little benchmark utility that is mostly borrowed from `mtbench`, found [here](https://github.com/MassTransit/MassTransit-Benchmark).

It's a useful tool for testing queue throughput, and the effectiveness of the new consume pipeline. 

The output looks like this (run from my local machine):

![image](https://user-images.githubusercontent.com/130231/103885934-a9641a80-50d8-11eb-88a7-ab8d57d12694.png)
