### PR TITLE
Allow verification instead of creation for infrastructure dependencies

### DIFF
--- a/src/JustSaying.Tools/Commands/MoveCommand.cs
+++ b/src/JustSaying.Tools/Commands/MoveCommand.cs
@@ -34,8 +34,8 @@ namespace JustSaying.Tools.Commands
 
             var config = new AmazonSQSConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(Region) };
             var client = new DefaultAwsClientFactory().GetSqsClient(config.RegionEndpoint);
-            var sourceQueue = new SqsQueueByName(config.RegionEndpoint, SourceQueueName, client, JustSayingConstants.DefaultHandlerRetryCount, loggerFactory);
-            var destinationQueue = new SqsQueueByName(config.RegionEndpoint, DestinationQueueName, client, JustSayingConstants.DefaultHandlerRetryCount, loggerFactory);
+            var sourceQueue = new SqsQueueByName(config.RegionEndpoint, SourceQueueName,false, JustSayingConstants.DefaultHandlerRetryCount, client, loggerFactory);
+            var destinationQueue = new SqsQueueByName(config.RegionEndpoint, DestinationQueueName, false, JustSayingConstants.DefaultHandlerRetryCount, client, loggerFactory);
 
             await EnsureQueueExistsAsync(sourceQueue).ConfigureAwait(false);
             await EnsureQueueExistsAsync(destinationQueue).ConfigureAwait(false);

--- a/src/JustSaying.Tools/Commands/MoveCommand.cs
+++ b/src/JustSaying.Tools/Commands/MoveCommand.cs
@@ -34,8 +34,8 @@ namespace JustSaying.Tools.Commands
 
             var config = new AmazonSQSConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(Region) };
             var client = new DefaultAwsClientFactory().GetSqsClient(config.RegionEndpoint);
-            var sourceQueue = new SqsQueueByName(config.RegionEndpoint, SourceQueueName,false, JustSayingConstants.DefaultHandlerRetryCount, client, loggerFactory);
-            var destinationQueue = new SqsQueueByName(config.RegionEndpoint, DestinationQueueName, false, JustSayingConstants.DefaultHandlerRetryCount, client, loggerFactory);
+            var sourceQueue = new SqsQueueByName(config.RegionEndpoint, SourceQueueName, JustSayingConstants.DefaultHandlerRetryCount, client, loggerFactory);
+            var destinationQueue = new SqsQueueByName(config.RegionEndpoint, DestinationQueueName, JustSayingConstants.DefaultHandlerRetryCount, client, loggerFactory);
 
             await EnsureQueueExistsAsync(sourceQueue).ConfigureAwait(false);
             await EnsureQueueExistsAsync(destinationQueue).ConfigureAwait(false);

