### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    timezone: Europe/London
 - package-ecosystem: nuget
   directory: "/"
   schedule:


### PR DESCRIPTION
Configure dependabot to also update the versions of GitHub Actions we use.
