### PR TITLE
Include publisher ARN's when interrogating the publisher

### DIFF
--- a/src/JustSaying/AwsTools/MessageHandling/SnsMessagePublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsMessagePublisher.cs
@@ -145,6 +145,9 @@ public class SnsMessagePublisher : IMessagePublisher, IInterrogable
 
     public virtual InterrogationResult Interrogate()
     {
-        return new InterrogationResult(InterrogationResult.Empty);
+        return new InterrogationResult(new
+        {
+            Arn
+        });
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/SqsMessagePublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsMessagePublisher.cs
@@ -98,8 +98,9 @@ public class SqsMessagePublisher : IMessagePublisher
 
         if (metadata?.Delay != null)
         {
-            request.DelaySeconds = (int)metadata.Delay.Value.TotalSeconds;
+            request.DelaySeconds = (int) metadata.Delay.Value.TotalSeconds;
         }
+
         return request;
     }
 
@@ -107,6 +108,9 @@ public class SqsMessagePublisher : IMessagePublisher
 
     public InterrogationResult Interrogate()
     {
-        return InterrogationResult.Empty;
+        return new InterrogationResult(new
+        {
+            QueueUrl
+        });
     }
 }

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -274,8 +274,7 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IDisposabl
     public InterrogationResult Interrogate()
     {
         var publisherDescriptions =
-            _publishersByType.Select(publisher =>
-                publisher.Key.Name).ToArray();
+            _publishersByType.ToDictionary(x => x.Key.Name, x => x.Value.Interrogate());
 
         return new InterrogationResult(new
         {

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/Approvals/WhenInterrogatingTheBus.Then_The_Interrogation_Result_Should_Be_Returned.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/Approvals/WhenInterrogatingTheBus.Then_The_Interrogation_Result_Should_Be_Returned.approved.txt
@@ -16,7 +16,7 @@
       }
     ]
   },
-  "PublishedMessageTypes": [],
+  "PublishedMessageTypes": {},
   "SubscriptionGroups": {
     "Groups": [
       {
@@ -44,8 +44,12 @@
   "Middleware": {
     "Middlewares": []
   },
-  "PublishedMessageTypes": [
-    "SimpleMessage"
-  ],
-  "SubscriptionGroups": null
+  "PublishedMessageTypes": {
+    "SimpleMessage": {
+      "Arn": "arn:aws:sns:us-east-1:000000000000:simplemessage"
+    }
+  },
+  "SubscriptionGroups": {
+    "Groups": []
+  }
 }

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenInterrogatingTheBus.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenInterrogatingTheBus.cs
@@ -31,6 +31,7 @@ public class WhenInterrogatingTheBus : IntegrationTestBase
             async (publisher, listener, cancellationToken) =>
             {
                 await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
 
                 var listenerJson = JsonConvert.SerializeObject(listener.Interrogate(), Formatting.Indented);
                 var publisherJson = JsonConvert.SerializeObject(publisher.Interrogate(), Formatting.Indented);

--- a/tests/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
+++ b/tests/JustSaying.UnitTests/JustSayingBus/WhenRegisteringPublishers.cs
@@ -1,4 +1,5 @@
 using JustSaying.Messaging;
+using JustSaying.Messaging.Interrogation;
 using JustSaying.Models;
 using JustSaying.TestingFramework;
 using NSubstitute;
@@ -51,10 +52,10 @@ public class WhenRegisteringPublishers : GivenAServiceBus
     {
         dynamic response = SystemUnderTest.Interrogate();
 
-        string[] publishedTypes = response.Data.PublishedMessageTypes;
+        Dictionary<string, InterrogationResult> publishedTypes = response.Data.PublishedMessageTypes;
 
-        publishedTypes.ShouldContain(nameof(OrderAccepted));
-        publishedTypes.ShouldContain(nameof(OrderRejected));
+        publishedTypes.ShouldContainKey(nameof(OrderAccepted));
+        publishedTypes.ShouldContainKey(nameof(OrderRejected));
     }
 
     public WhenRegisteringPublishers(ITestOutputHelper outputHelper) : base(outputHelper)

--- a/tests/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
+++ b/tests/JustSaying.UnitTests/JustSayingBus/WhenRegisteringTheSamePublisherTwice.cs
@@ -1,4 +1,5 @@
 using JustSaying.Messaging;
+using JustSaying.Messaging.Interrogation;
 using JustSaying.Models;
 using NSubstitute;
 
@@ -35,9 +36,9 @@ public class WhenRegisteringTheSamePublisherTwice : GivenAServiceBus
     {
         dynamic response = SystemUnderTest.Interrogate();
 
-        string[] publishedTypes = response.Data.PublishedMessageTypes;
+        Dictionary<string, InterrogationResult> publishedTypes = response.Data.PublishedMessageTypes;
 
-        publishedTypes.ShouldContain(nameof(Message));
+        publishedTypes.ShouldContainKey(nameof(Message));
     }
 
     public WhenRegisteringTheSamePublisherTwice(ITestOutputHelper outputHelper) : base(outputHelper)


### PR DESCRIPTION
We encountered a situation in which we wanted to know what topic name is generated from a naming convention, and found that interrogation doesn't emit ARN's or generated topic names. This PR adds them so you can now see what message type is published to an ARN.