--- a/src/JustSaying/AwsTools/ErrorQueue.cs
+++ b/src/JustSaying/AwsTools/ErrorQueue.cs
@@ -17,7 +17,7 @@ namespace JustSaying.AwsTools
     public class ErrorQueue : SqsQueueByNameBase
     {
         public ErrorQueue(RegionEndpoint region, string sourceQueueName, IAmazonSQS client, ILoggerFactory loggerFactory)
-            : base(region, sourceQueueName + "_error", false, client, loggerFactory)
+            : base(region, sourceQueueName + "_error", client, loggerFactory)
         {
             ErrorQueue = null;
         }

--- a/src/JustSaying/AwsTools/ErrorQueue.cs
+++ b/src/JustSaying/AwsTools/ErrorQueue.cs
@@ -17,7 +17,7 @@ namespace JustSaying.AwsTools
     public class ErrorQueue : SqsQueueByNameBase
     {
         public ErrorQueue(RegionEndpoint region, string sourceQueueName, IAmazonSQS client, ILoggerFactory loggerFactory)
-            : base(region, sourceQueueName + "_error", client, loggerFactory)
+            : base(region, sourceQueueName + "_error", false, client, loggerFactory)
         {
             ErrorQueue = null;
         }

--- a/src/JustSaying/AwsTools/MessageHandling/Arn.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/Arn.cs
@@ -1,0 +1,26 @@
+namespace JustSaying.AwsTools.MessageHandling
+{
+    /// <summary>
+    /// Represents an Arn and allows access to its elements
+    /// </summary>
+    internal struct Arn
+    {
+        private const int ARN = 0;
+        private const int PARTITION = 1;
+        private const int SERVICE = 2;
+        private const int REGION = 3;
+        private const int ACCOUNT = 4;
+        private const int RESOURCE = 5;
+        private readonly string _arn;
+        private string[] _decomposedArn;
+
+        public string Resource => _decomposedArn[RESOURCE];
+
+        public Arn(string arn)
+        {
+            _arn = arn;
+            _decomposedArn = _arn.Split(':');
+        }
+
+    }
+}

--- a/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -29,7 +29,7 @@ namespace JustSaying.AwsTools.MessageHandling
             int retryCountBeforeSendingToErrorQueue,
             IMessageSerializationRegister serializationRegister,
             ILoggerFactory loggerFactory)
-            : base(region, queueName, client, retryCountBeforeSendingToErrorQueue, loggerFactory)
+            : base(region, queueName, false, retryCountBeforeSendingToErrorQueue, client, loggerFactory)
         {
             _client = client;
             _serializationRegister = serializationRegister;

--- a/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPublisher.cs
@@ -29,7 +29,7 @@ namespace JustSaying.AwsTools.MessageHandling
             int retryCountBeforeSendingToErrorQueue,
             IMessageSerializationRegister serializationRegister,
             ILoggerFactory loggerFactory)
-            : base(region, queueName, false, retryCountBeforeSendingToErrorQueue, client, loggerFactory)
+            : base(region, queueName, retryCountBeforeSendingToErrorQueue, client, loggerFactory)
         {
             _client = client;
             _serializationRegister = serializationRegister;

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -18,8 +18,14 @@ namespace JustSaying.AwsTools.MessageHandling
     {
         private readonly int _retryCountBeforeSendingToErrorQueue;
 
-        public SqsQueueByName(RegionEndpoint region, string queueName, IAmazonSQS client, int retryCountBeforeSendingToErrorQueue, ILoggerFactory loggerFactory)
-            : base(region, queueName, client, loggerFactory)
+        public SqsQueueByName(
+            RegionEndpoint region,
+            string queueName,
+            bool queueNameIsArn,
+            int retryCountBeforeSendingToErrorQueue,
+            IAmazonSQS client,
+            ILoggerFactory loggerFactory)
+            : base(region, queueName, queueNameIsArn, client, loggerFactory)
         {
             _retryCountBeforeSendingToErrorQueue = retryCountBeforeSendingToErrorQueue;
             ErrorQueue = new ErrorQueue(region, queueName, client, loggerFactory);

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -21,11 +21,10 @@ namespace JustSaying.AwsTools.MessageHandling
         public SqsQueueByName(
             RegionEndpoint region,
             string queueName,
-            bool queueNameIsArn,
             int retryCountBeforeSendingToErrorQueue,
             IAmazonSQS client,
             ILoggerFactory loggerFactory)
-            : base(region, queueName, queueNameIsArn, client, loggerFactory)
+            : base(region, queueName, client, loggerFactory)
         {
             _retryCountBeforeSendingToErrorQueue = retryCountBeforeSendingToErrorQueue;
             ErrorQueue = new ErrorQueue(region, queueName, client, loggerFactory);

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByNameBase.cs
@@ -18,12 +18,11 @@ namespace JustSaying.AwsTools.MessageHandling
         protected SqsQueueByNameBase(
             RegionEndpoint region,
             string queueName,
-            bool queueNameIsArn,
             IAmazonSQS client,
             ILoggerFactory loggerFactory)
             : base(region, client, loggerFactory)
         {
-            _queueNameIsArn = queueNameIsArn;
+            _queueNameIsArn = Amazon.Arn.IsArn(queueName);
             QueueName = queueName;
         }
 
@@ -43,7 +42,7 @@ namespace JustSaying.AwsTools.MessageHandling
             ListQueuesResponse listQueuesResponse = new ListQueuesResponse();
             do
             {
-                listQueuesResponse = await Client.ListQueuesAsync(new ListQueuesRequest{MaxResults = 100, QueueNamePrefix = new Arn(QueueName).Resource, NextToken = listQueuesResponse.NextToken});
+                listQueuesResponse = await Client.ListQueuesAsync(new ListQueuesRequest{MaxResults = 100, QueueNamePrefix = Amazon.Arn.Parse(QueueName).Resource, NextToken = listQueuesResponse.NextToken});
 
                 //Hopefully we get one, but possible we have synomyms, partial matches etc
                 foreach (var queueUrl in listQueuesResponse.QueueUrls)

--- a/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -30,13 +30,22 @@ namespace JustSaying.AwsTools.QueueCreation
             IMessageSerializationRegister serializationRegister,
             SqsReadConfiguration queueConfig,
             IMessageSubjectProvider messageSubjectProvider,
-            InfrastructureAction infrastructureAction)
+            InfrastructureAction infrastructureAction = InfrastructureAction.CreateIfMissing,
+            bool hasQueueArnNotName = false,
+            bool hasTopicArnNotName = false)
         {
+            //TODO: We may want to support provided Topic ARN but subscriber creates queue, which means we would need two InfrastrcutureAction variables
+            if ((hasQueueArnNotName) && infrastructureAction == InfrastructureAction.CreateIfMissing)
+                throw new InvalidOperationException($"With a Queue ARN the only supported action is validate");
+
+            if ((hasTopicArnNotName) && infrastructureAction == InfrastructureAction.CreateIfMissing)
+                throw new InvalidOperationException($"With a Queue ARN the only supported action is validate");
+
             var regionEndpoint = RegionEndpoint.GetBySystemName(region);
             var sqsClient = _awsClientFactory.GetAwsClientFactory().GetSqsClient(regionEndpoint);
             var snsClient = _awsClientFactory.GetAwsClientFactory().GetSnsClient(regionEndpoint);
 
-            var queueWithStartup = EnsureQueueExists(region, queueConfig);
+            var queueWithStartup = EnsureQueueExists(region, hasQueueArnNotName, queueConfig);
 
             async Task StartupTask()
             {
@@ -51,30 +60,37 @@ namespace JustSaying.AwsTools.QueueCreation
                 }
                 else if (infrastructureAction == InfrastructureAction.ValidateExists)
                 {
-                    if (TopicExistsInAnotherAccount(queueConfig))
-                        await CheckForeignTopicExists(queueConfig, regionEndpoint, snsClient);
+                    if (hasTopicArnNotName || TopicExistsInAnotherAccount(queueConfig))
+                        await CheckTopicAndSubscriptionExistsByArn(queueConfig, regionEndpoint, snsClient, queue, hasTopicArnNotName);
                     else
-                        await CheckTopicAndSubscriptioon(serializationRegister, queueConfig, messageSubjectProvider, snsClient, sqsClient, queue);
+                        await CheckTopicAndSubscriptioon(serializationRegister, queueConfig, messageSubjectProvider, snsClient, queue);
                 }
             }
 
             return new QueueWithAsyncStartup(StartupTask, queueWithStartup.Queue);
         }
 
-        private async Task CheckForeignTopicExists(SqsReadConfiguration queueConfig, RegionEndpoint regionEndpoint, IAmazonSimpleNotificationService snsClient)
+        private async Task CheckTopicAndSubscriptionExistsByArn(
+            SqsReadConfiguration queueConfig,
+            RegionEndpoint regionEndpoint,
+            IAmazonSimpleNotificationService snsClient,
+            ISqsQueue queue,
+            bool hasTopicArnNotName)
         {
-            var arnProvider = new ForeignTopicArnProvider(regionEndpoint,
-                queueConfig.TopicSourceAccount,
-                queueConfig.PublishEndpoint,
-                snsClient);
+            ForeignTopicArnProvider arnProvider = hasTopicArnNotName ?
+                new ForeignTopicArnProvider(queueConfig.TopicName, snsClient)
+                :
+                new ForeignTopicArnProvider(regionEndpoint, queueConfig.TopicSourceAccount, queueConfig.PublishEndpoint, snsClient);
 
             var exists = await arnProvider.ArnExistsAsync();
             if (!exists)
                 throw new InvalidOperationException($"The topic {queueConfig.PublishEndpoint} in account {queueConfig.TopicSourceAccount} does not exist");
+
+            await CheckSubscription(snsClient, queueConfig.TopicName, queue.Arn);
         }
 
 
-       private async Task CheckTopicAndSubscriptioon(IMessageSerializationRegister serializationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider, IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient, ISqsQueue queue)
+       private async Task CheckTopicAndSubscriptioon(IMessageSerializationRegister serializationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider, IAmazonSimpleNotificationService snsClient, ISqsQueue queue)
        {
 #pragma warning disable 618
                 var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint,
@@ -88,20 +104,24 @@ namespace JustSaying.AwsTools.QueueCreation
            if (!topicExists)
                throw new InvalidOperationException($"The topic {queueConfig.PublishEndpoint} does not exist");
 
+           await CheckSubscription(snsClient, eventTopic.Arn,queue.Arn);
+       }
+
+       private static async Task CheckSubscription(IAmazonSimpleNotificationService snsClient, string topicArn, string queueArn)
+       {
            bool subExists = false;
            ListSubscriptionsByTopicResponse response;
            do
            {
-               response = await snsClient.ListSubscriptionsByTopicAsync(new ListSubscriptionsByTopicRequest {TopicArn =eventTopic.Arn});
-               subExists  = response.Subscriptions.Any(sub => (sub.Protocol.ToLower() == "sqs") && (sub.Endpoint == queue.Arn));
+               response = await snsClient.ListSubscriptionsByTopicAsync(new ListSubscriptionsByTopicRequest { TopicArn = topicArn });
+               subExists = response.Subscriptions.Any(sub => (sub.Protocol.ToLower() == "sqs") && (sub.Endpoint == queueArn));
            } while (!subExists && response.NextToken != null);
 
            if (!subExists)
-               throw new InvalidOperationException($"Could not find subscription on topic: {eventTopic.Arn} for queue: {queue.Arn} ");
-
+               throw new InvalidOperationException($"Could not find subscription on topic: {topicArn} for queue: {queueArn} ");
        }
 
-        private static async Task SubscribeToTopic(SqsReadConfiguration queueConfig, RegionEndpoint regionEndpoint, IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient, ISqsQueue queue)
+       private static async Task SubscribeToTopic(SqsReadConfiguration queueConfig, RegionEndpoint regionEndpoint, IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient, ISqsQueue queue)
         {
             var arnProvider = new ForeignTopicArnProvider(regionEndpoint,
                 queueConfig.TopicSourceAccount,
@@ -152,6 +172,7 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public QueueWithAsyncStartup EnsureQueueExists(
             string region,
+            bool hasArnNotName,
             SqsReadConfiguration queueConfig)
         {
             var regionEndpoint = RegionEndpoint.GetBySystemName(region);
@@ -160,12 +181,21 @@ namespace JustSaying.AwsTools.QueueCreation
 #pragma warning disable 618
             var queue = new SqsQueueByName(regionEndpoint,
                 queueConfig.QueueName,
-                sqsClient,
+                hasArnNotName,
                 queueConfig.RetryCountBeforeSendingToErrorQueue,
+                sqsClient,
                 _loggerFactory);
 #pragma warning restore 618
 
-            var startupTask = new Func<Task>(() => queue.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(queueConfig));
+            Func<Task> startupTask;
+            if (!hasArnNotName)
+            {
+                startupTask = new Func<Task>(() => queue.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(queueConfig));
+            }
+            else
+            {
+                startupTask = new Func<Task>(() => queue.ExistsAsync());
+            }
 
             return new QueueWithAsyncStartup(startupTask, queue);
         }

--- a/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -181,7 +181,6 @@ namespace JustSaying.AwsTools.QueueCreation
 #pragma warning disable 618
             var queue = new SqsQueueByName(regionEndpoint,
                 queueConfig.QueueName,
-                hasArnNotName,
                 queueConfig.RetryCountBeforeSendingToErrorQueue,
                 sqsClient,
                 _loggerFactory);

--- a/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
 using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Fluent;
 using JustSaying.Messaging.MessageSerialization;
 using Microsoft.Extensions.Logging;
 
@@ -26,7 +29,8 @@ namespace JustSaying.AwsTools.QueueCreation
             string region,
             IMessageSerializationRegister serializationRegister,
             SqsReadConfiguration queueConfig,
-            IMessageSubjectProvider messageSubjectProvider)
+            IMessageSubjectProvider messageSubjectProvider,
+            InfrastructureAction infrastructureAction)
         {
             var regionEndpoint = RegionEndpoint.GetBySystemName(region);
             var sqsClient = _awsClientFactory.GetAwsClientFactory().GetSqsClient(regionEndpoint);
@@ -38,50 +42,107 @@ namespace JustSaying.AwsTools.QueueCreation
             {
                 await queueWithStartup.StartupTask.Invoke().ConfigureAwait(false);
                 var queue = queueWithStartup.Queue;
-                if (TopicExistsInAnotherAccount(queueConfig))
+                if (infrastructureAction == InfrastructureAction.CreateIfMissing)
                 {
-                    var arnProvider = new ForeignTopicArnProvider(regionEndpoint,
-                        queueConfig.TopicSourceAccount,
-                        queueConfig.PublishEndpoint);
-
-                    var topicArn = await arnProvider.GetArnAsync().ConfigureAwait(false);
-                    await SubscribeQueueAndApplyFilterPolicyAsync(snsClient,
-                        topicArn,
-                        sqsClient,
-                        queue.Uri,
-                        queueConfig.FilterPolicy).ConfigureAwait(false);
+                    if (TopicExistsInAnotherAccount(queueConfig))
+                        await SubscribeToTopic(queueConfig, regionEndpoint, snsClient, sqsClient, queue);
+                    else
+                        await CreateAndSubscribeToTopic(serializationRegister, queueConfig, messageSubjectProvider, snsClient, sqsClient, queue);
                 }
-                else
+                else if (infrastructureAction == InfrastructureAction.ValidateExists)
                 {
-#pragma warning disable 618
-                    var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint,
-                        snsClient,
-                        serializationRegister,
-                        _loggerFactory,
-                        messageSubjectProvider);
-#pragma warning restore 618
-                    await eventTopic.CreateAsync().ConfigureAwait(false);
-
-                    await SubscribeQueueAndApplyFilterPolicyAsync(snsClient,
-                        eventTopic.Arn,
-                        sqsClient,
-                        queue.Uri,
-                        queueConfig.FilterPolicy).ConfigureAwait(false);
-
-                    var sqsDetails = new SqsPolicyDetails
-                    {
-                        SourceArn = eventTopic.Arn,
-                        QueueArn = queue.Arn,
-                        QueueUri = queue.Uri
-                    };
-                    await SqsPolicy
-                        .SaveAsync(sqsDetails, sqsClient)
-                        .ConfigureAwait(false);
+                    if (TopicExistsInAnotherAccount(queueConfig))
+                        await CheckForeignTopicExists(queueConfig, regionEndpoint);
+                    else
+                        await CheckTopicAndSubscriptioon(serializationRegister, queueConfig, messageSubjectProvider, snsClient, sqsClient, queue);
                 }
             }
 
             return new QueueWithAsyncStartup(StartupTask, queueWithStartup.Queue);
         }
+
+        private async Task CheckForeignTopicExists(SqsReadConfiguration queueConfig, RegionEndpoint regionEndpoint)
+        {
+            var arnProvider = new ForeignTopicArnProvider(regionEndpoint,
+                queueConfig.TopicSourceAccount,
+                queueConfig.PublishEndpoint);
+
+            //TODO: Currently a no-op on this class - but we should check x-account - if we have a queue should we check for subscription instead
+            var exists = await arnProvider.ArnExistsAsync();
+            if (!exists)
+                throw new InvalidOperationException($"The topic {queueConfig.PublishEndpoint} in account {queueConfig.TopicSourceAccount} does not exist");
+        }
+
+
+       private async Task CheckTopicAndSubscriptioon(IMessageSerializationRegister serializationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider, IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient, ISqsQueue queue)
+       {
+#pragma warning disable 618
+                var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint,
+                snsClient,
+                serializationRegister,
+                _loggerFactory,
+                messageSubjectProvider);
+#pragma warning restore 618
+
+           var topicExists = await eventTopic.ExistsAsync();
+           if (!topicExists)
+               throw new InvalidOperationException($"The topic {queueConfig.PublishEndpoint} does not exist");
+
+           bool subExists = false;
+           ListSubscriptionsByTopicResponse response;
+           do
+           {
+               response = await snsClient.ListSubscriptionsByTopicAsync(new ListSubscriptionsByTopicRequest {TopicArn =eventTopic.Arn});
+               subExists  = response.Subscriptions.Any(sub => (sub.Protocol.ToLower() == "sqs") && (sub.Endpoint == queue.Arn));
+           } while (!subExists && response.NextToken != null);
+
+           if (!subExists)
+               throw new InvalidOperationException($"Could not find subscription on topic: {eventTopic.Arn} for queue: {queue.Arn} ");
+
+       }
+
+        private static async Task SubscribeToTopic(SqsReadConfiguration queueConfig, RegionEndpoint regionEndpoint, IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient, ISqsQueue queue)
+        {
+            var arnProvider = new ForeignTopicArnProvider(regionEndpoint,
+                queueConfig.TopicSourceAccount,
+                queueConfig.PublishEndpoint);
+
+            var topicArn = await arnProvider.GetArnAsync().ConfigureAwait(false);
+            await SubscribeQueueAndApplyFilterPolicyAsync(snsClient,
+                topicArn,
+                sqsClient,
+                queue.Uri,
+                queueConfig.FilterPolicy).ConfigureAwait(false);
+        }
+
+        private async Task CreateAndSubscribeToTopic(IMessageSerializationRegister serializationRegister, SqsReadConfiguration queueConfig, IMessageSubjectProvider messageSubjectProvider, IAmazonSimpleNotificationService snsClient, IAmazonSQS sqsClient, ISqsQueue queue)
+        {
+#pragma warning disable 618
+            var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint,
+                snsClient,
+                serializationRegister,
+                _loggerFactory,
+                messageSubjectProvider);
+#pragma warning restore 618
+            await eventTopic.CreateAsync().ConfigureAwait(false);
+
+            await SubscribeQueueAndApplyFilterPolicyAsync(snsClient,
+                eventTopic.Arn,
+                sqsClient,
+                queue.Uri,
+                queueConfig.FilterPolicy).ConfigureAwait(false);
+
+            var sqsDetails = new SqsPolicyDetails
+            {
+                SourceArn = eventTopic.Arn,
+                QueueArn = queue.Arn,
+                QueueUri = queue.Uri
+            };
+            await SqsPolicy
+                .SaveAsync(sqsDetails, sqsClient)
+                .ConfigureAwait(false);
+        }
+
 
         private static bool TopicExistsInAnotherAccount(SqsReadConfiguration queueConfig)
         {

--- a/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -68,7 +68,6 @@ namespace JustSaying.AwsTools.QueueCreation
                 queueConfig.PublishEndpoint,
                 snsClient);
 
