### PR TITLE
Enable package validation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,6 +48,7 @@
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>aws,sns,sqs</PackageTags>
+    <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">false</PublicSign>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.302",
+    "version": "6.0.401",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
* Enable [package validation](https://devblogs.microsoft.com/dotnet/package-validation/) against the baseline of version [`7.0.0`](https://github.com/justeat/JustSaying/releases/tag/v7.0.0).
* Update to the latest .NET 6 SDK.
