### PR TITLE
Unify Publish logs

### DIFF
--- a/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Program.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Program.cs
@@ -94,6 +94,7 @@ namespace JustSaying.Sample.Restaurant.KitchenConsole
                                     .WithTag("Subscriber", nameof(KitchenConsole))
                                     .WithReadConfiguration(rc  =>
                                         rc.WithSubscriptionGroup("GroupA")));
+
                             x.ForTopic<OrderOnItsWayEvent>(cfg =>
                                 cfg.WithReadConfiguration(rc =>
                                     rc.WithSubscriptionGroup("GroupB")));

--- a/src/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -46,7 +46,7 @@ namespace JustSaying.AwsTools.MessageHandling
             IMessageSubjectProvider messageSubjectProvider)
         {
             _serializationRegister = serializationRegister;
-            _logger = loggerFactory.CreateLogger("JustSaying");
+            _logger = loggerFactory.CreateLogger("JustSaying.Publish");
             _snsWriteConfiguration = snsWriteConfiguration;
             _messageSubjectProvider = messageSubjectProvider;
         }
@@ -80,11 +80,19 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
             }
 
-            _logger.LogInformation(
-                "Published message: '{SnsSubject}' with content {SnsMessage} and request Id '{SnsRequestId}'",
-                request.Subject,
-                request.Message,
-                response?.ResponseMetadata?.RequestId);
+
+            using (_logger.BeginScope(new[]
+            {
+                new KeyValuePair<string, object>("AwsRequestId", response?.MessageId)
+            }))
+            {
+                _logger.LogInformation(
+                    "Published message {MessageId} of type {MessageType} to {Type} '{Target}'.",
+                    message.Id,
+                    message.GetType().Name,
+                    "Topic",
+                    request.TopicArn);
+            }
 
             if (MessageResponseLogger != null)
             {

--- a/src/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -87,7 +87,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }))
             {
                 _logger.LogInformation(
-                    "Published message {MessageId} of type {MessageType} to {Type} '{Target}'.",
+                    "Published message {MessageId} of type {MessageType} to {QueueOrTopic} '{MessageDestination}'.",
                     message.Id,
                     message.GetType().Name,
                     "Topic",

--- a/src/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsTopicBase.cs
@@ -80,14 +80,13 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
             }
 
-
             using (_logger.BeginScope(new[]
             {
                 new KeyValuePair<string, object>("AwsRequestId", response?.MessageId)
             }))
             {
                 _logger.LogInformation(
-                    "Published message {MessageId} of type {MessageType} to {QueueOrTopic} '{MessageDestination}'.",
+                    "Published message {MessageId} of type {MessageType} to {DestinationType} '{MessageDestination}'.",
                     message.Id,
                     message.GetType().Name,
                     "Topic",

--- a/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -65,7 +65,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }))
             {
                 Logger.LogInformation(
-                    "Published message {MessageId} of type {MessageType} to {Type} '{Target}'.",
+                    "Published message {MessageId} of type {MessageType} to {QueueOrTopic} '{MessageDestination}'.",
                     message.Id,
                     message.GetType().Name,
                     "Queue",

--- a/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -65,7 +65,7 @@ namespace JustSaying.AwsTools.MessageHandling
             }))
             {
                 Logger.LogInformation(
-                    "Published message {MessageId} of type {MessageType} to {QueueOrTopic} '{MessageDestination}'.",
+                    "Published message {MessageId} of type {MessageType} to {DestinationType} '{MessageDestination}'.",
                     message.Id,
                     message.GetType().Name,
                     "Queue",

--- a/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -59,10 +59,18 @@ namespace JustSaying.AwsTools.MessageHandling
                     ex);
             }
 
-            Logger.LogInformation(
-                "Published message to queue '{QueueUrl}' with content '{MessageBody}'.",
-                request.QueueUrl,
-                request.MessageBody);
+            using (Logger.BeginScope(new[]
+            {
+                new KeyValuePair<string, object>("AwsRequestId", response?.MessageId)
+            }))
+            {
+                Logger.LogInformation(
+                    "Published message {MessageId} of type {MessageType} to {Type} '{Target}'.",
+                    message.Id,
+                    message.GetType().Name,
+                    "Queue",
+                    request.QueueUrl);
+            }
 
             if (MessageResponseLogger != null)
             {

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -39,7 +39,7 @@ namespace JustSaying.AwsTools.MessageHandling
             Region = region;
             Client = client;
 
-            Logger = loggerFactory.CreateLogger("JustSaying");
+            Logger = loggerFactory.CreateLogger("JustSaying.Publish");
         }
 
         protected ILogger Logger { get; }

--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -88,6 +88,8 @@ namespace JustSaying.Fluent
             ConfigureWrites?.Invoke(writeConfiguration);
             writeConfiguration.ApplyQueueNamingConvention<T>(config.QueueNamingConvention);
 