-            //TODO: Currently a no-op on this class - but we should check x-account - if we have a queue should we check for subscription instead
             var exists = await arnProvider.ArnExistsAsync();
             if (!exists)
                 throw new InvalidOperationException($"The topic {queueConfig.PublishEndpoint} in account {queueConfig.TopicSourceAccount} does not exist");

--- a/src/JustSaying/AwsTools/QueueCreation/IVerifyAmazonQueues.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/IVerifyAmazonQueues.cs
@@ -1,4 +1,5 @@
 using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Fluent;
 using JustSaying.Messaging.MessageSerialization;
 
 namespace JustSaying.AwsTools.QueueCreation
@@ -9,7 +10,8 @@ namespace JustSaying.AwsTools.QueueCreation
             string region,
             IMessageSerializationRegister serializationRegister,
             SqsReadConfiguration queueConfig,
-            IMessageSubjectProvider messageSubjectProvider);
+            IMessageSubjectProvider messageSubjectProvider,
+            InfrastructureAction infrastructureAction);
 
         QueueWithAsyncStartup EnsureQueueExists(string region, SqsReadConfiguration queueConfig);
     }

--- a/src/JustSaying/AwsTools/QueueCreation/IVerifyAmazonQueues.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/IVerifyAmazonQueues.cs
@@ -11,8 +11,10 @@ namespace JustSaying.AwsTools.QueueCreation
             IMessageSerializationRegister serializationRegister,
             SqsReadConfiguration queueConfig,
             IMessageSubjectProvider messageSubjectProvider,
-            InfrastructureAction infrastructureAction);
+            InfrastructureAction infrastructureAction,
+            bool hasQueueArnNotName,
+            bool hasTopicArnNotName);
 
-        QueueWithAsyncStartup EnsureQueueExists(string region, SqsReadConfiguration queueConfig);
+        QueueWithAsyncStartup EnsureQueueExists(string region, bool hasArnNotName, SqsReadConfiguration queueConfig);
     }
 }

--- a/src/JustSaying/Fluent/InfrastructureAction.cs
+++ b/src/JustSaying/Fluent/InfrastructureAction.cs
@@ -1,0 +1,8 @@
+namespace JustSaying.Fluent
+{
+    public enum InfrastructureAction
+    {
+        CreateIfMissing,
+        ValidateExists
+    }
+}

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -14,7 +14,7 @@ namespace JustSaying.Fluent
     /// <summary>
     /// A class representing a builder for a queue subscription. This class cannot be inherited.
     /// </summary>
-    /// <typeparam name="T">
+    /// <typeparam queueName="T">
     /// The type of the message.
     /// </typeparam>
     public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T>
@@ -27,9 +27,15 @@ namespace JustSaying.Fluent
         { }
 
         /// <summary>
-        /// Gets or sets the queue name.
+        /// Gets or sets the queue queueName.
         /// </summary>
         private string QueueName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the topic queueName or Arn.
+        /// </summary>
+        private string Topic { get; set; } = string.Empty;
+
 
         /// <summary>
         /// Gets or sets a delegate to a method to use to configure SQS reads.
@@ -37,44 +43,90 @@ namespace JustSaying.Fluent
         private Action<SqsReadConfiguration> ConfigureReads { get; set; }
 
         /// <summary>
