### PR TITLE
Unify subscribe logs

### DIFF
--- a/src/JustSaying.Extensions.DependencyInjection.Microsoft/ServiceProviderResolver.cs
+++ b/src/JustSaying.Extensions.DependencyInjection.Microsoft/ServiceProviderResolver.cs
@@ -72,7 +72,7 @@ namespace JustSaying
             {
                 Logger.LogDebug(
                     "Resolved handler of type {ResolvedHandlerType} for queue {QueueName}.",
-                    handler.GetType().FullName,
+                    handler.GetType().Name,
                     context.QueueName);
             }
 

--- a/src/JustSaying/AwsTools/MessageHandling/Dispatch/MessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/Dispatch/MessageDispatcher.cs
@@ -175,10 +175,10 @@ namespace JustSaying.AwsTools.MessageHandling.Dispatch
 
             using (_messagingMonitor.MeasureDispatch())
             {
+                var context = new HandleMessageContext(message, messageType, queueName);
                 bool dispatchSuccessful = false;
                 try
                 {
-                    var context = new HandleMessageContext(message, messageType, queueName);
                     dispatchSuccessful = await middleware.RunAsync(context, null, cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -186,23 +186,30 @@ namespace JustSaying.AwsTools.MessageHandling.Dispatch
                 {
                     watch.Stop();
 
-                    var logMessage =
-                        "{Status} handling message with Id '{MessageId}' of type {MessageType} in {TimeToHandle}ms.";
-                    if (dispatchSuccessful)
+                    using (_logger.BeginScope(new[]
                     {
-                        _logger.LogInformation(logMessage,
-                            "Succeeded",
-                            message.Id,
-                            messageType,
-                            watch.ElapsedMilliseconds);
-                    }
-                    else
+                        new KeyValuePair<string, object>("MessageSource", context.QueueName),
+                        new KeyValuePair<string, object>("SourceType", "Queue")
+                    }))
                     {
-                        _logger.LogWarning(logMessage,
-                            "Failed",
-                            message.Id,
-                            messageType,
-                            watch.ElapsedMilliseconds);
+                        var logMessage =
+                            "{Status} handling message with Id '{MessageId}' of type {MessageType} in {TimeToHandle}ms.";
+                        if (dispatchSuccessful)
+                        {
+                            _logger.LogInformation(logMessage,
+                                "Succeeded",
+                                message.Id,
+                                messageType,
+                                watch.ElapsedMilliseconds);
+                        }
+                        else
+                        {
+                            _logger.LogWarning(logMessage,
+                                "Failed",
+                                message.Id,
+                                messageType,
+                                watch.ElapsedMilliseconds);
+                        }
                     }
                 }
 

--- a/src/JustSaying/AwsTools/MessageHandling/Dispatch/MessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/Dispatch/MessageDispatcher.cs
@@ -186,10 +186,10 @@ namespace JustSaying.AwsTools.MessageHandling.Dispatch
                 {
                     watch.Stop();
 
-                    using (_logger.BeginScope(new[]
+                    using (_logger.BeginScope(new Dictionary<string, object>()
                     {
-                        new KeyValuePair<string, object>("MessageSource", context.QueueName),
-                        new KeyValuePair<string, object>("SourceType", "Queue")
+                        ["MessageSource"] = context.QueueName,
+                        ["SourceType"] = "Queue"
                     }))
                     {
                         var logMessage =

--- a/src/JustSaying/AwsTools/MessageHandling/SnsMessagePublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsMessagePublisher.cs
@@ -78,9 +78,9 @@ namespace JustSaying.AwsTools.MessageHandling
                 }
             }
 
-            using (_logger.BeginScope(new[]
+            using (_logger.BeginScope(new Dictionary<string, object>
             {
-                new KeyValuePair<string, object>("AwsRequestId", response?.MessageId)
+                ["AwsRequestId"] = response?.MessageId
             }))
             {
                 _logger.LogInformation(

--- a/src/JustSaying/AwsTools/MessageHandling/SqsMessagePublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsMessagePublisher.cs
@@ -67,9 +67,9 @@ namespace JustSaying.AwsTools.MessageHandling
                     ex);
             }
 
-            using (_logger.BeginScope(new[]
+            using (_logger.BeginScope(new Dictionary<string, object>
             {
-                new KeyValuePair<string, object>("AwsRequestId", response?.MessageId)
+                ["AwsRequestId"] = response?.MessageId
             }))
             {
                 _logger.LogInformation(

--- a/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -24,8 +24,6 @@ namespace JustSaying.IntegrationTests.Fluent
             OutputHelper = new CapturingTestOutputHelper(outputHelper);
         }
 
-        protected virtual LogLevel MinimumLogLevel { get; set; } = LogLevel.Debug;
-
         protected virtual string AccessKeyId { get; } = "accessKeyId";
 
         protected virtual string SecretAccessKey { get; } = "secretAccessKey";
@@ -56,14 +54,15 @@ namespace JustSaying.IntegrationTests.Fluent
 
         protected IServiceCollection Given(
             Action<MessagingBusBuilder, IServiceProvider> configure,
-            LogLevel? levelOverride = null)
+            LogLevel? levelOverride)
         {
+            LogLevel logLevel = levelOverride ?? LogLevel.Debug;
             return new ServiceCollection()
                 .AddLogging((p) => p.AddXUnit(OutputHelper, o =>
                 {
                     o.IncludeScopes = true;
-                    o.Filter = (_, level) => level >= MinimumLogLevel;
-                }).SetMinimumLevel(levelOverride ?? LogLevel.Debug))
+                    o.Filter = (_, level) => level >= logLevel;
+                }).SetMinimumLevel(logLevel))
                 .AddJustSaying(
                     (builder, serviceProvider) =>
                     {

--- a/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using JustSaying.AwsTools;
+using JustSaying.IntegrationTests.Fluent.Subscribing;
 using JustSaying.Messaging;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.Models;

--- a/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -54,7 +54,7 @@ namespace JustSaying.IntegrationTests.Fluent
 
         protected IServiceCollection Given(
             Action<MessagingBusBuilder, IServiceProvider> configure,
-            LogLevel? levelOverride)
+            LogLevel? levelOverride = null)
         {
             LogLevel logLevel = levelOverride ?? LogLevel.Debug;
             return new ServiceCollection()
@@ -136,32 +136,6 @@ namespace JustSaying.IntegrationTests.Fluent
                 }
 
                 await actionTask;
-            }
-        }
-
-        public class CapturingTestOutputHelper : ITestOutputHelper
-        {
-            private readonly ITestOutputHelper _inner;
-            private readonly StringBuilder _sb;
-
-            public string Output => _sb.ToString();
-
-            public CapturingTestOutputHelper(ITestOutputHelper inner)
-            {
-                _inner = inner;
-                _sb = new StringBuilder();
-            }
-
-            public void WriteLine(string message)
-            {
-                _sb.AppendLine(message);
-                _inner.WriteLine(message);
-            }
-
-            public void WriteLine(string format, params object[] args)
-            {
-                _sb.AppendLine(string.Format(format, args));
-                _inner.WriteLine(format, args);
             }
         }
     }

--- a/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/IntegrationTestBase.cs
@@ -23,6 +23,8 @@ namespace JustSaying.IntegrationTests.Fluent
             OutputHelper = new CapturingTestOutputHelper(outputHelper);
         }
 
+        protected virtual LogLevel MinimumLogLevel { get; set; } = LogLevel.Debug;
+
         protected virtual string AccessKeyId { get; } = "accessKeyId";
 
         protected virtual string SecretAccessKey { get; } = "secretAccessKey";
@@ -56,7 +58,11 @@ namespace JustSaying.IntegrationTests.Fluent
             LogLevel? levelOverride = null)
         {
             return new ServiceCollection()
-                .AddLogging((p) => p.AddXUnit(OutputHelper, o => o.IncludeScopes = true).SetMinimumLevel(levelOverride ?? LogLevel.Debug))
+                .AddLogging((p) => p.AddXUnit(OutputHelper, o =>
+                {
+                    o.IncludeScopes = true;
+                    o.Filter = (_, level) => level >= MinimumLogLevel;
+                }).SetMinimumLevel(levelOverride ?? LogLevel.Debug))
                 .AddJustSaying(
                     (builder, serviceProvider) =>
                     {

--- a/tests/JustSaying.IntegrationTests/Fluent/TestHelpers/CapturingTestOutputHelper.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/TestHelpers/CapturingTestOutputHelper.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class CapturingTestOutputHelper : ITestOutputHelper
+    {
+        private readonly ITestOutputHelper _inner;
+        private readonly StringBuilder _sb;
+
+        public string Output => _sb.ToString();
+
+        public CapturingTestOutputHelper(ITestOutputHelper inner)
+        {
+            _inner = inner;
+            _sb = new StringBuilder();
+        }
+
+        public void WriteLine(string message)
+        {
+            _sb.AppendLine(message);
+            _inner.WriteLine(message);
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            _sb.AppendLine(string.Format(format, args));
+            _inner.WriteLine(format, args);
+        }
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
@@ -1,0 +1,62 @@
+[{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
+      Adding SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
+[{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
+      Created SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
+[{DateTime}] dbug: JustSaying.Publish[0]
+      Checking if queue '{TestDiscriminator}' exists
+[{DateTime}] dbug: JustSaying.Publish[0]
+      Checking if queue '{TestDiscriminator}_error' exists
+[{DateTime}] info: JustSaying.Publish[0]
+      Created queue '{TestDiscriminator}_error' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}_error'.
+[{DateTime}] info: JustSaying.Publish[0]
+      Creating error queue {TestDiscriminator}_error
+[{DateTime}] info: JustSaying.Publish[0]
+      Created queue '{TestDiscriminator}' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}'.
+[{DateTime}] info: JustSaying.Publish[0]
+      Creating queue {TestDiscriminator} attempt number 0
+[{DateTime}] info: JustSaying[0]
+      Running 1 startup tasks
+[{DateTime}] info: JustSaying[0]
+      Starting bus with settings: JustSaying.Messaging.Interrogation.InterrogationResult
+[{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroupCollection[0]
+      Subscription group collection successfully started
+[{DateTime}] info: JustSaying[0]
+      Starting bus
+[{DateTime}] info: JustSaying.Fluent.QueueSubscriptionBuilder[0]
+      Created SQS subscriber for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
+[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
+      Resolving handler for message type JustSaying.TestingFramework.SimpleMessage for queue {TestDiscriminator}.
+[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
+      Resolved handler of type InspectableHandler`1 for queue {TestDiscriminator}.
+[{DateTime}] info: JustSaying.Fluent.QueueSubscriptionBuilder[0]
+      Added a message handler for message type for 'JustSaying.TestingFramework.SimpleMessage' on topic 'simplemessage' and queue '{TestDiscriminator}'.
+[{DateTime}] dbug: JustSaying.Publish[0]
+      Checking if queue '{TestDiscriminator}' exists
+[{DateTime}] dbug: JustSaying.Publish[0]
+      Checking if queue '{TestDiscriminator}_error' exists
+[{DateTime}] info: JustSaying[0]
+      Running 1 startup tasks
+[{DateTime}] info: JustSaying[0]
+      Starting bus with settings: JustSaying.Messaging.Interrogation.InterrogationResult
+[{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroup[0]
+      Starting up SubscriptionGroup {TestDiscriminator} for queues [{TestDiscriminator}] with 1 receive buffers and 48 subscribers.
+[{DateTime}] dbug: JustSaying.Messaging.Channels.Multiplexer.MergingMultiplexer[0]
+      Starting up channel multiplexer with a queue capacity of 100
+[{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroupCollection[0]
+      Subscription group collection successfully started
+[{DateTime}] info: JustSaying[0]
+      Starting bus
+[{DateTime}] info: JustSaying.Publish[0]
+      => AwsRequestId: {AwsRequestId}
+      Published message {MessageId} of type SimpleMessage to Queue 'http://localhost:4566/000000000000/{TestDiscriminator}'.
+[{DateTime}] dbug: JustSaying[0]
+      Attempting to deserialize message with serialization register JustSaying.Messaging.MessageSerialization.MessageSerializationRegister
+[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
+      Resolving handler for message type JustSaying.TestingFramework.SimpleMessage for queue {TestDiscriminator}.
+[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
+      Resolved handler of type InspectableHandler`1 for queue {TestDiscriminator}.
+[{DateTime}] info: JustSaying[0]
+      => MessageSource: {TestDiscriminator}
+      => SourceType: Queue
+      Succeeded handling message with Id '{MessageId}' of type JustSaying.TestingFramework.SimpleMessage {Duration}
+Waiting for {Duration} - Still waiting for HandleMessageFromQueueLogs_ShouldHaveContext.

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
@@ -2,10 +2,6 @@
       Adding SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
 [{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
       Created SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
-[{DateTime}] dbug: JustSaying.Publish[0]
-      Checking if queue '{TestDiscriminator}' exists
-[{DateTime}] dbug: JustSaying.Publish[0]
-      Checking if queue '{TestDiscriminator}_error' exists
 [{DateTime}] info: JustSaying.Publish[0]
       Created queue '{TestDiscriminator}_error' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}_error'.
 [{DateTime}] info: JustSaying.Publish[0]
@@ -24,24 +20,14 @@
       Starting bus
 [{DateTime}] info: JustSaying.Fluent.QueueSubscriptionBuilder[0]
       Created SQS subscriber for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
-[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
-      Resolving handler for message type JustSaying.TestingFramework.SimpleMessage for queue {TestDiscriminator}.
-[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
-      Resolved handler of type InspectableHandler`1 for queue {TestDiscriminator}.
 [{DateTime}] info: JustSaying.Fluent.QueueSubscriptionBuilder[0]
       Added a message handler for message type for 'JustSaying.TestingFramework.SimpleMessage' on topic 'simplemessage' and queue '{TestDiscriminator}'.
-[{DateTime}] dbug: JustSaying.Publish[0]
-      Checking if queue '{TestDiscriminator}' exists
-[{DateTime}] dbug: JustSaying.Publish[0]
-      Checking if queue '{TestDiscriminator}_error' exists
 [{DateTime}] info: JustSaying[0]
       Running 1 startup tasks
 [{DateTime}] info: JustSaying[0]
       Starting bus with settings: JustSaying.Messaging.Interrogation.InterrogationResult
 [{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroup[0]
       Starting up SubscriptionGroup {TestDiscriminator} for queues [{TestDiscriminator}] with 1 receive buffers and 10 subscribers.
-[{DateTime}] dbug: JustSaying.Messaging.Channels.Multiplexer.MergingMultiplexer[0]
-      Starting up channel multiplexer with a queue capacity of 100
 [{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroupCollection[0]
       Subscription group collection successfully started
 [{DateTime}] info: JustSaying[0]
@@ -49,14 +35,7 @@
 [{DateTime}] info: JustSaying.Publish[0]
       => AwsRequestId: {AwsRequestId}
       Published message {MessageId} of type SimpleMessage to Queue 'http://localhost:4566/000000000000/{TestDiscriminator}'.
-[{DateTime}] dbug: JustSaying[0]
-      Attempting to deserialize message with serialization register JustSaying.Messaging.MessageSerialization.MessageSerializationRegister
-[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
-      Resolving handler for message type JustSaying.TestingFramework.SimpleMessage for queue {TestDiscriminator}.
-[{DateTime}] dbug: JustSaying.ServiceProviderResolver[0]
-      Resolved handler of type InspectableHandler`1 for queue {TestDiscriminator}.
 [{DateTime}] info: JustSaying[0]
       => MessageSource: {TestDiscriminator}
       => SourceType: Queue
       Succeeded handling message with Id '{MessageId}' of type JustSaying.TestingFramework.SimpleMessage {Duration}
-Waiting for {Duration} - Still waiting for HandleMessageFromQueueLogs_ShouldHaveContext.

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
@@ -39,7 +39,7 @@
 [{DateTime}] info: JustSaying[0]
       Starting bus with settings: JustSaying.Messaging.Interrogation.InterrogationResult
 [{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroup[0]
-      Starting up SubscriptionGroup {TestDiscriminator} for queues [{TestDiscriminator}] with 1 receive buffers and 48 subscribers.
+      Starting up SubscriptionGroup {TestDiscriminator} for queues [{TestDiscriminator}] with 1 receive buffers and 10 subscribers.
 [{DateTime}] dbug: JustSaying.Messaging.Channels.Multiplexer.MergingMultiplexer[0]
       Starting up channel multiplexer with a queue capacity of 100
 [{DateTime}] info: JustSaying.Messaging.Channels.SubscriptionGroups.SubscriptionGroupCollection[0]

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.HandleMessageFromQueueLogs_ShouldHaveContext.approved.txt
@@ -2,13 +2,13 @@
       Adding SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
 [{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
       Created SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
-[{DateTime}] info: JustSaying.Publish[0]
+[{DateTime}] info: JustSaying[0]
       Created queue '{TestDiscriminator}_error' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}_error'.
-[{DateTime}] info: JustSaying.Publish[0]
+[{DateTime}] info: JustSaying[0]
       Creating error queue {TestDiscriminator}_error
-[{DateTime}] info: JustSaying.Publish[0]
+[{DateTime}] info: JustSaying[0]
       Created queue '{TestDiscriminator}' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}'.
-[{DateTime}] info: JustSaying.Publish[0]
+[{DateTime}] info: JustSaying[0]
       Creating queue {TestDiscriminator} attempt number 0
 [{DateTime}] info: JustSaying[0]
       Running 1 startup tasks

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToQueueLogsShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToQueueLogsShouldHaveContext.approved.txt
@@ -2,10 +2,6 @@
       Adding SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
 [{DateTime}] info: JustSaying.Fluent.QueuePublicationBuilder[0]
       Created SQS publisher for message type 'JustSaying.TestingFramework.SimpleMessage' on queue '{TestDiscriminator}'.
-[{DateTime}] dbug: JustSaying[0]
-      Checking if queue '{TestDiscriminator}' exists
-[{DateTime}] dbug: JustSaying[0]
-      Checking if queue '{TestDiscriminator}_error' exists
 [{DateTime}] info: JustSaying[0]
       Created queue '{TestDiscriminator}_error' with ARN 'arn:aws:sqs:us-east-1:000000000000:{TestDiscriminator}_error'.
 [{DateTime}] info: JustSaying[0]

--- a/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToTopicLogsShouldHaveContext.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Logging/Approvals/LogContextTests.PublishToTopicLogsShouldHaveContext.approved.txt
@@ -2,8 +2,6 @@
       Adding SNS publisher for message type 'JustSaying.TestingFramework.SimpleMessage'.
 [{DateTime}] info: JustSaying.Fluent.TopicPublicationBuilder[0]
       Created SNS topic publisher on topic 'simplemessage' for message type 'JustSaying.TestingFramework.SimpleMessage'.
-[{DateTime}] dbug: JustSaying[0]
-      Created topic 'simplemessage' with ARN 'arn:aws:sns:us-east-1:000000000000:simplemessage'.
 [{DateTime}] info: JustSaying[0]
       Running 1 startup tasks
 [{DateTime}] info: JustSaying[0]

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -17,14 +17,13 @@ namespace JustSaying.Logging
     {
         public LogContextTests(ITestOutputHelper outputHelper) : base(outputHelper)
         {
-            MinimumLogLevel = LogLevel.Information;
         }
 
 
         [AwsFact]
         public async Task PublishToTopicLogsShouldHaveContext()
         {
-            var services = GivenJustSaying()
+            var services = GivenJustSaying(levelOverride: LogLevel.Information)
                 .ConfigureJustSaying(
                     (builder) => builder.WithLoopbackTopic<SimpleMessage>(UniqueName));
 
@@ -49,7 +48,7 @@ namespace JustSaying.Logging
         [AwsFact]
         public async Task PublishToQueueLogsShouldHaveContext()
         {
-            var services = GivenJustSaying()
+            var services = GivenJustSaying(levelOverride: LogLevel.Information)
                 .ConfigureJustSaying(
                     (builder) => builder.WithLoopbackQueue<SimpleMessage>(UniqueName));
 
@@ -76,7 +75,7 @@ namespace JustSaying.Logging
         {
             var handler = new InspectableHandler<SimpleMessage>();
 
-            var services = GivenJustSaying()
+            var services = GivenJustSaying(levelOverride: LogLevel.Information)
                 .ConfigureJustSaying(
                     (builder) => builder.WithLoopbackQueue<SimpleMessage>(UniqueName)
                         .Subscriptions(sub => sub.WithDefaults(sgb =>

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -73,7 +73,9 @@ namespace JustSaying.Logging
 
             var services = GivenJustSaying()
                 .ConfigureJustSaying(
-                    (builder) => builder.WithLoopbackQueue<SimpleMessage>(UniqueName))
+                    (builder) => builder.WithLoopbackQueue<SimpleMessage>(UniqueName)
+                        .Subscriptions(sub => sub.WithDefaults(sgb =>
+                            sgb.WithDefaultConcurrencyLimit(10))))
                 .AddSingleton<IHandlerAsync<SimpleMessage>>(handler);
 
             var sp = services.BuildServiceProvider();

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.IntegrationTests.Fluent;
 using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
@@ -65,6 +66,43 @@ namespace JustSaying.Logging
             cts.Cancel();
         }
 
+        [AwsFact]
+        public async Task HandleMessageFromQueueLogs_ShouldHaveContext()
+        {
+            var handler = new InspectableHandler<SimpleMessage>();
+
+            var services = GivenJustSaying()
+                .ConfigureJustSaying(
+                    (builder) => builder.WithLoopbackQueue<SimpleMessage>(UniqueName))
+                .AddSingleton<IHandlerAsync<SimpleMessage>>(handler);
+
+            var sp = services.BuildServiceProvider();
+
+            var cts = new CancellationTokenSource();
+
+            var publisher = sp.GetRequiredService<IMessagePublisher>();
+            await publisher.StartAsync(cts.Token);
+            await sp.GetRequiredService<IMessagingBus>().StartAsync(cts.Token);
+
+            var message = new SimpleMessage();
+            await publisher .PublishAsync(message, cts.Token);
+
+            await Patiently.AssertThatAsync(OutputHelper,
+                () =>
+                {
+                    handler.ReceivedMessages
+                        .ShouldHaveSingleItem()
+                        .Id.ShouldBe(message.Id);
+                });
+
+            var output = ((TestOutputHelper) OutputHelper).Output;
+            output.ShouldMatchApproved(o => o
+                .SubFolder("Approvals")
+                .WithScrubber(logMessage => ScrubLogs(logMessage, message.Id.ToString())));
+
+            cts.Cancel();
+        }
+
         private string ScrubLogs(string message, string messageId)
         {
             message = message.Replace(messageId, "{MessageId}");
@@ -72,6 +110,8 @@ namespace JustSaying.Logging
 
             message = Regex.Replace(message, @"AwsRequestId: .{8}-.{4}-.{4}-.{4}-.{12}", "AwsRequestId: {AwsRequestId}");
             message = Regex.Replace(message, @"(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})Z", "{DateTime}");
+            message = Regex.Replace(message, @"(\d+).(\d+) ms", "{Duration}");
+            message = Regex.Replace(message, @"in (\d+)ms.", "{Duration}");
             return message;
         }
     }

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using JustSaying.Messaging;
 using JustSaying.Messaging.MessageHandling;
 using JustSaying.TestingFramework;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Shouldly;
 using Xunit.Abstractions;
 

--- a/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
+++ b/tests/JustSaying.IntegrationTests/Logging/LogContextTests.cs
@@ -96,7 +96,7 @@ namespace JustSaying.Logging
                     .ShouldHaveSingleItem()
                     .Id.ShouldBe(message.Id));
 
-            var output = ((TestOutputHelper) OutputHelper).Output;
+            var output = OutputHelper.Output;
             output.ShouldMatchApproved(o => o
                 .SubFolder("Approvals")
                 .WithScrubber(logMessage => ScrubLogs(logMessage, message.Id.ToString())));

--- a/tests/JustSaying.TestingFramework/Patiently.cs
+++ b/tests/JustSaying.TestingFramework/Patiently.cs
@@ -10,6 +10,12 @@ namespace JustSaying.TestingFramework
     public static class Patiently
     {
         public static async Task AssertThatAsync(
+            Action func,
+            [System.Runtime.CompilerServices.CallerMemberName]
+            string memberName = "") =>
+            await AssertThatAsync(null, func, memberName);
+
+        public static async Task AssertThatAsync(
             ITestOutputHelper output,
             Action func,
             [System.Runtime.CompilerServices.CallerMemberName]
@@ -63,7 +69,7 @@ namespace JustSaying.TestingFramework
 
                 await Task.Delay(50.Milliseconds()).ConfigureAwait(false);
 
-                output.WriteLine(
+                output?.WriteLine(
                     $"Waiting for {watch.Elapsed.TotalMilliseconds} ms - Still Checking.");
             } while (watch.Elapsed < timeout);
 
@@ -95,7 +101,7 @@ namespace JustSaying.TestingFramework
 
                 await Task.Delay(50.Milliseconds()).ConfigureAwait(false);
 
-                output.WriteLine(
+                output?.WriteLine(
                     $"Waiting for {watch.Elapsed.TotalMilliseconds} ms - Still waiting for {description}.");
             } while (watch.Elapsed < timeout);
 


### PR DESCRIPTION
This PR completes #867 by adding log context to match the publish logs.

The list of properties for this log are:
Status: Succeeded or Failed
`MessageId`: MessageId guid
`MessageType`: Type of the message
`TimeToHandle`: ms taken to handle the message
`SourceType`: Always "Queue", here to be consistent with publish logs (we don't currently support subscribe from topic)
`MessageSource`: The name of the queue the message came from

To compare with publish logs:

`MessageId`
`MessageType`
`DestinationType`: Queue or Topic
`PublishDestination`: the topic or queue arn
`AwsRequestId`