### PR TITLE
Prevent request too large after a period of time

### DIFF
--- a/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
@@ -28,7 +28,7 @@ namespace JustSaying.Messaging.Channels.Receive
         private readonly IMessageMonitor _monitor;
         private readonly ILogger _logger;
 
-        private readonly List<string> _requestMessageAttributeNames = new List<string>();
+        private readonly HashSet<string> _requestMessageAttributeNames = new HashSet<string>();
         private readonly string _backoffStrategyName;
 
         public ChannelReader<IQueueMessageContext> Reader => _channel.Reader;


### PR DESCRIPTION
On each GetMessages request, we add a 'content' attribute. After 5 requests, this attribute would be added 5 times.

Using a hashset instead of a list ensures we don't get duplicates, but keep the same 'ensure' semantics when adding to the collection.