### PR TITLE
Register Middlewares as Transient to avoid clobber

### DIFF
--- a/src/JustSaying.Extensions.DependencyInjection.Microsoft/IServiceCollectionExtensions.cs
+++ b/src/JustSaying.Extensions.DependencyInjection.Microsoft/IServiceCollectionExtensions.cs
@@ -116,7 +116,7 @@ public static class IServiceCollectionExtensions
         {
             throw new ArgumentNullException(nameof(configure));
         }
-
+        
         // Register as self so the same singleton instance implements two different interfaces
         services.TryAddSingleton((p) => new ServiceProviderResolver(p));
         services.TryAddSingleton<IHandlerResolver>((p) => p.GetRequiredService<ServiceProviderResolver>());
@@ -127,8 +127,8 @@ public static class IServiceCollectionExtensions
         services.TryAddSingleton<IMessagingConfig, MessagingConfig>();
         services.TryAddSingleton<IMessageMonitor, NullOpMessageMonitor>();
 
-        services.TryAddSingleton<LoggingMiddleware>();
-        services.TryAddSingleton<SqsPostProcessorMiddleware>();
+        services.TryAddTransient<LoggingMiddleware>();
+        services.TryAddTransient<SqsPostProcessorMiddleware>();
 
         services.AddSingleton<MessageContextAccessor>();
         services.TryAddSingleton<IMessageContextAccessor>(serviceProvider => serviceProvider.GetRequiredService<MessageContextAccessor>());

--- a/src/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
+++ b/src/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
@@ -38,8 +38,8 @@ internal sealed class JustSayingRegistry : Registry
         For<IMessageContextAccessor>().Use(context => context.GetInstance<MessageContextAccessor>());
         For<IMessageContextReader>().Use(context => context.GetInstance<MessageContextAccessor>());
 
