### PR TITLE
Improve arn parsing and testability of IAM SQS policy generation

### DIFF
--- a/src/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPolicy.cs
@@ -7,27 +7,7 @@ internal static class SqsPolicy
 {
     internal static async Task SaveAsync(SqsPolicyDetails policyDetails, IAmazonSQS client)
     {
-        var topicArnWildcard = CreateTopicArnWildcard(policyDetails.SourceArn);
-
-        var policyJson = $@"{{
-    ""Version"" : ""2012-10-17"",
-    ""Statement"" : [
-        {{
-            ""Sid"" : ""{Guid.NewGuid().ToString().Replace("-", "")}"",
-            ""Effect"" : ""Allow"",
-            ""Principal"" : {{
-                ""AWS"" : ""*""
-            }},
-            ""Action""    : ""sqs:SendMessage"",
-            ""Resource""  : ""{policyDetails.QueueArn}"",
-            ""Condition"" : {{
-                ""ArnLike"" : {{
-                    ""aws:SourceArn"" : ""{topicArnWildcard}""
-                }}
-            }}
-        }}
-    ]
-}}";
+        var policyJson = SqsPolicyBuilder.BuildPolicyJson(policyDetails);
 
         var setQueueAttributesRequest = new SetQueueAttributesRequest
         {
@@ -39,21 +19,5 @@ internal static class SqsPolicy
         };
 
         await client.SetQueueAttributesAsync(setQueueAttributesRequest).ConfigureAwait(false);
-    }
-
-    private static string CreateTopicArnWildcard(string topicArn)
-    {
-        if (string.IsNullOrWhiteSpace(topicArn))
-        {
-            return "*";
-        }
-
-        var index = topicArn.LastIndexOf(":", StringComparison.OrdinalIgnoreCase);
-        if (index > 0)
-        {
-            topicArn = topicArn.Substring(0, index + 1);
-        }
-
-        return topicArn + "*";
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/SqsPolicyBuilder.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsPolicyBuilder.cs
@@ -1,0 +1,45 @@
+﻿using Amazon;
+
+namespace JustSaying.AwsTools.MessageHandling;
+
+internal static class SqsPolicyBuilder{
+
+    public static string BuildPolicyJson(SqsPolicyDetails policyDetails)
+    {
+        var sid = Guid.NewGuid().ToString().Replace("-", "");
+
+        var resource = policyDetails.QueueArn;
+
+        var topicArnWildcard = string.IsNullOrWhiteSpace(policyDetails.SourceArn)
+            ? "*"
+            : CreateTopicArnWildcard(policyDetails.SourceArn);
+
+        var policyJson = $@"{{
+    ""Version"" : ""2012-10-17"",
+    ""Statement"" : [
+        {{
+            ""Sid"" : ""{sid}"",
+            ""Effect"" : ""Allow"",
+            ""Principal"" : {{
+                ""AWS"" : ""*""
+            }},
+            ""Action""    : ""sqs:SendMessage"",
+            ""Resource""  : ""{resource}"",
+            ""Condition"" : {{
+                ""ArnLike"" : {{
+                    ""aws:SourceArn"" : ""{topicArnWildcard}""
+                }}
+            }}
+        }}
+    ]
+}}";
+        return policyJson;
+    }
+
+    private static string CreateTopicArnWildcard(string topicArn)
+    {
+        var arn = Arn.Parse(topicArn);
+        arn.Resource = "*";
+        return arn.ToString();
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/Policy/Approvals/SqsPolicyBuilderTests.ShouldGenerateApprovedIamPolicy.approved.txt
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/Policy/Approvals/SqsPolicyBuilderTests.ShouldGenerateApprovedIamPolicy.approved.txt
@@ -1,0 +1,19 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [
+        {
+            "Sid" : "<sid>",
+            "Effect" : "Allow",
+            "Principal" : {
+                "AWS" : "*"
+            },
+            "Action"    : "sqs:SendMessage",
+            "Resource"  : "",
+            "Condition" : {
+                "ArnLike" : {
+                    "aws:SourceArn" : "arn:aws:sqs:ap-southeast-2:123456789012:*"
+                }
+            }
+        }
+    ]
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/Policy/Approvals/SqsPolicyBuilderTests.ShouldGenerateApprovedIamPolicyWithWildcardFromEmptySourceArn.approved.txt
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/Policy/Approvals/SqsPolicyBuilderTests.ShouldGenerateApprovedIamPolicyWithWildcardFromEmptySourceArn.approved.txt
@@ -1,0 +1,19 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [
+        {
+            "Sid" : "<sid>",
+            "Effect" : "Allow",
+            "Principal" : {
+                "AWS" : "*"
+            },
+            "Action"    : "sqs:SendMessage",
+            "Resource"  : "",
+            "Condition" : {
+                "ArnLike" : {
+                    "aws:SourceArn" : "*"
+                }
+            }
+        }
+    ]
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/Policy/SqsPolicyBuilderTests.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/Policy/SqsPolicyBuilderTests.cs
@@ -1,0 +1,58 @@
+﻿using JustSaying.AwsTools.MessageHandling;
+using Newtonsoft.Json.Linq;
+
+namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs.Policy;
+
+public class SqsPolicyBuilderTests
+{
+    [Fact]
+    public void ShouldGenerateApprovedIamPolicy()
+    {
+        // arrange
+        var sqsPolicyDetails = new SqsPolicyDetails
+        {
+            SourceArn = "arn:aws:sqs:ap-southeast-2:123456789012:topic",
+        };
+
+        // act
+        var policy = SqsPolicyBuilder.BuildPolicyJson(sqsPolicyDetails);
+
+        // assert
+        policy.ShouldMatchApproved(c =>
+        {
+            c.SubFolder("Approvals");
+            // Sids are generated from guids on each invocation so must be ignored
+            // when performing approval tests
+            c.WithScrubber(ScrubSids);
+        });
+    }
+
+    [Fact]
+    public void ShouldGenerateApprovedIamPolicyWithWildcardFromEmptySourceArn()
+    {
+        // arrange
+        var sqsPolicyDetails = new SqsPolicyDetails
+        {
+            SourceArn = "",
+        };
+
+        // act
+        var policy = SqsPolicyBuilder.BuildPolicyJson(sqsPolicyDetails);
+
+        // assert
+        policy.ShouldMatchApproved(c =>
+        {
+            c.SubFolder("Approvals");
+            // Sids are generated from guids on each invocation so must be ignored
+            // when performing approval tests
+            c.WithScrubber(ScrubSids);
+        });
+    }
+
+    private static string ScrubSids(string iamPolicy)
+    {
+        var json = JObject.Parse(iamPolicy);
+        return iamPolicy
+            .Replace(json["Statement"]![0]!["Sid"]!.ToString(), "<sid>");
+    }
+}


### PR DESCRIPTION
I noticed `SqsPolicy.cs` was using string manipulation to parse the source ARN instead of using Amazons supplied `ARN.Parse(..) `method.
Before changing this I separated the two responsibilities of `generating` and `applying` the policy
This allowed me to add an approval test against the IAM policy generated
Then I made the actual change and introduced `ARN.Parse(..)` and observed no regressions.
Added an additional test that covers the `wildcard topic` scenario.