+        /// Is the queue named via a naming strategy via the subscription data type (true) or passed in (false)
+        /// </summary>
+        private bool HasDefaultQueueName { get; set; }
+
+        /// <summary>
+        /// Just use the naming convention to create the topic queueName from type queueName
+        /// </summary>
+        private bool HasDefaultTopicName { get; set; }
+
+        /// <summary>
+        /// Do we override the queueName of the topic from the infer from type approach
+        /// </summary>
+        private bool HasNameOverride { get; set; }
+
+        /// <summary>
+        /// Do we supply an ARN and not use the queueName at all?
+        /// </summary>
+        private bool HasArnNotName { get; set; }
+
+        /// <summary>
+        /// What should we do about required infrastructure
+        /// </summary>
+        private InfrastructureAction InfrastructureAction { get; set; } = InfrastructureAction.CreateIfMissing;
+
+        /// <summary>
         /// Gets the tags to add to the queue.
         /// </summary>
         private Dictionary<string, string> Tags { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
-        /// Configures that the <see cref="IQueueNamingConvention"/> will create the queue name that should be used.
+        /// Configures that the <see cref="IQueueNamingConvention"/> will create the queue queueName that should be used.
         /// </summary>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         public QueueSubscriptionBuilder<T> WithDefaultQueue()
-            => WithName(string.Empty);
+            => WithQueue(string.Empty);
 
         /// <summary>
-        /// Configures the name of the queue.
+        /// What should we do about infrastructure requirements
         /// </summary>
-        /// <param name="name">The name of the queue to subscribe to.</param>
+        /// <param queueName="action">What action should we take</param>
+        /// <returns></returns>
+        public QueueSubscriptionBuilder<T> WithInfrastructure(InfrastructureAction action)
+        {
+            InfrastructureAction = action;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the queueName of the queue.
+        /// </summary>
+        /// <param queueName="queueName">The queueName of the queue to subscribe to.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="name"/> is <see langword="null"/>.
+        /// <paramref queueName="queueName"/> is <see langword="null"/>.
         /// </exception>
-        public QueueSubscriptionBuilder<T> WithName(string name)
+        public QueueSubscriptionBuilder<T> WithQueue(string queueName)
         {
-            QueueName = name ?? throw new ArgumentNullException(nameof(name));
+            if (string.IsNullOrEmpty(queueName))
+            {
+                HasDefaultQueueName = true;
+            }
+            else
+            {
+                QueueName = queueName;
+                HasDefaultQueueName = false;
+            }
+
+
             return this;
         }
 
         /// <summary>
         /// Configures the SQS read configuration.
         /// </summary>
-        /// <param name="configure">A delegate to a method to use to configure SQS reads.</param>
+        /// <param queueName="configure">A delegate to a method to use to configure SQS reads.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="configure"/> is <see langword="null"/>.
+        /// <paramref queueName="configure"/> is <see langword="null"/>.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithReadConfiguration(
             Action<SqsReadConfigurationBuilder> configure)
@@ -95,12 +147,12 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Configures the SQS read configuration.
         /// </summary>
-        /// <param name="configure">A delegate to a method to use to configure SQS reads.</param>
+        /// <param queueName="configure">A delegate to a method to use to configure SQS reads.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="configure"/> is <see langword="null"/>.
+        /// <paramref queueName="configure"/> is <see langword="null"/>.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithReadConfiguration(Action<SqsReadConfiguration> configure)
         {
@@ -109,29 +161,63 @@ namespace JustSaying.Fluent
         }
 
         /// <summary>
+        /// Overrides the policy of generating the topic from the type queueName, and allows it to be passed in instead
+        /// </summary>
+        /// <param queueName="topicName">The topic queueName to use</param>
+        /// <param queueName="topicARN">We do not supply a queueName, instead use this externally created Arn instead. Should be used with validate infrastructure only</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public QueueSubscriptionBuilder<T> WithTopic(string topicName = null, string topicARN = null)
+        {
+            bool emptyName = string.IsNullOrEmpty(topicName);
+            bool emptyArn = string.IsNullOrEmpty(topicARN);
+
+            if (!emptyArn && !emptyName)
+            {
+                HasDefaultTopicName = true;
+            }
+
+            //if we supply both, just use the Arn
+            if (!emptyArn)
+            {
+                HasArnNotName = true;
+                Topic = topicARN;
+            }
+
+            if (!emptyName)
+            {
+                HasNameOverride = true;
+                Topic = topicName;
+            }
+
+            return this;
+
+        }
+
+        /// <summary>
         /// Creates a tag with no value that will be assigned to the SQS queue.
         /// </summary>
-        /// <param name="key">The key for the tag.</param>
+        /// <param queueName="key">The key for the tag.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
+        /// <paramref queueName="key"/> is <see langword="null"/> or whitespace.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithTag(string key) => WithTag(key, null);
 
         /// <summary>
         /// Creates a tag with a value that will be assigned to the SQS queue.
         /// </summary>
-        /// <param name="key">The key for the tag.</param>
-        /// <param name="value">The value associated with this tag.</param>
+        /// <param queueName="key">The key for the tag.</param>
+        /// <param queueName="value">The value associated with this tag.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
+        /// <paramref queueName="key"/> is <see langword="null"/> or whitespace.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithTag(string key, string value)
         {
@@ -158,6 +244,7 @@ namespace JustSaying.Fluent
             var subscriptionConfig = new SqsReadConfiguration(SubscriptionType.PointToPoint)
             {
                 QueueName = QueueName,
+                TopicName = Topic,
                 Tags = Tags
             };
 
@@ -165,8 +252,16 @@ namespace JustSaying.Fluent
 
             var config = bus.Config;
 
-            subscriptionConfig.ApplyTopicNamingConvention<T>(config.TopicNamingConvention);
-            subscriptionConfig.ApplyQueueNamingConvention<T>(config.QueueNamingConvention);
+            if (HasDefaultTopicName)
+            {
+                subscriptionConfig.ApplyTopicNamingConvention<T>(config.TopicNamingConvention);
+            }
+
+            if (HasDefaultQueueName)
+            {
+                subscriptionConfig.ApplyQueueNamingConvention<T>(config.QueueNamingConvention);
+            }
+
             subscriptionConfig.SubscriptionGroupName ??= subscriptionConfig.QueueName;
             subscriptionConfig.MiddlewareConfiguration = subscriptionConfig.MiddlewareConfiguration;
             subscriptionConfig.Validate();
@@ -205,5 +300,5 @@ namespace JustSaying.Fluent
                 subscriptionConfig.TopicName,
                 subscriptionConfig.QueueName);
         }
-    }
+   }
 }

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -266,7 +266,7 @@ namespace JustSaying.Fluent
             subscriptionConfig.MiddlewareConfiguration = subscriptionConfig.MiddlewareConfiguration;
             subscriptionConfig.Validate();
 
-            var queue = creator.EnsureQueueExists(config.Region, subscriptionConfig);
+            var queue = creator.EnsureQueueExists(config.Region, HasArnNotName, subscriptionConfig);
             bus.AddStartupTask(queue.StartupTask);
 
             bus.AddQueue(subscriptionConfig.SubscriptionGroupName, queue.Queue);

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -14,7 +14,7 @@ namespace JustSaying.Fluent
     /// <summary>
     /// A class representing a builder for a queue subscription. This class cannot be inherited.
     /// </summary>
-    /// <typeparam queueName="T">
+    /// <typeparam name="T">
     /// The type of the message.
     /// </typeparam>
     public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T>
@@ -84,7 +84,7 @@ namespace JustSaying.Fluent
         /// <summary>
         /// What should we do about infrastructure requirements
         /// </summary>
