### PR TITLE
Make fields read-only when only set in constructor

### DIFF
--- a/samples/src/JustSaying.Sample.Restaurant.OrderingApi/BusService.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.OrderingApi/BusService.cs
@@ -10,7 +10,7 @@ public class BusService : BackgroundService
 {
     private readonly IMessagingBus _bus;
     private readonly ILogger<BusService> _logger;
-    private IMessagePublisher _publisher;
+    private readonly IMessagePublisher _publisher;
 
     public BusService(IMessagingBus bus, ILogger<BusService> logger, IMessagePublisher publisher)
     {

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -29,7 +29,7 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IDisposabl
 
     public IMessagingConfig Config { get; }
 
-    private IMessageMonitor _monitor;
+    private readonly IMessageMonitor _monitor;
 
     private ISubscriptionGroup SubscriptionGroups { get; set; }
     public IMessageSerializationRegister SerializationRegister { get; }


### PR DESCRIPTION
These fields are only set in the constructor and shouldnt be reinitialised so are good candiates to make readonly