### PR TITLE
Update AWS SDKs and .NET SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,10 @@ updates:
   ignore:
   - dependency-name: AWSSDK.SimpleNotificationService
     versions:
-    - "> 3.3.100.1, < 3.6"
+    - "> 3.3.100.1, < 3.8"
   - dependency-name: AWSSDK.SQS
     versions:
-    - "> 3.3.100.1, < 3.6"
+    - "> 3.3.100.1, < 3.8"
   - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
     versions:
     - "> 1.1.0"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AwsSdkSnsVersion>3.5.0.9</AwsSdkSnsVersion>
-    <AwsSdkSqsVersion>3.5.0.9</AwsSdkSqsVersion>
+    <AwsSdkSnsVersion>3.7.0</AwsSdkSnsVersion>
+    <AwsSdkSqsVersion>3.7.0</AwsSdkSqsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.0.3" PrivateAssets="All" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.101",
+    "version": "5.0.201",
     "allowPrerelease": false
   }
 }

--- a/src/JustSaying/JustSaying.csproj
+++ b/src/JustSaying/JustSaying.csproj
@@ -6,8 +6,8 @@
     <ProjectReference Include="..\JustSaying.Models\JustSaying.Models.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.0" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />


### PR DESCRIPTION
  * Update the minimum AWS SDK version to 3.7.0 and disable dependabot updates.
  * Update to the latest .NET SDK.
 