### PR TITLE
Feature/improve arn parsing and IAM Policy testability

### DIFF
--- a/src/JustSaying/AwsTools/MessageHandling/SnsPolicy.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsPolicy.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 
@@ -9,52 +7,8 @@ internal static class SnsPolicy
 {
     internal static async Task SaveAsync(SnsPolicyDetails policyDetails, IAmazonSimpleNotificationService client)
     {
-        var sourceAccountId = ExtractSourceAccountId(policyDetails.SourceArn);
-        var policyJson = $@"{{
-    ""Version"" : ""2012-10-17"",
-    ""Statement"" : [
-        {{
-            ""Sid"" : ""{Guid.NewGuid().ToString().Replace("-", "")}"",
-            ""Effect"" : ""Allow"",
-            ""Principal"" : {{
-                ""AWS"" : ""*""
-            }},
-            ""Action""    : [
-                ""sns:GetTopicAttributes"",
-                ""sns:SetTopicAttributes"",
-                ""sns:AddPermission"",
-                ""sns:RemovePermission"",
-                ""sns:DeleteTopic"",
-                ""sns:Subscribe"",
-                ""sns:Publish""
-            ],
-            ""Resource""  : ""{policyDetails.SourceArn}"",
-            ""Condition"" : {{
-                ""StringEquals"" : {{
-                    ""AWS:SourceOwner"" : ""{sourceAccountId}""
-                }}
-            }}
-        }},
-        {{
-            ""Sid"" : ""{Guid.NewGuid().ToString().Replace("-", "")}"",
-            ""Effect"" : ""Allow"",
-            ""Principal"" : {{
-                ""AWS"" : {JsonSerializer.Serialize(policyDetails.AccountIds)}
-            }},
-            ""Action""    : ""sns:Subscribe"",
-            ""Resource""  : ""{policyDetails.SourceArn}""
-        }}
-    ]
-}}";
+        var policyJson = SnsPolicyBuilder.BuildPolicyJson(policyDetails);
         var setQueueAttributesRequest = new SetTopicAttributesRequest(policyDetails.SourceArn, "Policy", policyJson);
-
         await client.SetTopicAttributesAsync(setQueueAttributesRequest).ConfigureAwait(false);