-        /// <param queueName="action">What action should we take</param>
+        /// <param name="action">What action should we take</param>
         /// <returns></returns>
         public QueueSubscriptionBuilder<T> WithInfrastructure(InfrastructureAction action)
         {
@@ -95,12 +95,12 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Configures the queueName of the queue.
         /// </summary>
-        /// <param queueName="queueName">The queueName of the queue to subscribe to.</param>
+        /// <param name="queueName">The queueName of the queue to subscribe to.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref queueName="queueName"/> is <see langword="null"/>.
+        /// <paramref name="queueName"/> is <see langword="null"/>.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithQueue(string queueName)
         {
@@ -121,12 +121,12 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Configures the SQS read configuration.
         /// </summary>
-        /// <param queueName="configure">A delegate to a method to use to configure SQS reads.</param>
+        /// <param name="configure">A delegate to a method to use to configure SQS reads.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref queueName="configure"/> is <see langword="null"/>.
+        /// <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithReadConfiguration(
             Action<SqsReadConfigurationBuilder> configure)
@@ -147,12 +147,12 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Configures the SQS read configuration.
         /// </summary>
-        /// <param queueName="configure">A delegate to a method to use to configure SQS reads.</param>
+        /// <param name="configure">A delegate to a method to use to configure SQS reads.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref queueName="configure"/> is <see langword="null"/>.
+        /// <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithReadConfiguration(Action<SqsReadConfiguration> configure)
         {
@@ -163,8 +163,8 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Overrides the policy of generating the topic from the type queueName, and allows it to be passed in instead
         /// </summary>
-        /// <param queueName="topicName">The topic queueName to use</param>
-        /// <param queueName="topicARN">We do not supply a queueName, instead use this externally created Arn instead. Should be used with validate infrastructure only</param>
+        /// <param name="topicName">The topic queueName to use</param>
+        /// <param name="topicARN">We do not supply a queueName, instead use this externally created Arn instead. Should be used with validate infrastructure only</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
         public QueueSubscriptionBuilder<T> WithTopic(string topicName = null, string topicARN = null)
@@ -197,27 +197,27 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Creates a tag with no value that will be assigned to the SQS queue.
         /// </summary>
-        /// <param queueName="key">The key for the tag.</param>
+        /// <param name="key">The key for the tag.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref queueName="key"/> is <see langword="null"/> or whitespace.
+        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithTag(string key) => WithTag(key, null);
 
         /// <summary>
         /// Creates a tag with a value that will be assigned to the SQS queue.
         /// </summary>
-        /// <param queueName="key">The key for the tag.</param>
-        /// <param queueName="value">The value associated with this tag.</param>
+        /// <param name="key">The key for the tag.</param>
+        /// <param name="value">The value associated with this tag.</param>
         /// <returns>
         /// The current <see cref="QueueSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref queueName="key"/> is <see langword="null"/> or whitespace.
+        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
         /// </exception>
         public QueueSubscriptionBuilder<T> WithTag(string key, string value)
         {

--- a/src/JustSaying/Fluent/SubscriptionsBuilder.cs
+++ b/src/JustSaying/Fluent/SubscriptionsBuilder.cs
@@ -82,7 +82,7 @@ namespace JustSaying.Fluent
         public SubscriptionsBuilder ForQueue<T>(string name)
             where T : Message
         {
-            return ForQueue<T>((p) => p.WithName(name));
+            return ForQueue<T>((p) => p.WithQueue(name));
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace JustSaying.Fluent
         public SubscriptionsBuilder ForTopic<T>(string name)
             where T : Message
         {
-            return ForTopic<T>((p) => p.WithName(name));
+            return ForTopic<T>((p) => p.WithTopic(name));
         }
 
         /// <summary>

--- a/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
@@ -155,18 +155,21 @@ namespace JustSaying.Fluent
             if (!emptyArn && !emptyName)
             {
                 HasArnNotName = true;
+                HasNameOverride = false;
                 Topic = topicARN;
             }
 
             if (!emptyName && emptyArn)
             {
                 HasNameOverride = true;
+                HasArnNotName = false;
                 Topic = topicName;
             }
 
             if (!emptyArn && emptyName)
             {
                 HasArnNotName = true;
+                HasNameOverride = false;
                 Topic = topicARN;
             }
 
@@ -204,9 +207,7 @@ namespace JustSaying.Fluent
 
             if (!HasNameOverride && !HasArnNotName)
                 readConfiguration.ApplyTopicNamingConvention<T>(config.TopicNamingConvention);
-            else if (HasArnNotName)
-                readConfiguration.TopicName = Topic;
-            else if (HasNameOverride)
+            else if (HasArnNotName || HasNameOverride)
                 readConfiguration.TopicName = Topic;
 
             if (HasArnNotName && InfrastructureAction != InfrastructureAction.ValidateExists)
@@ -222,7 +223,8 @@ namespace JustSaying.Fluent
                 bus.SerializationRegister,
                 loggerFactory,
                 writeConfiguration,
-                config.MessageSubjectProvider)
+                config.MessageSubjectProvider,
+                topicNameIsArn: HasArnNotName)
             {
                 MessageResponseLogger = config.MessageResponseLogger,
                 Tags = Tags

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -11,7 +11,7 @@ namespace JustSaying.Fluent
     /// <summary>
     /// A class representing a builder for a topic subscription. This class cannot be inherited.
     /// </summary>
-    /// <typeparam topicName="T">
+    /// <typeparam name="T">
     /// The type of the message.
     /// </typeparam>
     public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
@@ -103,7 +103,7 @@ namespace JustSaying.Fluent
         /// <summary>
         /// We need a topic to send a message to. Do we want to create it, or do we want to validate it exists?
         /// </summary>
-        /// <param topicName="action">The action to take with respect to topics</param>
+        /// <param name="action">The action to take with respect to topics</param>
         /// <returns></returns>
         public TopicSubscriptionBuilder<T> WithInfrastructure(InfrastructureAction action)
         {
@@ -148,12 +148,12 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Configures the SNS read configuration.
         /// </summary>
-        /// <param topicName="configure">A delegate to a method to use to configure SNS reads.</param>
+        /// <param name="configure">A delegate to a method to use to configure SNS reads.</param>
         /// <returns>
         /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref topicName="configure"/> is <see langword="null"/>.
+        /// <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public TopicSubscriptionBuilder<T> WithReadConfiguration(
             Action<SqsReadConfigurationBuilder> configure)
@@ -174,12 +174,12 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Configures the SNS read configuration.
         /// </summary>
-        /// <param topicName="configure">A delegate to a method to use to configure SNS reads.</param>
+        /// <param name="configure">A delegate to a method to use to configure SNS reads.</param>
         /// <returns>
         /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref topicName="configure"/> is <see langword="null"/>.
+        /// <paramref name="configure"/> is <see langword="null"/>.
         /// </exception>
         public TopicSubscriptionBuilder<T> WithReadConfiguration(Action<SqsReadConfiguration> configure)
         {
@@ -190,27 +190,27 @@ namespace JustSaying.Fluent
         /// <summary>
         /// Creates a tag with no value that will be assigned to the SQS queue.
         /// </summary>
-        /// <param topicName="key">The key for the tag.</param>
+        /// <param name="key">The key for the tag.</param>
         /// <returns>
         /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref topicName="key"/> is <see langword="null"/> or whitespace.
+        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
         /// </exception>
         public TopicSubscriptionBuilder<T> WithTag(string key) => WithTag(key, null);
 
         /// <summary>
         /// Creates a tag with a value that will be assigned to the SQS queue.
         /// </summary>
-        /// <param topicName="key">The key for the tag.</param>
-        /// <param topicName="value">The value associated with this tag.</param>
+        /// <param name="key">The key for the tag.</param>
+        /// <param name="value">The value associated with this tag.</param>
         /// <returns>
         /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
         /// </returns>
         /// <remarks>Tag keys are case-sensitive. A new tag with a key identical to that of an existing one will overwrite it.</remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref topicName="key"/> is <see langword="null"/> or whitespace.
+        /// <paramref name="key"/> is <see langword="null"/> or whitespace.
         /// </exception>
         public TopicSubscriptionBuilder<T> WithTag(string key, string value)
         {

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedQueueIsCreated.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedQueueIsCreated.cs
@@ -28,8 +28,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             // Act

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedQueueIsCreated.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedQueueIsCreated.cs
@@ -28,7 +28,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingAQueueWithNoErrorQueue.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingAQueueWithNoErrorQueue.cs
@@ -28,8 +28,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             // Act

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingAQueueWithNoErrorQueue.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingAQueueWithNoErrorQueue.cs
@@ -28,7 +28,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenQueueIsDeleted.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenQueueIsDeleted.cs
@@ -28,8 +28,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             await queue.CreateAsync(new SqsBasicConfiguration());

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenQueueIsDeleted.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenQueueIsDeleted.cs
@@ -28,7 +28,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingServerSideEncryption.cs
@@ -29,7 +29,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingServerSideEncryption.cs
@@ -29,8 +29,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             await queue.CreateAsync(

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingDeliveryDelay.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingDeliveryDelay.cs
@@ -33,8 +33,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             await queue.CreateAsync(

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingDeliveryDelay.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingDeliveryDelay.cs
@@ -33,7 +33,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRedrivePolicy.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRedrivePolicy.cs
@@ -31,8 +31,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             await queue.CreateAsync(new SqsBasicConfiguration());

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRedrivePolicy.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRedrivePolicy.cs
@@ -31,7 +31,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRetentionPeriod.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRetentionPeriod.cs
@@ -33,8 +33,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 1,
+                client,
                 loggerFactory);
 
             await queue.CreateAsync(

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRetentionPeriod.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRetentionPeriod.cs
@@ -33,7 +33,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 1,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingABasicThrottle.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingABasicThrottle.cs
@@ -42,8 +42,9 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                client,
+                false,
                 retryCountBeforeSendingToErrorQueue,
+                client,
                 loggerFactory);
 
             if (!await queue.ExistsAsync())

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingABasicThrottle.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingABasicThrottle.cs
@@ -42,7 +42,6 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             var queue = new SqsQueueByName(
                 Region,
                 UniqueName,
-                false,
                 retryCountBeforeSendingToErrorQueue,
                 client,
                 loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingServerSideEncryption.cs
@@ -33,7 +33,7 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
                             (config) => config.WithQueueName(UniqueName).WithEncryption(masterKeyId)))))
                 .ConfigureJustSaying(
                     (builder) => builder.Subscriptions((options) => options.ForQueue<SimpleMessage>(
-                        (queue) => queue.WithName(UniqueName).WithReadConfiguration(
+                        (queue) => queue.WithQueue(UniqueName).WithReadConfiguration(
                             (config) => config.WithEncryption(masterKeyId)))))
                 .AddSingleton<IHandlerAsync<SimpleMessage>>(handler);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingSnsServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingSnsServerSideEncryption.cs
@@ -33,7 +33,7 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
                             (config) => config.WithQueueName(UniqueName)))
                         .WithTopic<SimpleMessage>(topic => topic.WithWriteConfiguration(writeConfig => writeConfig.Encryption = new ServerSideEncryption { KmsMasterKeyId = masterSnsKeyId }))))
                 .ConfigureJustSaying(
-                    (builder) => builder.Subscriptions((options) => options.ForTopic<SimpleMessage>(topic => topic.WithName(UniqueName))))
+                    (builder) => builder.Subscriptions((options) => options.ForTopic<SimpleMessage>(topic => topic.WithTopic(UniqueName))))
                 .AddSingleton(handler);
 
             string content = Guid.NewGuid().ToString();

--- a/tests/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTestExtensions.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTestExtensions.cs
@@ -14,7 +14,7 @@ namespace JustSaying.IntegrationTests.Fluent
                 .Publications((options) => options.WithQueue<T>(name))
                 .Subscriptions((options) => options.ForQueue<T>(subscriptionBuilder =>
                 {
-                    subscriptionBuilder.WithName(name);
+                    subscriptionBuilder.WithQueue(name);
                     configure?.Invoke(subscriptionBuilder);
                 }));
         }
@@ -27,7 +27,7 @@ namespace JustSaying.IntegrationTests.Fluent
                 .Publications((options) => options.WithTopic<T>())
                 .Subscriptions((options) => options.ForTopic<T>(subscriptionBuilder =>
                 {
-                    subscriptionBuilder.WithName(name);
+                    subscriptionBuilder.WithTopic(name);
                     configure?.Invoke(subscriptionBuilder);
                 }));
         }

