### PR TITLE
Add support for overriding topic names

### DIFF
--- a/src/JustSaying/Fluent/SubscriptionsBuilder.cs
+++ b/src/JustSaying/Fluent/SubscriptionsBuilder.cs
@@ -2,6 +2,7 @@ using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging.Channels.SubscriptionGroups;
 using JustSaying.Models;
+using JustSaying.Naming;
 using Microsoft.Extensions.Logging;
 
 namespace JustSaying.Fluent;
@@ -195,6 +196,35 @@ public sealed class SubscriptionsBuilder
 
         return this;
     }
+
+    /// <summary>
+    /// Configures a topic subscription.
+    /// </summary>
+    /// <typeparam name="T">The type of the message to subscribe to.</typeparam>
+    /// <param name="topicNameOverride">The name of the topic that will be subscribed to this queue. Overrides the default set by the <see cref="ITopicNamingConvention"/></param>
+    /// <param name="configure">A delegate to a method to use to configure a topic subscription.</param>
+    /// <returns>
+    /// The current <see cref="SubscriptionsBuilder"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="configure"/> is <see langword="null"/>.
+    /// </exception>
+    public SubscriptionsBuilder ForTopic<T>(string topicNameOverride, Action<TopicSubscriptionBuilder<T>> configure)
+        where T : Message
+    {
+        if (configure == null) throw new ArgumentNullException(nameof(configure));
+        if (topicNameOverride == null) throw new ArgumentNullException(nameof(topicNameOverride));
+
+        var builder = new TopicSubscriptionBuilder<T>().WithTopicName(topicNameOverride);
+
+        configure(builder);
+
+        Subscriptions.Add(builder);
+
+        return this;
+    }
+
+
 
     /// <summary>
     /// Configures the subscriptions for the <see cref="JustSayingBus"/>.

