### PR TITLE
Fix package publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           path: ./artifacts/packages
 
       - name: Publish pre-release NuGet packages to GitHub Packages
-        run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols true --source https://nuget.pkg.github.com/justeat/index.json
+        run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source https://nuget.pkg.github.com/justeat/index.json
         if: ${{ github.repository_owner == 'justeat' && github.ref == 'refs/heads/main' && runner.os == 'Windows' }}
 
       - name: Push NuGet packages to NuGet.org


### PR DESCRIPTION
Remove unused `true` value to work around [this issue](https://docs.microsoft.com/en-us/nuget/release-notes/nuget-6.1#dotnet-nuget-push--n--no-symbols-or--d--disable-buffering-raises-error-file-does-not-exist--exception---11601).