--- a/tests/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTestExtensions.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTestExtensions.cs
@@ -27,7 +27,7 @@ namespace JustSaying.IntegrationTests.Fluent
                 .Publications((options) => options.WithTopic<T>())
                 .Subscriptions((options) => options.ForTopic<T>(subscriptionBuilder =>
                 {
-                    subscriptionBuilder.WithTopic(name);
+                    subscriptionBuilder.WithQueue(name);
                     configure?.Invoke(subscriptionBuilder);
                 }));
         }

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenExplicitlyCreatingAMessagePublisher.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenExplicitlyCreatingAMessagePublisher.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using JustSaying.Fluent;
+using JustSaying.Messaging;
+using JustSaying.Naming;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing
+{
+    public class WhenExplicitlyCreatingAMessagePublisher : IntegrationTestBase
+    {
+        public WhenExplicitlyCreatingAMessagePublisher(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Topic_Exist()
+        {
+            // Arrange
+            //Create Bus that uses this topic
+            var serviceProvider = GivenJustSaying()
+                .ConfigureJustSaying(
+                    builder => builder.Publications(
+                        options =>
+                        {
+                            options.WithQueue<SimpleMessage>(UniqueName);
+                            options.WithTopic<SimpleMessage>(configure =>
+                            {
+                                //The topic should already exists and we just want to verify it
+                                configure.WithInfastructure(InfrastructureAction.CreateIfMissing);
+                            });
+                        })
+                )
+                .BuildServiceProvider();
+
+
+            // Act - Force topic creation
+            IMessagePublisher publisher = serviceProvider.GetRequiredService<IMessagePublisher>();
+            await publisher.StartAsync(CancellationToken.None);
+
+
+            // Assert
+            var topicCreated = await FindTopicByName<SimpleMessage>();
+            topicCreated.ShouldBe(true);
+
+        }
+
+        private async Task<bool> FindTopicByName<T>()
+        {
+            var snsClient = CreateClientFactory().GetSnsClient(Region);
+            var topic = await snsClient.FindTopicAsync(new DefaultNamingConventions().TopicName<T>()).ConfigureAwait(false);
+            return topic != null;
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenPublishingWithoutAMonitor.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenPublishingWithoutAMonitor.cs
@@ -51,7 +51,7 @@ namespace JustSaying.IntegrationTests.Fluent.Publishing
 
                     builder.Subscriptions(
                         (subscription) => subscription.ForTopic<SimpleMessage>(
-                            (topic) => topic.WithName(UniqueName)));
+                            (topic) => topic.WithTopic(UniqueName)));
                 })
                 .AddSingleton(handler);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenPublishingWithoutAMonitor.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenPublishingWithoutAMonitor.cs
@@ -51,7 +51,7 @@ namespace JustSaying.IntegrationTests.Fluent.Publishing
 
                     builder.Subscriptions(
                         (subscription) => subscription.ForTopic<SimpleMessage>(
-                            (topic) => topic.WithTopic(UniqueName)));
+                            (topic) => topic.WithQueue(UniqueName)));
                 })
                 .AddSingleton(handler);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisher.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisher.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using JustSaying.Fluent;
