### PR TITLE
Add a serializer in queue publication builder

### DIFF
--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -88,6 +88,8 @@ namespace JustSaying.Fluent
             ConfigureWrites?.Invoke(writeConfiguration);
             writeConfiguration.ApplyQueueNamingConvention<T>(config.QueueNamingConvention);
 
+            bus.SerializationRegister.AddSerializer<T>();
+
             var regionEndpoint = RegionEndpoint.GetBySystemName(config.Region);
             var sqsClient = proxy.GetAwsClientFactory().GetSqsClient(regionEndpoint);
 


### PR DESCRIPTION
This fixes a bug in which we weren't adding a serializer when registering a queue for publications, so attempting to publish would throw an exception.