--- a/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicPublicationBuilder`1.cs
@@ -33,6 +33,11 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T>
     private Dictionary<string, string> Tags { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Gets or sets the topic name.
+    /// </summary>
+    private string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
     /// Configures the SNS write configuration.
     /// </summary>
     /// <param name="configure">A delegate to a method to use to configure SNS writes.</param>
@@ -111,6 +116,23 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T>
         return this;
     }
 
+
+    /// <summary>
+    /// Configures the name of the topic
+    /// </summary>
+    /// <param name="name">The name of the topic to publish to.</param>
+    /// <returns>
+    /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="name"/> is <see langword="null"/>.
+    /// </exception>
+    public TopicPublicationBuilder<T> WithName(string name)
+    {
+        TopicName = name;
+        return this;
+    }
+
     /// <inheritdoc />
     void IPublicationBuilder<T>.Configure(
         JustSayingBus bus,
@@ -125,7 +147,10 @@ public sealed class TopicPublicationBuilder<T> : IPublicationBuilder<T>
         var config = bus.Config;
         var region = config.Region ?? throw new InvalidOperationException($"Config cannot have a blank entry for the {nameof(config.Region)} property.");
 
-        var readConfiguration = new SqsReadConfiguration(SubscriptionType.ToTopic);
+        var readConfiguration = new SqsReadConfiguration(SubscriptionType.ToTopic)
+        {
+            TopicName = TopicName
+        };
         var writeConfiguration = new SnsWriteConfiguration();
         ConfigureWrites?.Invoke(writeConfiguration);
         readConfiguration.ApplyTopicNamingConvention<T>(config.TopicNamingConvention);

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -1,3 +1,4 @@
+using Amazon.SimpleNotificationService.Model;
 using JustSaying.AwsTools;
 using JustSaying.AwsTools.QueueCreation;
 using JustSaying.Messaging.Middleware;
@@ -27,6 +28,8 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
     /// </summary>
     private string TopicName { get; set; } = string.Empty;
 
+    private string QueueName { get; set; } = string.Empty;
+
     /// <summary>
     /// Gets or sets a delegate to a method to use to configure SNS reads.
     /// </summary>
@@ -50,9 +53,9 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
         => WithName(string.Empty);
 
     /// <summary>
-    /// Configures the name of the topic.
+    /// Configures the name of the queue that will be subscribed to.
     /// </summary>
-    /// <param name="name">The name of the topic to subscribe to.</param>
+    /// <param name="name">The name of the queue to subscribe to.</param>
     /// <returns>
     /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
     /// </returns>
@@ -60,6 +63,22 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
     /// <paramref name="name"/> is <see langword="null"/>.
     /// </exception>
     public TopicSubscriptionBuilder<T> WithName(string name)
+    {
+        QueueName = name ?? throw new ArgumentNullException(nameof(name));
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the name of the topic that will be subscribed to this queue.
+    /// </summary>
+    /// <param name="name">The name of the topic subscribe to.</param>
+    /// <returns>
+    /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="name"/> is <see langword="null"/>.
+    /// </exception>
+    public TopicSubscriptionBuilder<T> WithTopicName(string name)
     {
         TopicName = name ?? throw new ArgumentNullException(nameof(name));
         return this;
@@ -164,7 +183,8 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
 
         var subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic)
         {
-            QueueName = TopicName,
+            QueueName = QueueName,
+            TopicName = TopicName,
             Tags = Tags
         };
 

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/Approvals/WhenAMessageIsPublishedToATopicWithACustomName.Then_The_Message_Is_Handled.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/Approvals/WhenAMessageIsPublishedToATopicWithACustomName.Then_The_Message_Is_Handled.approved.txt
@@ -1,0 +1,55 @@
+{
+  "Region": "eu-west-1",
+  "Middleware": {
+    "Middlewares": [
+      {
+        "MessageType": "SimpleMessage",
+        "QueueName": "integrationTestQueueName",
+        "MiddlewareChain": [
+          "MessageContextAccessorMiddleware",
+          "ErrorHandlerMiddleware",
+          "LoggingMiddleware",
+          "StopwatchMiddleware",
+          "SqsPostProcessorMiddleware",
+          "HandlerInvocationMiddleware`1[JustSaying.TestingFramework.SimpleMessage]"
+        ]
+      }
+    ]
+  },
+  "PublishedMessageTypes": {},
+  "SubscriptionGroups": {
+    "Groups": [
+      {
+        "Name": "integrationTestQueueName",
+        "ConcurrencyLimit": 10,
+        "Multiplexer": {
+          "ChannelCapacity": 100,
+          "ReaderCount": 1
+        },
+        "ReceiveBuffers": [
+          {
+            "BufferSize": 10,
+            "QueueName": "integrationTestQueueName",
+            "Region": "eu-west-1",
+            "Prefetch": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+
+{
+  "Region": "eu-west-1",
+  "Middleware": {
+    "Middlewares": []
+  },
+  "PublishedMessageTypes": {
+    "SimpleMessage": {
+      "Arn": "arn:aws:sns:us-east-1:000000000000:my-special-topic"
+    }
+  },
+  "SubscriptionGroups": {
+    "Groups": []
+  }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToATopicWithACustomName.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToATopicWithACustomName.cs
@@ -1,0 +1,60 @@
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using NSubstitute;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing;
+
+public class WhenAMessageIsPublishedToATopicWithACustomName : IntegrationTestBase
+{
+    public WhenAMessageIsPublishedToATopicWithACustomName(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    { }
+
+    [AwsFact]
+    public async Task Then_The_Message_Is_Handled()
+    {
+        // Arrange
+        var handler = new InspectableHandler<SimpleMessage>();
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) =>
+                builder.Publications((options) => options.WithTopic<SimpleMessage>(configure => { configure.WithName("my-special-topic"); }))
+                    .Subscriptions((options) => options.ForTopic<SimpleMessage>("my-special-topic", subscriptionBuilder => { subscriptionBuilder.WithName(UniqueName); })))
+            .AddSingleton<IHandlerAsync<SimpleMessage>>(handler);
+
+        string content = Guid.NewGuid().ToString();
+
+        var message = new SimpleMessage()
+        {
+            Content = content
+        };
+
+        string json = "";
+
+        await WhenAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                var listenerJson = JsonConvert.SerializeObject(listener.Interrogate(), Formatting.Indented);
+                var publisherJson = JsonConvert.SerializeObject(publisher.Interrogate(), Formatting.Indented);
+
+                await publisher.PublishAsync(message, cancellationToken);
+
+                json = string.Join($"{Environment.NewLine}{Environment.NewLine}",
+                        listenerJson,
+                        publisherJson)
+                    .Replace(UniqueName, "integrationTestQueueName", StringComparison.Ordinal);
+
+                await Patiently.AssertThatAsync(OutputHelper,
+                    () =>
+                        handler.ReceivedMessages.Any(x => x.Content == content).ShouldBeTrue());
+            });
+
+        json.ShouldMatchApproved(opt => opt.SubFolder("Approvals"));
+    }
+}


### PR DESCRIPTION
This PR should resolve #979 by making it possible to specify a name override when registering publishers, as well as topic name overrides when registering subscriptions. 

It enables the following scenario:
```csharp
builder
    .Publications((options) => 
        options.WithTopic<SimpleMessage>(configure => { configure.WithName("my-special-topic"); }))
    .Subscriptions((options) => 
        options.ForTopic<SimpleMessage>("my-special-topic", 
            subscriptionBuilder => { subscriptionBuilder.WithName(UniqueName); })))
```

This does a few things:
1. Changes the name of the configured publisher topic so that the interrogation now returns:
```json
  "PublishedMessageTypes": {
    "SimpleMessage": {
      "Arn": "arn:aws:sns:us-east-1:000000000000:my-special-topic"
    }
  },
```
2. Changes the generated subscription of the topic => queue so that the queue is subscribed to the correct topic:
```
[2022-02-24 15:09:32Z] info: JustSaying.Fluent.TopicSubscriptionBuilder[0]
      Created SQS topic subscription on topic 'my-special-topic' and queue 'e3900412f15d405ebc37af5ac84b8bfe-integration-tests'.
``` 

With this API, it's possible to configure publishers and subscribers independently, so if you're only doing one or the other, both can now be customised.