### PR TITLE
Add TimeStampWithOffset

### DIFF
--- a/src/JustSaying.Models/Message.cs
+++ b/src/JustSaying.Models/Message.cs
@@ -6,14 +6,16 @@ namespace JustSaying.Models
     {
         protected Message()
         {
-            TimeStampWithOffset = DateTimeOffset.Now;
-            TimeStamp = TimeStampWithOffset.UtcDateTime;            
+            TimeStamp = DateTime.UtcNow;            
             Id = Guid.NewGuid();            
         }
 
         public Guid Id { get; set; }
         public DateTime TimeStamp { get; set; }
-        public DateTimeOffset TimeStampWithOffset { get; set; }
+        //NOTE: 
+        //1. this is nullable because it is not present in older versions of JustSaying and we need versions to interop seamlessly
+        //2. we do not set it in the constructor, since it would mean when consuming messages that don't have this property it gets set spuriously
+        public DateTimeOffset? TimeStampWithOffset { get; set; }
         public string RaisingComponent { get; set; }
         public string Version { get; private set; }
         public string SourceIp { get; private set; }

--- a/src/JustSaying.Models/Message.cs
+++ b/src/JustSaying.Models/Message.cs
@@ -7,11 +7,13 @@ namespace JustSaying.Models
         protected Message()
         {
             TimeStamp = DateTime.UtcNow;
-            Id = Guid.NewGuid();
+            TimeStampWithOffset = DateTimeOffset.Now;
+            Id = Guid.NewGuid();            
         }
 
         public Guid Id { get; set; }
         public DateTime TimeStamp { get; set; }
+        public DateTimeOffset TimeStampWithOffset { get; set; }
         public string RaisingComponent { get; set; }
         public string Version { get; private set; }
         public string SourceIp { get; private set; }

--- a/src/JustSaying.Models/Message.cs
+++ b/src/JustSaying.Models/Message.cs
@@ -6,8 +6,8 @@ namespace JustSaying.Models
     {
         protected Message()
         {
-            TimeStamp = DateTime.UtcNow;
             TimeStampWithOffset = DateTimeOffset.Now;
+            TimeStamp = TimeStampWithOffset.UtcDateTime;            
             Id = Guid.NewGuid();            
         }
 

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -247,6 +247,12 @@ namespace JustSaying
             CancellationToken cancellationToken)
         {
             attemptCount++;
+
+            if (message.TimeStampWithOffset == null)
+            {
+                message.TimeStampWithOffset = DateTimeOffset.Now;
+            }
+
             try
             {
                 using (Monitor.MeasurePublish())

--- a/tests/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenSerializingAndDeserializing.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenSerializingAndDeserializing.cs
@@ -33,6 +33,7 @@ namespace JustSaying.UnitTests.Messaging.Serialization.Newtonsoft
             _messageOut.EnumVal.ShouldBe(_messageIn.EnumVal);
             _messageOut.RaisingComponent.ShouldBe(_messageIn.RaisingComponent);
             _messageOut.TimeStamp.ShouldBe(_messageIn.TimeStamp);
+            _messageOut.TimeStampWithOffset.ShouldBe(_messageIn.TimeStampWithOffset);
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenSerializingAndDeserializing.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Serialization/SystemTextJson/WhenSerializingAndDeserializing.cs
@@ -34,6 +34,7 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SystemTextJson
             _messageOut.EnumVal.ShouldBe(_messageIn.EnumVal);
             _messageOut.RaisingComponent.ShouldBe(_messageIn.RaisingComponent);
             _messageOut.TimeStamp.ShouldBe(_messageIn.TimeStamp);
+            _messageOut.TimeStampWithOffset.ShouldBe(_messageIn.TimeStampWithOffset);
         }
 
         [Fact]


### PR DESCRIPTION
In a global system, it is far better to be explicit about timestamps and include the offset to remove any ambiguity.

Ideally we could switch `TimeStamp` to use `DateTimeOffset` but this would be a breaking change which could have an impact on any message consumers that were expecting an offsetless datetime format.  