+using JustSaying.IntegrationTests.Fluent.Subscribing;
+using JustSaying.Messaging;
+using JustSaying.Naming;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing
+{
+    public class WhenVerifyingAMessagePublisher : IntegrationTestBase
+    {
+        public WhenVerifyingAMessagePublisher(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Topic_Exist()
+        {
+            // Arrange
+            //Let's create the required topic
+            var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
+            var snsClient = CreateClientFactory().GetSnsClient(Region);
+            var response = await snsClient.CreateTopicAsync(new CreateTopicRequest()
+            {
+                Name = topicName,
+                Tags = new List<Tag>{new Tag{Key="Author", Value="WhenVerifyingAMessagePublisher"}}
+            });
+
+            //sanity check
+            response.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+
+            // Act - Check topic creation
+            var createdOK = true;
+            try
+            {
+                //Create Bus that uses this topic
+                var serviceProvider = GivenJustSaying()
+                    .ConfigureJustSaying(
+                        builder => builder.Publications(
+                            options =>
+                            {
+                                options.WithQueue<SimpleMessage>(UniqueName);
+                                options.WithTopic<SimpleMessage>(configure =>
+                                {
+                                    configure.WithTopic(topicName);
+                                    //The topic should already exists and we just want to verify it
+                                    configure.WithInfastructure(InfrastructureAction.ValidateExists);
+                                });
+                            })
+                    )
+                    .BuildServiceProvider();
+            }
+            catch (InvalidOperationException)
+            {
+                createdOK = false;
+            }
+
+            // Assert
+            createdOK.ShouldBeTrue();
+
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisherByArn.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisherByArn.cs
@@ -17,28 +17,28 @@ using Xunit.Abstractions;
 
 namespace JustSaying.IntegrationTests.Fluent.Publishing
 {
-    public class WhenVerifyingAMessagePublisher : IntegrationTestBase
+    public class WhenVerifyingAMessagePublisherByArn : IntegrationTestBase
     {
-        public WhenVerifyingAMessagePublisher(ITestOutputHelper outputHelper)
+        public WhenVerifyingAMessagePublisherByArn(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
         }
 
         [AwsFact]
-        public async Task Then_The_Topic_Exist()
+        public async Task Then_The_Topic_Exists()
         {
             // Arrange
             //Let's create the required topic
             var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
             var snsClient = CreateClientFactory().GetSnsClient(Region);
-            var response = await snsClient.CreateTopicAsync(new CreateTopicRequest()
+            var createTopicResponse = await snsClient.CreateTopicAsync(new CreateTopicRequest()
             {
                 Name = topicName,
                 Tags = new List<Tag>{new Tag{Key="Author", Value="WhenVerifyingAMessagePublisher"}}
             });
 
             //sanity check
-            response.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+            createTopicResponse.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
 
             // Act - Check topic creation
             var createdOK = true;
@@ -55,7 +55,7 @@ namespace JustSaying.IntegrationTests.Fluent.Publishing
                                 {
                                     //The topic should already exists and we just want to verify it
                                     configure
-                                        .WithTopic(topicName)
+                                        .WithTopic(topicARN: createTopicResponse.TopicArn)
                                         .WithInfastructure(InfrastructureAction.ValidateExists);
                                 });
                             })

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisherByArnFails.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisherByArnFails.cs
@@ -17,28 +17,18 @@ using Xunit.Abstractions;
 
 namespace JustSaying.IntegrationTests.Fluent.Publishing
 {
-    public class WhenVerifyingAMessagePublisher : IntegrationTestBase
+    public class WhenVerifyingAMessagePublisherByArnFails : IntegrationTestBase
     {
-        public WhenVerifyingAMessagePublisher(ITestOutputHelper outputHelper)
+        public WhenVerifyingAMessagePublisherByArnFails(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
         }
 
         [AwsFact]
-        public async Task Then_The_Topic_Exist()
+        public async Task Then_The_Topic_Does_Not_Exist()
         {
             // Arrange
-            //Let's create the required topic
-            var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
-            var snsClient = CreateClientFactory().GetSnsClient(Region);
-            var response = await snsClient.CreateTopicAsync(new CreateTopicRequest()
-            {
-                Name = topicName,
-                Tags = new List<Tag>{new Tag{Key="Author", Value="WhenVerifyingAMessagePublisher"}}
-            });
-
-            //sanity check
-            response.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+            string topicName = new UniqueTopicNamingConvention().AsArn<SimpleMessage>();
 
             // Act - Check topic creation
             var createdOK = true;
@@ -55,7 +45,7 @@ namespace JustSaying.IntegrationTests.Fluent.Publishing
                                 {
                                     //The topic should already exists and we just want to verify it
                                     configure
-                                        .WithTopic(topicName)
+                                        .WithTopic(topicARN: topicName)
                                         .WithInfastructure(InfrastructureAction.ValidateExists);
                                 });
                             })
@@ -73,7 +63,7 @@ namespace JustSaying.IntegrationTests.Fluent.Publishing
             }
 
             // Assert
-            createdOK.ShouldBeTrue();
+            createdOK.ShouldBeFalse();
 
         }
     }

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisherFails.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenVerifyingAMessagePublisherFails.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using JustSaying.Fluent;
+using JustSaying.IntegrationTests.Fluent.Subscribing;
+using JustSaying.Messaging;
+using JustSaying.Naming;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing
+{
+    public class WhenVerifyingAMessagePublisherFails : IntegrationTestBase
+    {
+        public WhenVerifyingAMessagePublisherFails(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Bus_Fails_Fast()
+        {
+            //Arrange
+            var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
+
+            var serviceProvider = GivenJustSaying()
+                .ConfigureJustSaying(
+                    builder => builder.Publications(
+                        options =>
+                        {
+                            options.WithQueue<SimpleMessage>(UniqueName);
+                            options.WithTopic<SimpleMessage>(configure =>
+                            {
+                                configure.WithTopic(topicName);
+                                //The topic should already exists and we just want to verify it
+                                configure.WithInfastructure(InfrastructureAction.ValidateExists);
+                            });
+                        })
+                )
+                .BuildServiceProvider();
+
+            // Act - Try to validate a non-existant topic
+            var result = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                {
+                    IMessagePublisher publisher = serviceProvider.GetRequiredService<IMessagePublisher>();
+                    await publisher.StartAsync(CancellationToken.None);
+                }
+            );
+
+            // Assert
+
+            result.Message.ShouldBe($"The topic {topicName} does not exist and infrastructure was set to validate");
+
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenAHandlerThrowsAnExceptionWithNoMonitor.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenAHandlerThrowsAnExceptionWithNoMonitor.cs
@@ -35,7 +35,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                 .ConfigureJustSaying(
                     (builder) => builder.Subscriptions(
                         (options) => options.ForQueue<SimpleMessage>(
-                            (queue) => queue.WithName(UniqueName)))
+                            (queue) => queue.WithQueue(UniqueName)))
                         .Services(c => c.WithMessageMonitoring(() => monitor)))
                 .AddSingleton<IHandlerAsync<SimpleMessage>>(handler);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForQueue.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForQueue.cs
@@ -40,8 +40,9 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                             {
                                 options.ForQueue<SimpleMessage>(queueConfig =>
                                  {
-                                     queueConfig.WithQueue(UniqueName);
-                                     queueConfig.WithInfrastructure(InfrastructureAction.CreateIfMissing);
+                                     queueConfig
+                                         .WithQueue(UniqueName)
+                                         .WithInfrastructure(InfrastructureAction.CreateIfMissing);
                                  });
                             });
                         })

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForQueue.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForQueue.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS.Model;
+using JustSaying.Fluent;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class WhenExplicityCreatingAMessageSubscriberForQueue : IntegrationTestBase
+    {
+        public WhenExplicityCreatingAMessageSubscriberForQueue(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Topic_Exist()
+        {
+            // Arrange
+            // Act - Force topic creation
+            var createdOK = true;
+            try
+            {
+                var completionSource = new TaskCompletionSource<object>();
+                var handler = CreateHandler<SimpleMessage>(completionSource);
+                //Create Bus that uses this topic
+                var serviceProvider = GivenJustSaying()
+                    .ConfigureJustSaying(
+                        builder =>
+                        {
+                            builder.Subscriptions(options =>
+                            {
+                                options.ForQueue<SimpleMessage>(queueConfig =>
+                                 {
+                                     queueConfig.WithQueue(UniqueName);
+                                     queueConfig.WithInfrastructure(InfrastructureAction.CreateIfMissing);
+                                 });
+                            });
+                        })
+                    .AddSingleton(handler)
+                    .BuildServiceProvider();
+
+                IMessagingBus listener = serviceProvider.GetRequiredService<IMessagingBus>();
+                var ctx = new CancellationTokenSource();
+
+                await listener.StartAsync(ctx.Token);
+
+                ctx.CancelAfter(1000);
+            }
+            catch (InvalidOperationException)
+            {
+                createdOK = false;
+            }
+
+            // Assert
+            createdOK.ShouldBeTrue();
+            var sqsClient = CreateClientFactory().GetSqsClient(Region);
+            var findQueueResult = await sqsClient.GetQueueUrlAsync(UniqueName);
+            findQueueResult.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+            findQueueResult.QueueUrl.ShouldNotBeNull();
+        }
+   }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForTopic.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForTopic.cs
@@ -41,9 +41,10 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                             {
                                 options.ForTopic<SimpleMessage>(topicConfig =>
                                 {
-                                    topicConfig.WithQueue(UniqueName);
-                                    topicConfig.WithTopic(topicName);
-                                    topicConfig.WithInfrastructure(InfrastructureAction.CreateIfMissing);
+                                    topicConfig
+                                        .WithQueue(UniqueName)
+                                        .WithTopic(topicName)
+                                        .WithInfrastructure(InfrastructureAction.CreateIfMissing);
                                 });
                            });
                         })

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForTopic.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenExplicityCreatingAMessageSubscriberForTopic.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS.Model;
+using JustSaying.Fluent;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class WhenExplicityCreatingAMessageSubscriberForTopic : IntegrationTestBase
+    {
+        public WhenExplicityCreatingAMessageSubscriberForTopic (ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Topic_Exist()
+        {
+            // Arrange
+            var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
+
+            // Act - Force topic creation
+            var createdOK = true;
+            try
+            {
+                var completionSource = new TaskCompletionSource<object>();
+                var handler = CreateHandler<SimpleMessage>(completionSource);
+                //Create Bus that uses this topic
+                var serviceProvider = GivenJustSaying()
+                    .ConfigureJustSaying(
+                        builder =>
+                        {
+                            builder.Subscriptions(options =>
+                            {
+                                options.ForTopic<SimpleMessage>(topicConfig =>
+                                {
+                                    topicConfig.WithQueue(UniqueName);
+                                    topicConfig.WithTopic(topicName);
+                                    topicConfig.WithInfrastructure(InfrastructureAction.CreateIfMissing);
+                                });
+                           });
+                        })
+                    .AddSingleton(handler)
+                    .BuildServiceProvider();
+
+                IMessagingBus listener = serviceProvider.GetRequiredService<IMessagingBus>();
+                var ctx = new CancellationTokenSource();
+
+                await listener.StartAsync(ctx.Token);
+
+                ctx.CancelAfter(1000);
+            }
+            catch (InvalidOperationException)
+            {
+                createdOK = false;
+            }
+
+            // Assert
+            createdOK.ShouldBeTrue();
+            await ValidateRequiredInfrastructure(topicName, UniqueName);
+
+        }
+
+        private async Task ValidateRequiredInfrastructure(string topicName, string QueueName)
+        {
+            var snsClient = CreateClientFactory().GetSnsClient(Region);
+            var findTopicResult = await snsClient.FindTopicAsync(topicName);
+            findTopicResult.TopicArn.ShouldNotBeNull();
+
+
+            //and now the required queue
+            var sqsClient = CreateClientFactory().GetSqsClient(Region);
+            var findQueueResult = await sqsClient.GetQueueUrlAsync(UniqueName);
+            findQueueResult.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+            findQueueResult.QueueUrl.ShouldNotBeNull();
+
+            //now find the binding
+            var queueAttributesib = await sqsClient.GetQueueAttributesAsync(new GetQueueAttributesRequest{QueueUrl = findQueueResult.QueueUrl});
+            var queueArn = queueAttributesib.QueueARN;
+
+            bool exists = false;
+            ListSubscriptionsByTopicResponse response;
+            do
+            {
+                response = await snsClient.ListSubscriptionsByTopicAsync(new ListSubscriptionsByTopicRequest {TopicArn =findTopicResult.TopicArn});
+                exists = response.Subscriptions.Any(sub => (sub.Protocol.ToLower() == "sqs") && (sub.Endpoint == queueArn));
+            } while (!exists && response.NextToken != null);
+
+            exists.ShouldBeTrue();
+
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenHandlingMultipleTopics.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenHandlingMultipleTopics.cs
@@ -39,7 +39,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
                     var client = clientFactory.GetSqsClient(Region);
 
-                    var queue = new SqsQueueByName(Region, UniqueName, client, 0, loggerFactory);
+                    var queue = new SqsQueueByName(Region, UniqueName, false, 0, client, loggerFactory);
 
                     await Patiently.AssertThatAsync(OutputHelper, () => queue.ExistsAsync(), 60.Seconds());
 

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenHandlingMultipleTopics.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenHandlingMultipleTopics.cs
@@ -39,7 +39,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                     var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
                     var client = clientFactory.GetSqsClient(Region);
 
-                    var queue = new SqsQueueByName(Region, UniqueName, false, 0, client, loggerFactory);
+                    var queue = new SqsQueueByName(Region, UniqueName, 0, client, loggerFactory);
 
                     await Patiently.AssertThatAsync(OutputHelper, () => queue.ExistsAsync(), 60.Seconds());
 

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenReceivingIsThrottled.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenReceivingIsThrottled.cs
@@ -47,7 +47,7 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                         (options) => options
                             .WithSubscriptionGroup("group", groupConfig =>
                                 groupConfig.WithConcurrencyLimit(2))
-                            .ForQueue<WaitingMessage>((queue) => queue.WithName(UniqueName)
+                            .ForQueue<WaitingMessage>((queue) => queue.WithQueue(UniqueName)
                                 .WithReadConfiguration(c =>
                                     c.WithSubscriptionGroup("group")))))
                 .AddSingleton<IHandlerAsync<WaitingMessage>>(handler);

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenVerifyingAMessageSubscriber.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenVerifyingAMessageSubscriber.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS.Model;
+using JustSaying.Fluent;
+using JustSaying.Naming;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class WhenVerifyingAMessageSubscriber : IntegrationTestBase
+    {
+        public WhenVerifyingAMessageSubscriber(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Topic_Exist()
+        {
+            // Arrange
+            var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
+            await CreateRequiredInfrastructure(topicName);
+
+            // Act - Force topic creation
+            var createdOK = true;
+            try
+            {
+                var completionSource = new TaskCompletionSource<object>();
+                var handler = CreateHandler<SimpleMessage>(completionSource);
+                //Create Bus that uses this topic
+                var serviceProvider = GivenJustSaying()
+                    .ConfigureJustSaying(
+                        builder =>
+                        {
+                            builder.Subscriptions(options =>
+                            {
+                                options.ForTopic<SimpleMessage>(topicConfig =>
+                                {
+                                    topicConfig.WithQueue(UniqueName);
+                                    topicConfig.WithTopic(topicName);
+                                    topicConfig.WithInfrastructure(InfrastructureAction.ValidateExists);
+                                });
+                            });
+                        })
+                    .AddSingleton(handler)
+                    .BuildServiceProvider();
+
+                IMessagingBus listener = serviceProvider.GetRequiredService<IMessagingBus>();
+                var ctx = new CancellationTokenSource();
+
+                await listener.StartAsync(ctx.Token);
+
+                ctx.CancelAfter(1000);
+            }
+            catch (InvalidOperationException)
+            {
+                createdOK = false;
+            }
+
+            // Assert
+            createdOK.ShouldBeTrue();
+
+        }
+
+        private async Task CreateRequiredInfrastructure(string topicName)
+        {
+            var snsClient = CreateClientFactory().GetSnsClient(Region);
+            var createTopicResponse = await snsClient.CreateTopicAsync(new CreateTopicRequest()
+            {
+                Name = topicName,
+                Tags = new List<Tag> { new Tag { Key = "Author", Value = "WhenVerifyingAMessagePublisher" } }
+            });
+
+            //sanity check
+            createTopicResponse.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+
+            //and now the required queue
+            var sqsClient = CreateClientFactory().GetSqsClient(Region);
+            var createQueueResponse = await sqsClient.CreateQueueAsync(new CreateQueueRequest()
+            {
+                QueueName = UniqueName,
+                Tags = new Dictionary<string, string> { { "Author", "WhenVerifyingAMessagePublisher" } }
+            });
+
+            //sanity check
+            createQueueResponse.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+
+            //bind the queue to the topic
+            var subscriptionArn = await snsClient.SubscribeQueueAsync(createTopicResponse.TopicArn, sqsClient, createQueueResponse.QueueUrl);
+
+            //sanityCheck
+            subscriptionArn.ShouldNotBeNull();
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenVerifyingAMessageSubscriberFails.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenVerifyingAMessageSubscriberFails.cs
@@ -41,9 +41,10 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
                             {
                                 options.ForTopic<SimpleMessage>(topicConfig =>
                                 {
-                                    topicConfig.WithQueue(UniqueName);
-                                    topicConfig.WithTopic(topicName);
-                                    topicConfig.WithInfrastructure(InfrastructureAction.ValidateExists);
+                                    topicConfig
+                                        .WithQueue(UniqueName)
+                                        .WithTopic(topicName)
+                                        .WithInfrastructure(InfrastructureAction.ValidateExists);
                                 });
                             });
                         })

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenVerifyingAMessageSubscriberFails.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenVerifyingAMessageSubscriberFails.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS.Model;
+using JustSaying.Fluent;
+using JustSaying.Naming;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class WhenVerifyingAMessageSubcriber : IntegrationTestBase
+    {
+        public WhenVerifyingAMessageSubcriber(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [AwsFact]
+        public async Task Then_The_Bus_Fails_Fast()
+        {
+            // Arrange
+            var topicName = new UniqueTopicNamingConvention().TopicName<SimpleMessage>();
+            await CreateRequiredInfrastructure();
+
+            // Act - Force topic creation
+            var createdOK = true;
+            try
+            {
+                //Create Bus that uses this topic
+                var serviceProvider = GivenJustSaying()
+                    .ConfigureJustSaying(
+                        builder =>
+                        {
+                            builder.Subscriptions(options =>
+                            {
+                                options.ForTopic<SimpleMessage>(topicConfig =>
+                                {
+                                    topicConfig.WithQueue(UniqueName);
+                                    topicConfig.WithTopic(topicName);
+                                    topicConfig.WithInfrastructure(InfrastructureAction.ValidateExists);
+                                });
+                            });
+                        })
+                    .BuildServiceProvider();
+
+                IMessagingBus listener = serviceProvider.GetRequiredService<IMessagingBus>();
+                var ctx = new CancellationTokenSource();
+
+                await listener.StartAsync(ctx.Token);
+
+                ctx.CancelAfter(1000);
+            }
+            catch (InvalidOperationException)
+            {
+                createdOK = false;
+            }
+
+            // Assert
+            createdOK.ShouldBeFalse();
+
+        }
+
+        private async Task CreateRequiredInfrastructure()
+        {
+            var sqsClient = CreateClientFactory().GetSqsClient(Region);
+            var createQueueResponse = await sqsClient.CreateQueueAsync(new CreateQueueRequest()
+            {
+                QueueName = UniqueName,
+                Tags = new Dictionary<string, string> { { "Author", "WhenVerifyingAMessagePublisher" } }
+            });
+
+            //sanity check
+            createQueueResponse.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/TestHelpers/UniqueTopicNamingConvention.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/TestHelpers/UniqueTopicNamingConvention.cs
@@ -9,6 +9,11 @@ namespace JustSaying.IntegrationTests.Fluent.Subscribing
         private const int MaxTopicNameLength = 256;
         public string TopicName<T>() => CreateResourceName(Guid.NewGuid(), MaxTopicNameLength);
 
+        public string AsArn<T>()
+        {
+            return $"arn:aws:sns:us-east-1:000000000000:{TopicName<T>()}";
+        }
+
         private static string CreateResourceName(Guid uuid, int maximumLength)
         {
             var name = Regex.Replace(uuid.ToString(), "[^a-zA-Z0-9_-]", string.Empty);

--- a/tests/JustSaying.IntegrationTests/Fluent/TestHelpers/UniqueTopicNamingConvention.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/TestHelpers/UniqueTopicNamingConvention.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.RegularExpressions;
+using JustSaying.Naming;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class UniqueTopicNamingConvention : ITopicNamingConvention
+    {
+        private const int MaxTopicNameLength = 256;
+        public string TopicName<T>() => CreateResourceName(Guid.NewGuid(), MaxTopicNameLength);
+
+        private static string CreateResourceName(Guid uuid, int maximumLength)
+        {
+            var name = Regex.Replace(uuid.ToString(), "[^a-zA-Z0-9_-]", string.Empty);
+
+            return name.Length <= maximumLength ? name.ToLowerInvariant() : name.Substring(0, maximumLength);
+        }
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
@@ -70,7 +70,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public async Task TagsAreAppliedToParentAndErrorQueues()
         {
             // Arrange
-            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, _client, 3, NullLoggerFactory.Instance);
+            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, false, 3, _client, NullLoggerFactory.Instance);
 
             var config = new SqsReadConfiguration(SubscriptionType.ToTopic)
             {
@@ -92,7 +92,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public async Task TagsAreNotAppliedIfNoneAreProvided()
         {
             // Arrange
-            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, _client, 3, NullLoggerFactory.Instance);
+            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, false, 3, _client, NullLoggerFactory.Instance);
 
             // Act
             await sut.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(new SqsReadConfiguration(SubscriptionType.ToTopic));

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
@@ -70,7 +70,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public async Task TagsAreAppliedToParentAndErrorQueues()
         {
             // Arrange
-            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, false, 3, _client, NullLoggerFactory.Instance);
+            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, 3, _client, NullLoggerFactory.Instance);
 
             var config = new SqsReadConfiguration(SubscriptionType.ToTopic)
             {
@@ -92,7 +92,7 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         public async Task TagsAreNotAppliedIfNoneAreProvided()
         {
             // Arrange
-            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, false, 3, _client, NullLoggerFactory.Instance);
+            var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, 3, _client, NullLoggerFactory.Instance);
 
             // Act
             await sut.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(new SqsReadConfiguration(SubscriptionType.ToTopic));

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingQueueByName.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingQueueByName.cs
@@ -43,21 +43,21 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         [Fact]
         public async Task IncorrectQueueNameDoNotMatch()
         {
-            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name1", _client, RetryCount, _log);
+            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name1", false, RetryCount, _client, _log);
             (await sqsQueueByName.ExistsAsync()).ShouldBeFalse();
         }
 
         [Fact]
         public async Task IncorrectPartialQueueNameDoNotMatch()
         {
-            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue", _client, RetryCount, _log);
+            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue", false, RetryCount, _client, _log);
             (await sqsQueueByName.ExistsAsync()).ShouldBeFalse();
         }
 
         [Fact]
         public async Task CorrectQueueNameShouldMatch()
         {
-            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name", _client, RetryCount, _log);
+            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name", false, RetryCount, _client, _log);
             (await sqsQueueByName.ExistsAsync()).ShouldBeTrue();
         }
     }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingQueueByName.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingQueueByName.cs
@@ -43,21 +43,21 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs
         [Fact]
         public async Task IncorrectQueueNameDoNotMatch()
         {
-            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name1", false, RetryCount, _client, _log);
+            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name1", RetryCount, _client, _log);
             (await sqsQueueByName.ExistsAsync()).ShouldBeFalse();
         }
 
         [Fact]
         public async Task IncorrectPartialQueueNameDoNotMatch()
         {
-            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue", false, RetryCount, _client, _log);
+            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue", RetryCount, _client, _log);
             (await sqsQueueByName.ExistsAsync()).ShouldBeFalse();
         }
 
         [Fact]
         public async Task CorrectQueueNameShouldMatch()
         {
-            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name", false, RetryCount, _client, _log);
+            var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name", RetryCount, _client, _log);
             (await sqsQueueByName.ExistsAsync()).ShouldBeTrue();
         }
     }

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/WhenUsingSqsQueueByName.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/WhenUsingSqsQueueByName.cs
@@ -36,8 +36,9 @@ namespace JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests
 
             var queue = new SqsQueueByName(RegionEndpoint.EUWest1,
                 "some-queue-name",
-                _client,
+                false,
                 retryCount,
+                _client,
                 LoggerFactory);
             queue.ExistsAsync().Wait();
 

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/WhenUsingSqsQueueByName.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/WhenUsingSqsQueueByName.cs
@@ -36,7 +36,6 @@ namespace JustSaying.UnitTests.Messaging.Channels.SubscriptionGroupTests
 
             var queue = new SqsQueueByName(RegionEndpoint.EUWest1,
                 "some-queue-name",
-                false,
                 retryCount,
                 _client,
                 LoggerFactory);


### PR DESCRIPTION
Today JustSaying tries to create the required infrastructure for you. Although creation is a no-op for topic, it is not for queues and subscriptions and requires a check to determine if it has already been done. Without a distributed lock, this can lead to race conditions between components. Although topic is a no-op, IaC approaches may prefer to desired state approaches to topics, which may mean we want to create those outside of the JustSaying initialization too.

This PR allows explicit configuration of whether JustSaying should create missing message oriented middleware (MoM) dependencies, validate them, or just call assuming they exist.

it allows for externally-created infrastructure to be identified by name or by Arn.

It tries to support both the existing workflow of creation by default under the principle of "least surprise' and explicitly set other options, though it allows explicit request for creation as well.