+            bus.SerializationRegister.AddSerializer<T>();
+
             var regionEndpoint = RegionEndpoint.GetBySystemName(config.Region);
             var sqsClient = proxy.GetAwsClientFactory().GetSqsClient(regionEndpoint);
 

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -174,8 +174,8 @@ namespace JustSaying.Fluent
                 bus.SerializationRegister,
                 subscriptionConfig,
                 config.MessageSubjectProvider);
-            bus.AddStartupTask(queueWithStartup.StartupTask);
 
+            bus.AddStartupTask(queueWithStartup.StartupTask);
             bus.AddQueue(subscriptionConfig.SubscriptionGroupName, queueWithStartup.Queue);
 
             logger.LogInformation(

--- a/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -56,7 +56,7 @@ namespace JustSaying.IntegrationTests.Fluent
             LogLevel? levelOverride = null)
         {
             return new ServiceCollection()
-                .AddLogging((p) => p.AddXUnit(OutputHelper).SetMinimumLevel(levelOverride ?? LogLevel.Debug))
+                .AddLogging((p) => p.AddXUnit(OutputHelper, o => o.IncludeScopes = true).SetMinimumLevel(levelOverride ?? LogLevel.Debug))
                 .AddJustSaying(
                     (builder, serviceProvider) =>
                     {

--- a/tests/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
+++ b/tests/JustSaying.IntegrationTests/JustSaying.IntegrationTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="$(AwsSdkSnsVersion)" />
     <PackageReference Include="AWSSDK.SQS" Version="$(AwsSdkSqsVersion)" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(DotNetTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToQueueLogsShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToQueueLogsShouldHaveContext.approved.txt
@@ -23,5 +23,5 @@
 [{DateTime}] info: JustSaying[0]
       Starting bus
 [{DateTime}] info: JustSaying.Publish[0]
-      => System.Collections.Generic.KeyValuePair`2[System.String,System.Object][]
+      => AwsRequestId: {AwsRequestId}
       Published message {MessageId} of type SimpleMessage to Queue 'http://localhost:4566/000000000000/{TestDiscriminator}'.

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToQueueLogsShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToQueueLogsShouldHaveContext.approved.txt
@@ -1,0 +1,27 @@
+[{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
+      Adding SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
+[{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
+      Created SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
+[{DateTime}] dbug: JustSaying.Publish[0]
+      Checking if queue '{TestDiscriminator}' exists
+[{DateTime}] dbug: JustSaying.Publish[0]
+      Checking if queue '{TestDiscriminator}_error' exists
+[{DateTime}] info: JustSaying.Publish[0]
+      Created queue '{TestDiscriminator}_error' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}_error'.
+[{DateTime}] info: JustSaying.Publish[0]
+      Creating error queue {TestDiscriminator}_error
+[{DateTime}] info: JustSaying.Publish[0]
+      Created queue '{TestDiscriminator}' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}'.
+[{DateTime}] info: JustSaying.Publish[0]
+      Creating queue {TestDiscriminator} attempt number 0
+[{DateTime}] info: JustSaying[0]
+      Running 1 startup tasks
+[{DateTime}] info: JustSaying[0]
+      Starting bus with settings: JustSaying.Messaging.Interrogation.InterrogationResult
+[{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroupCollection[0]
+      Subscription group collection successfully started
+[{DateTime}] info: JustSaying[0]
+      Starting bus
+[{DateTime}] info: JustSaying.Publish[0]
+      => System.Collections.Generic.KeyValuePair`2[System.String,System.Object][]
+      Published message {MessageId} of type SimpleMessage to Queue 'http://localhost:4566/000000000000/{TestDiscriminator}'.

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToTopicLogsShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToTopicLogsShouldHaveContext.approved.txt
@@ -1,0 +1,17 @@
+[{DateTime}] info: JustSaying.Fluent.TopicPublicationBuilder[0]
+      Adding SNS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
+[{DateTime}] info: JustSaying.Fluent.TopicPublicationBuilder[0]
+      Created SNS topic publisher on topic 'simplemessage' for message type 'JustSaying.TestingFramework.SimpleMessage'.
+[{DateTime}] dbug: JustSaying[0]
+      Created topic 'simplemessage' with ARN 'arn:aws:sns:us-east-1:000000000000:simplemessage'.
+[{DateTime}] info: JustSaying[0]
+      Running 1 startup tasks
+[{DateTime}] info: JustSaying[0]
+      Starting bus with settings: JustSaying.Messaging.Interrogation.InterrogationResult
+[{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroupCollection[0]
+      Subscription group collection successfully started
+[{DateTime}] info: JustSaying[0]
+      Starting bus
+[{DateTime}] info: JustSaying.Publish[0]
+      => System.Collections.Generic.KeyValuePair`2[System.String,System.Object][]
+      Published message {MessageId} of type SimpleMessage to Topic 'arn:aws:sns:us-east-1:000000000000:simplemessage'.

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToTopicLogsShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToTopicLogsShouldHaveContext.approved.txt
@@ -13,5 +13,5 @@
 [{DateTime}] info: JustSaying[0]
       Starting bus
 [{DateTime}] info: JustSaying.Publish[0]
-      => System.Collections.Generic.KeyValuePair`2[System.String,System.Object][]
+      => AwsRequestId: {AwsRequestId}
       Published message {MessageId} of type SimpleMessage to Topic 'arn:aws:sns:us-east-1:000000000000:simplemessage'.

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -80,7 +80,7 @@ namespace JustSaying.Logging
             message = message.Replace(messageId, "{MessageId}");
             message = message.Replace(UniqueName, "{TestDiscriminator}");
 
-            message = Regex.Replace(message, @"AwsRequestId: {1}.{8}-.{4}-.{4}-.{4}-.{12}", "AwsRequestId: {AwsRequestId}");
+            message = Regex.Replace(message, @"AwsRequestId: .{8}-.{4}-.{4}-.{4}-.{12}", "AwsRequestId: {AwsRequestId}");
             message = Regex.Replace(message, @"(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})Z", "{DateTime}");
             return message;
         }

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using JustSaying.IntegrationTests.Fluent;
+using JustSaying.IntegrationTests.Fluent.Subscribing;
+using JustSaying.Messaging;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace JustSaying.Logging
+{
+    public class LogContextTests : IntegrationTestBase
+    {
+        public LogContextTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        { }
+
+        [AwsFact]
+        public async Task PublishToTopicLogsShouldHaveContext()
+        {
+            var services = GivenJustSaying()
+                .ConfigureJustSaying(
+                    (builder) => builder.WithLoopbackTopic<SimpleMessage>(UniqueName));
+
+            var sp = services.BuildServiceProvider();
+
+            var cts = new CancellationTokenSource();
+
+            var publisher = sp.GetRequiredService<IMessagePublisher>();
+            await publisher.StartAsync(cts.Token);
+
+            var message = new SimpleMessage();
+            await publisher.PublishAsync(message, cts.Token);
+
+            var output = ((TestOutputHelper) OutputHelper).Output;
+            output.ShouldMatchApproved(o => o
+                .SubFolder("Approvals")
+                .WithScrubber(logMessage => ScrubLogs(logMessage, message.Id.ToString())));
+
+            cts.Cancel();
+        }
+
+        [AwsFact]
+        public async Task PublishToQueueLogsShouldHaveContext()
+        {
+            var services = GivenJustSaying()
+                .ConfigureJustSaying(
+                    (builder) => builder.WithLoopbackQueue<SimpleMessage>(UniqueName));
+
+            var sp = services.BuildServiceProvider();
+
+            var cts = new CancellationTokenSource();
+
+            var publisher = sp.GetRequiredService<IMessagePublisher>();
+            await publisher.StartAsync(cts.Token);
+
+            var message = new SimpleMessage();
+            await publisher.PublishAsync(message, cts.Token);
+
+            var output = ((TestOutputHelper) OutputHelper).Output;
+            output.ShouldMatchApproved(o => o
+                .SubFolder("Approvals")
+                .WithScrubber(logMessage => ScrubLogs(logMessage, message.Id.ToString())));
+
+            cts.Cancel();
+        }
+
+        private string ScrubLogs(string message, string messageId)
+        {
+            message = message.Replace(messageId, "{MessageId}");
+            message = message.Replace(UniqueName, "{TestDiscriminator}");
+            message = Regex.Replace(message, @"(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})Z", "{DateTime}");
+            return message;
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -79,6 +79,8 @@ namespace JustSaying.Logging
         {
             message = message.Replace(messageId, "{MessageId}");
             message = message.Replace(UniqueName, "{TestDiscriminator}");
+
+            message = Regex.Replace(message, @"AwsRequestId: {1}.{8}-.{4}-.{4}-.{4}-.{12}", "AwsRequestId: {AwsRequestId}");
             message = Regex.Replace(message, @"(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})Z", "{DateTime}");
             return message;
         }

--- a/tests/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
+++ b/tests/JustSaying.TestingFramework/JustSaying.TestingFramework.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="4.0.3" />


### PR DESCRIPTION
This PR unifies the logs produced when publishing to topics and queues. It sets the same properties in the message and the log context, to make log navigation simpler.

The log template is `"Published message {MessageId} of type {MessageType} to {Type} '{Target}'."`

The properties available on logs are:
`MessageId`
`MessageType`
`DestinationType`: Queue or Topic
`PublishDestination`: the topic or queue arn

`AwsRequestId` is a log scope property and isn't directly in the message.

Partly resolves https://github.com/justeat/JustSaying/issues/867.