### PR TITLE
Try localstack 0.12.18

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -153,8 +153,8 @@ ForEach ($libraryProject in $libraryProjects) {
 }
 
 if (($null -ne $env:CI) -And ($EnableIntegrationTests -eq $true)) {
-    & docker pull localstack/localstack:0.12.15
-    & docker run -d --name localstack -p 4566:4566 localstack/localstack:0.12.15
+    & docker pull localstack/localstack:0.12.18
+    & docker run -d --name localstack -p 4566:4566 localstack/localstack:0.12.18
     $env:AWS_SERVICE_URL = "http://localhost:4566"
 }
 

--- a/tests/JustSaying.IntegrationTests/docker-compose.yml
+++ b/tests/JustSaying.IntegrationTests/docker-compose.yml
@@ -3,6 +3,6 @@ services:
   localstack:
     container_name: localstack
     restart: unless-stopped
-    image: localstack/localstack:0.12.15
+    image: localstack/localstack:0.12.18
     ports:
       - 4566:4566


### PR DESCRIPTION
We've pinned localstack to 0.12.15 as there were issues in subsequent releases causing our functional tests to fail.
Trying 0.12.18 as there are fixes to SQS which may be related to what we were seeing.