-    }
-
-    private static string ExtractSourceAccountId(string sourceArn)
-    {
-        //Sns Arn pattern: arn:aws:sns:region:account-id:topic
-        var match = Regex.Match(sourceArn, "(.*?):(.*?):(.*?):(.*?):(.*?):(.*?)", RegexOptions.None, Regex.InfiniteMatchTimeout);
-        return match.Groups[5].Value;
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/SnsPolicyBuilder.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsPolicyBuilder.cs
@@ -8,7 +8,10 @@ internal static class SnsPolicyBuilder
 {
     internal static string BuildPolicyJson(SnsPolicyDetails policyDetails)
     {
-        var arn = Arn.Parse(policyDetails.SourceArn);
+        if (!Arn.IsArn(policyDetails.SourceArn) || !Arn.TryParse(policyDetails.SourceArn, out var arn))
+        {
+            throw new ArgumentException("Must be a valid ARN.", nameof(policyDetails));
+        }
         var accountId = arn.AccountId;
         return $@"{{
     ""Version"" : ""2012-10-17"",

--- a/src/JustSaying/AwsTools/MessageHandling/SnsPolicyBuilder.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsPolicyBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.RegularExpressions;
+using Amazon;
 
 namespace JustSaying.AwsTools.MessageHandling;
 
@@ -7,8 +8,9 @@ internal static class SnsPolicyBuilder
 {
     internal static string BuildPolicyJson(SnsPolicyDetails policyDetails)
     {
-        var sourceAccountId = ExtractSourceAccountId(policyDetails.SourceArn);
-        var policyJson = $@"{{
+        var arn = Arn.Parse(policyDetails.SourceArn);
+        var accountId = arn.AccountId;
+        return $@"{{
     ""Version"" : ""2012-10-17"",
     ""Statement"" : [
         {{
@@ -29,7 +31,7 @@ internal static class SnsPolicyBuilder
             ""Resource""  : ""{policyDetails.SourceArn}"",
             ""Condition"" : {{
                 ""StringEquals"" : {{
-                    ""AWS:SourceOwner"" : ""{sourceAccountId}""
+                    ""AWS:SourceOwner"" : ""{accountId}""
                 }}
             }}
         }},
@@ -44,13 +46,5 @@ internal static class SnsPolicyBuilder
         }}
     ]
 }}";
-        return policyJson;
-    }
-
-    private static string ExtractSourceAccountId(string sourceArn)
-    {
-        //Sns Arn pattern: arn:aws:sns:region:account-id:topic
-        var match = Regex.Match(sourceArn, "(.*?):(.*?):(.*?):(.*?):(.*?):(.*?)", RegexOptions.None, Regex.InfiniteMatchTimeout);
-        return match.Groups[5].Value;
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/SnsPolicyBuilder.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsPolicyBuilder.cs
@@ -1,0 +1,56 @@
+﻿using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace JustSaying.AwsTools.MessageHandling;
+
+internal static class SnsPolicyBuilder
+{
+    internal static string BuildPolicyJson(SnsPolicyDetails policyDetails)
+    {
+        var sourceAccountId = ExtractSourceAccountId(policyDetails.SourceArn);
+        var policyJson = $@"{{
+    ""Version"" : ""2012-10-17"",
+    ""Statement"" : [
+        {{
+            ""Sid"" : ""{Guid.NewGuid().ToString().Replace("-", "")}"",
+            ""Effect"" : ""Allow"",
+            ""Principal"" : {{
+                ""AWS"" : ""*""
+            }},
+            ""Action""    : [
+                ""sns:GetTopicAttributes"",
+                ""sns:SetTopicAttributes"",
+                ""sns:AddPermission"",
+                ""sns:RemovePermission"",
+                ""sns:DeleteTopic"",
+                ""sns:Subscribe"",
+                ""sns:Publish""
+            ],
+            ""Resource""  : ""{policyDetails.SourceArn}"",
+            ""Condition"" : {{
+                ""StringEquals"" : {{
+                    ""AWS:SourceOwner"" : ""{sourceAccountId}""
+                }}
+            }}
+        }},
+        {{
+            ""Sid"" : ""{Guid.NewGuid().ToString().Replace("-", "")}"",
+            ""Effect"" : ""Allow"",
+            ""Principal"" : {{
+                ""AWS"" : {JsonSerializer.Serialize(policyDetails.AccountIds)}
+            }},
+            ""Action""    : ""sns:Subscribe"",
+            ""Resource""  : ""{policyDetails.SourceArn}""
+        }}
+    ]
+}}";
+        return policyJson;
+    }
+
+    private static string ExtractSourceAccountId(string sourceArn)
+    {
+        //Sns Arn pattern: arn:aws:sns:region:account-id:topic
+        var match = Regex.Match(sourceArn, "(.*?):(.*?):(.*?):(.*?):(.*?):(.*?)", RegexOptions.None, Regex.InfiniteMatchTimeout);
+        return match.Groups[5].Value;
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/Approvals/SnsPolicyBuilderTests.ShouldGenerateApprovedIamPolicy.approved.txt
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/Approvals/SnsPolicyBuilderTests.ShouldGenerateApprovedIamPolicy.approved.txt
@@ -27,7 +27,7 @@
             "Sid" : "<sid2>",
             "Effect" : "Allow",
             "Principal" : {
-                "AWS" : null
+                "AWS" : ["123456789012"]
             },
             "Action"    : "sns:Subscribe",
             "Resource"  : "arn:aws:sns:ap-southeast-2:123456789012:topic"

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/Approvals/SnsPolicyBuilderTests.WhenGeneratingPolicy_ForSnsTopic_ThenTheApprovedJsonShouldBeReturned.approved.txt
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/Approvals/SnsPolicyBuilderTests.WhenGeneratingPolicy_ForSnsTopic_ThenTheApprovedJsonShouldBeReturned.approved.txt
@@ -1,0 +1,36 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [
+        {
+            "Sid" : "<sid1>",
+            "Effect" : "Allow",
+            "Principal" : {
+                "AWS" : "*"
+            },
+            "Action"    : [
+                "sns:GetTopicAttributes",
+                "sns:SetTopicAttributes",
+                "sns:AddPermission",
+                "sns:RemovePermission",
+                "sns:DeleteTopic",
+                "sns:Subscribe",
+                "sns:Publish"
+            ],
+            "Resource"  : "arn:aws:sns:ap-southeast-2:123456789012:topic",
+            "Condition" : {
+                "StringEquals" : {
+                    "AWS:SourceOwner" : "123456789012"
+                }
+            }
+        },
+        {
+            "Sid" : "<sid2>",
+            "Effect" : "Allow",
+            "Principal" : {
+                "AWS" : null
+            },
+            "Action"    : "sns:Subscribe",
+            "Resource"  : "arn:aws:sns:ap-southeast-2:123456789012:topic"
+        }
+    ]
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/SnsPolicyBuilderTests.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/SnsPolicyBuilderTests.cs
@@ -12,7 +12,8 @@ public class SnsPolicyBuilderTests
         var sourceArn = "arn:aws:sns:ap-southeast-2:123456789012:topic";
         var snsPolicyDetails = new SnsPolicyDetails
         {
-            SourceArn = sourceArn
+            SourceArn = sourceArn,
+            AccountIds = new[] { "123456789012" }
         };
 
         // act
@@ -39,7 +40,7 @@ public class SnsPolicyBuilderTests
     [Theory]
     [InlineData("")]
     [InlineData(null)]
-    [InlineData("arn:aws:service:region:123456789012")] // missing topic
+    [InlineData("arn:aws:service:region:123456789012")]// missing topic
     public void ShouldThrowArgumentExceptionWhenUsingInvalidArn(string sourceArn)
     {
         // arrange

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/SnsPolicyBuilderTests.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/Policy/SnsPolicyBuilderTests.cs
@@ -1,0 +1,36 @@
+﻿using JustSaying.AwsTools.MessageHandling;
+using Newtonsoft.Json.Linq;
+
+namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sns.Policy;
+
+public class SnsPolicyBuilderTests
+{
+    [Fact]
+    public void WhenGeneratingPolicy_ForSnsTopic_ThenTheApprovedJsonShouldBeReturned()
+    {
+        // arrange
+        var sourceArn = "arn:aws:sns:ap-southeast-2:123456789012:topic";
+        var snsPolicyDetails = new SnsPolicyDetails
+        {
+            SourceArn = sourceArn
+        };
+
+        // act
+        var policy = SnsPolicyBuilder.BuildPolicyJson(snsPolicyDetails);
+
+        // assert
+        policy.ShouldMatchApproved(c =>
+        {
+            c.SubFolder("Approvals");
+            c.WithScrubber(ScrubSids);
+        });
+    }
+
+    private static string ScrubSids(string iamPolicy)
+    {
+        var json = JObject.Parse(iamPolicy);
+        return iamPolicy
+            .Replace(json["Statement"]![0]!["Sid"]!.ToString(), "<sid1>")
+            .Replace(json["Statement"]![1]!["Sid"]!.ToString(), "<sid2>");
+    }
+}


### PR DESCRIPTION
- I noticed `SnsPolicy.cs` was using regex to parse the source ARN instead of using Amazons supplied `ARN.Parse(..)` method.
- Before changing this I separated the two responsibilities of `generating` and `applying` the policy
- This allowed me to add an `approval test` against the IAM policy generated
- Then I made the actual change and introduced `ARN.Parse(..)` and observed no regressions.
- I also added a mechanism to validate the ARN I saw elsewhere.