### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,6 +106,8 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+Note that the `AddJustSaying` extension method requires installing the [JustSaying.Extensions.DependencyInjection](https://www.nuget.org/packages/JustSaying.Extensions.DependencyInjection.Microsoft/7.0.0-beta.1) package, which is currently in pre-release.
+
 ### Startup
 
 Now that we've created an event and handler, and wired it into the DI container, let's start the bus. How this is done is up to you, but here's an example using the built in `IHostedService` that comes with .NET Core. 


### PR DESCRIPTION
Specify that the extension method is defined in a separate package to the main JustSaying nuget package, which might not be obvious at first glance.

I thought it was also a good idea to include that the package is in pre-release, since prerelease packages aren't shown in the nuget package manager window by default.