-        For<LoggingMiddleware>().Singleton();
-        For<SqsPostProcessorMiddleware>().Singleton();
+        For<LoggingMiddleware>().Transient();
+        For<SqsPostProcessorMiddleware>().Transient();
 
         For<IMessageSerializationRegister>()
             .Use(

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -42,7 +42,13 @@ public sealed class HandlerMiddlewareBuilder
     public HandlerMiddlewareBuilder Use<TMiddleware>() where TMiddleware : MiddlewareBase<HandleMessageContext, bool>
     {
         var newMiddleware = ServiceResolver.ResolveService<TMiddleware>();
-        if (newMiddleware.HasNext) throw new InvalidOperationException("Middlewares must be registered as Transient.");
+        if (newMiddleware.HasNext)
+        {
+            throw new InvalidOperationException(
+                @"Middlewares must be registered into your DI container such that each resolution creates a new instance.
+For StructureMap use Transient(), and for Microsoft.Extensions.DependencyInjection, use AddTransient().
+Please check the documentation for your container for more details.");
+        }
 
         _middlewares.Add(() => newMiddleware);
         return this;

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -38,10 +38,11 @@ public sealed class HandlerMiddlewareBuilder
     /// </summary>
     /// <typeparam name="TMiddleware">The type of the middleware to add.</typeparam>
     /// <returns>The current HandlerMiddlewareBuilder.</returns>
+    /// <exception cref="InvalidOperationException">When the middleware is not registered as Transient, an exception will be thrown if the resolved middleware is already part of a pipeline.</exception>
     public HandlerMiddlewareBuilder Use<TMiddleware>() where TMiddleware : MiddlewareBase<HandleMessageContext, bool>
     {
         var newMiddleware = ServiceResolver.ResolveService<TMiddleware>();
-        if (newMiddleware.HasNext) throw new InvalidOperationException("Middlewares must be registered as Transient");
+        if (newMiddleware.HasNext) throw new InvalidOperationException("Middlewares must be registered as Transient.");
 
         _middlewares.Add(() => newMiddleware);
         return this;

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -43,7 +43,7 @@ public sealed class HandlerMiddlewareBuilder
         var newMiddleware = ServiceResolver.ResolveService<TMiddleware>();
         if (newMiddleware.HasNext) throw new InvalidOperationException("Middlewares must be registered as Transient");
 
-        _middlewares.Add(() => ServiceResolver.ResolveService<TMiddleware>());
+        _middlewares.Add(() => newMiddleware);
         return this;
     }
 

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilder.cs
@@ -40,6 +40,9 @@ public sealed class HandlerMiddlewareBuilder
     /// <returns>The current HandlerMiddlewareBuilder.</returns>
     public HandlerMiddlewareBuilder Use<TMiddleware>() where TMiddleware : MiddlewareBase<HandleMessageContext, bool>
     {
+        var newMiddleware = ServiceResolver.ResolveService<TMiddleware>();
+        if (newMiddleware.HasNext) throw new InvalidOperationException("Middlewares must be registered as Transient");
+
         _middlewares.Add(() => ServiceResolver.ResolveService<TMiddleware>());
         return this;
     }

--- a/src/JustSaying/Messaging/Middleware/MiddlewareBase`2.cs
+++ b/src/JustSaying/Messaging/Middleware/MiddlewareBase`2.cs
@@ -10,6 +10,8 @@ public abstract class MiddlewareBase<TContext, TOut>
         return this;
     }
 
+    public bool HasNext => _next != null;
+
     public async Task<TOut> RunAsync(
         TContext context,
         Func<CancellationToken, Task<TOut>> func,

--- a/src/JustSaying/Messaging/Middleware/MiddlewareBase`2.cs
+++ b/src/JustSaying/Messaging/Middleware/MiddlewareBase`2.cs
@@ -10,7 +10,7 @@ public abstract class MiddlewareBase<TContext, TOut>
         return this;
     }
 
-    public bool HasNext => _next != null;
+    internal bool HasNext => _next != null;
 
     public async Task<TOut> RunAsync(
         TContext context,

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenSubscribingToMultipleTopics.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenSubscribingToMultipleTopics.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace JustSaying.IntegrationTests.Fluent.Subscribing
+{
+    public class WhenSubscribingToMultipleTopics : IntegrationTestBase
+    {
+        public WhenSubscribingToMultipleTopics(ITestOutputHelper outputHelper) : base(outputHelper)
+        { }
+
+        [AwsFact]
+        public async Task Then_Both_Handlers_Receive_Messages()
+        {
+            // Arrange
+            var genericHandler = new InspectableHandler<GenericMessage<SimpleMessage>>();
+            var nonGenericHandler = new InspectableHandler<SimpleMessage>();
+
+            var services = GivenJustSaying()
+                .ConfigureJustSaying((builder) => builder.WithLoopbackTopic<GenericMessage<SimpleMessage>>($"{UniqueName}-generic"))
+                .ConfigureJustSaying((builder) => builder.WithLoopbackTopic<SimpleMessage>($"{UniqueName}-nongeneric"))
+                .AddSingleton<IHandlerAsync<GenericMessage<SimpleMessage>>>(genericHandler)
+                .AddSingleton<IHandlerAsync<SimpleMessage>>(nonGenericHandler);
+
+            await WhenAsync(
+                services,
+                async (publisher, listener, serviceProvider, cancellationToken) =>
+                {
+                    await listener.StartAsync(cancellationToken);
+                    await publisher.StartAsync(cancellationToken);
+
+                    // Act
+                    await publisher.PublishAsync(new GenericMessage<SimpleMessage>(), cancellationToken);
+                    await publisher.PublishAsync(new SimpleMessage(), cancellationToken);
+
+                    await Patiently.AssertThatAsync(OutputHelper,
+                        () =>
+                        {
+                            genericHandler.ReceivedMessages.ShouldHaveSingleItem();
+                            nonGenericHandler.ReceivedMessages.ShouldHaveSingleItem();
+                        });
+                });
+        }
+    }
+}


### PR DESCRIPTION
I noticed this issue due to a failing test in JustSayingStack.

Most of our tests only establish a single subscription, which works fine. If there are multiple subscriptions however, then the second will resolve the same instance of `LoggingMiddleware` or `SqsPostProcessorMiddleware` (the only middlewares that are resolved from DI). As those instances were already used to build the previous pipeline, they are already part of an existing pipeline, and therefore have `_next` values that link them to the next step. When the second builder comes along and resolves the same middleware, it redirects the `_next` to the second subscription. The end result is that the same handler is invoked for all subscriptions. Bad!

This PR does the following to fix this:
- Adds a test to ensure this doesn't happen 
- Changes the middleware registrations to be transient
- Emits an InvalidOperationException when constructing middlewares if the `_next` property has already been populated, which indicates that the middleware has been incorrectly registered and the single instance is already part of an existing pipeline. If there's only one subscription this won't throw, so it still works for apps that only have a single sub and single instance middlewares.

 