### PR TITLE
Reduce the log level of some frequent messages

### DIFF
--- a/src/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
@@ -123,7 +123,7 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
 
                 Arn = response.TopicArn;
-                _logger.LogInformation("Created topic '{TopicName}' with ARN '{Arn}'.", TopicName, Arn);
+                _logger.LogDebug("Created topic '{TopicName}' with ARN '{Arn}'.", TopicName, Arn);
             }
             catch (AuthorizationErrorException ex)
             {

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
@@ -29,7 +29,7 @@ namespace JustSaying.AwsTools.MessageHandling
 
             try
             {
-                using (Logger.Time("Checking if queue '{QueueName}' exists", QueueName))
+                using (Logger.Time(LogLevel.Debug, "Checking if queue '{QueueName}' exists", QueueName))
                 {
                     result = await Client.GetQueueUrlAsync(QueueName).ConfigureAwait(false);
                 }

--- a/src/JustSaying/Extensions/LogOperationExtensions.cs
+++ b/src/JustSaying/Extensions/LogOperationExtensions.cs
@@ -6,9 +6,14 @@ namespace JustSaying.Extensions
 {
     internal static class LogOperationExtensions
     {
+        internal static IDisposable Time(this ILogger logger, LogLevel level, string logMessage, params object[] args)
+        {
+            return new LogOperation(logger, level, logMessage, args);
+        }
+
         internal static IDisposable Time(this ILogger logger, string logMessage, params object[] args)
         {
-            return new LogOperation(logger, logMessage, args);
+            return new LogOperation(logger, LogLevel.Information, logMessage, args);
         }
     }
 }

--- a/src/JustSaying/Messaging/Channels/Multiplexer/MergingMultiplexer.cs
+++ b/src/JustSaying/Messaging/Channels/Multiplexer/MergingMultiplexer.cs
@@ -62,7 +62,7 @@ namespace JustSaying.Messaging.Channels.Multiplexer
 
             try
             {
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "Starting up channel multiplexer with a queue capacity of {Capacity}",
                     _channelCapacity);
 

--- a/src/JustSaying/Messaging/Monitoring/LogOperation.cs
+++ b/src/JustSaying/Messaging/Monitoring/LogOperation.cs
@@ -11,10 +11,12 @@ namespace JustSaying.Messaging.Monitoring
         private readonly string _message;
         private readonly object[] _args;
         private readonly Stopwatch _watch;
+        private readonly LogLevel _logLevel;
 
-        public LogOperation(ILogger logger, string message, params object[] args)
+        public LogOperation(ILogger logger, LogLevel logLevel, string message, params object[] args)
         {
             _logger = logger;
+            _logLevel = logLevel;
             _message = message;
             _args = args;
             _watch = Stopwatch.StartNew();
@@ -26,7 +28,29 @@ namespace JustSaying.Messaging.Monitoring
 
             var args = _args.Concat(new object[] { _watch.Elapsed }).ToArray();
 
-            _logger.LogInformation($"{_message} completed in {{Duration}}", args);
+            switch (_logLevel)
+            {
+                case LogLevel.Trace:
+                    _logger.LogTrace(_message, args);
+                    return;
+                case LogLevel.Debug:
+                    _logger.LogDebug(_message, args);
+                    return;
+                case LogLevel.Information:
+                    _logger.LogInformation(_message, args);
+                    return;
+                case LogLevel.Warning:
+                    _logger.LogWarning(_message, args);
+                    return;
+                case LogLevel.Error:
+                    _logger.LogError(_message, args);
+                    return;
+                case LogLevel.Critical:
+                    _logger.LogCritical(_message, args);
+                    return;
+                case LogLevel.None:
+                    return;
+            }
         }
     }
 }


### PR DESCRIPTION
In testing JS7 with a feature that subscribes to 200 queues (due to tenanting), it turns out that we log quite a lot of information multiple times, because of the way startup works. I think these messages are still useful, but perhaps mainly for debugging purposes.

I propose the following messages are reduced from Information to Debug:

`2021-01-27 13:19:30.5446|Info|JustSaying|Checking if queue '<queuename>' exists completed in 00:00:00.8224467|`
`2021-01-27 13:19:30.5446|Info|JustSaying|Created topic '<topicname>' with ARN '<arn>'.|`
`2021-01-27 13:19:29.6835|Info|JustSaying.Messaging.Channels.Multiplexer.MergingMultiplexer|Starting up channel multiplexer with a queue capacity of 100|`

The first two can't be filtered by namespace, so there's no other way to filter them out. 

Note that we still log an interrogation message with queue names (though no arns), and lots of other information on concurrency/buffer/prefetch etc.

It's likely there are other low hanging fruit here too, but I think this is a start.