### PR TITLE
Use localstack 0.14.2

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -153,8 +153,8 @@ ForEach ($libraryProject in $libraryProjects) {
 }
 
 if (($null -ne $env:CI) -And ($EnableIntegrationTests -eq $true)) {
-    & docker pull --quiet localstack/localstack:0.14
-    & docker run -d --name localstack -p 4566:4566 localstack/localstack:0.14
+    & docker pull --quiet localstack/localstack:0.14.2
+    & docker run -d --name localstack -p 4566:4566 localstack/localstack:0.14.2
     $env:AWS_SERVICE_URL = "http://localhost:4566"
 }
 


### PR DESCRIPTION
Reverts 3ba7164f2dbc33a45c63ff7249f9fdec8a83aa25 because they released [0.14.3](https://github.com/localstack/localstack/releases/tag/v0.14.3) last week and now the build is broken again.
