### PR TITLE
FIFO Queue/Topic Support

### DIFF
--- a/src/JustSaying/AwsTools/JustSayingConstants.cs
+++ b/src/JustSaying/AwsTools/JustSayingConstants.cs
@@ -10,6 +10,7 @@ public static class JustSayingConstants
     public const string AttributePolicy = "Policy";
     public const string AttributeEncryptionKeyId = "KmsMasterKeyId";
     public const string AttributeEncryptionKeyReusePeriodSecondId = "KmsDataKeyReusePeriodSeconds";
+    public const string AttributeFifoTopic = "FifoTopic";
 
     /// <summary>
     /// Default visibility timeout for message

--- a/src/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SnsTopicByName.cs
@@ -10,6 +10,7 @@ namespace JustSaying.AwsTools.MessageHandling;
 [Obsolete("SnsTopicByName is not intended for general usage and may be removed in a future major release")]
 public sealed class SnsTopicByName(
     string topicName,
+    bool isFifoTopic,
     IAmazonSimpleNotificationService client,
     ILoggerFactory loggerFactory) : IInterrogable
 {
@@ -76,7 +77,12 @@ public sealed class SnsTopicByName(
     {
         try
         {
-            var response = await client.CreateTopicAsync(new CreateTopicRequest(TopicName), cancellationToken)
+            var request = new CreateTopicRequest(TopicName);
+            if (isFifoTopic)
+            {
+                request.Attributes.Add(JustSayingConstants.AttributeFifoTopic, "true");
+            }
+            var response = await client.CreateTopicAsync(request, cancellationToken)
                 .ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(response.TopicArn))

--- a/src/JustSaying/AwsTools/MessageHandling/SqsMessagePublisher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsMessagePublisher.cs
@@ -88,6 +88,14 @@ public class SqsMessagePublisher(
         {
             request.DelaySeconds = (int)metadata.Delay.Value.TotalSeconds;
         }
+        if (metadata?.MessageGroupId != null)
+        {
+            request.MessageGroupId = metadata.MessageGroupId;
+        }
+        if (metadata?.MessageDeduplicationId != null)
+        {
+            request.MessageDeduplicationId = metadata.MessageDeduplicationId;
+        }
 
         return request;
     }
@@ -184,7 +192,7 @@ public class SqsMessagePublisher(
         }
     }
 
-    private SendMessageBatchRequest BuildSendMessageBatchRequest(Message[] messages, PublishMetadata metadata)
+    private SendMessageBatchRequest BuildSendMessageBatchRequest(Message[] messages, PublishBatchMetadata metadata)
     {
         var entries = new List<SendMessageBatchRequestEntry>(messages.Length);
         int? delaySeconds = metadata?.Delay is { } delay ? (int)delay.TotalSeconds : null;
@@ -200,6 +208,16 @@ public class SqsMessagePublisher(
             if (delaySeconds is { } value)
             {
                 entry.DelaySeconds = value;
+            }
+
+            if (metadata?.MessageGroupIds.TryGetValue(message, out var messageGroupId) ?? false)
+            {
+                entry.MessageGroupId = messageGroupId;
+            }
+
+            if (metadata?.MessageDeduplicationIds.TryGetValue(message, out var messageDeduplicationId) ?? false)
+            {
+                entry.MessageDeduplicationId = messageDeduplicationId;
             }
 
             entries.Add(entry);

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueByName.cs
@@ -13,11 +13,12 @@ namespace JustSaying.AwsTools.MessageHandling;
 public class SqsQueueByName(
     RegionEndpoint region,
     string queueName,
+    bool isFifoQueue,
     IAmazonSQS client,
     int retryCountBeforeSendingToErrorQueue,
-    ILoggerFactory loggerFactory) : SqsQueueByNameBase(region, queueName, client, loggerFactory)
+    ILoggerFactory loggerFactory) : SqsQueueByNameBase(region, queueName, isFifoQueue, client, loggerFactory)
 {
-    internal ErrorQueue ErrorQueue { get; } = new ErrorQueue(region, queueName, client, loggerFactory);
+    internal ErrorQueue ErrorQueue { get; } = new ErrorQueue(region, queueName, isFifoQueue, client, loggerFactory);
 
     public override async Task<bool> CreateAsync(SqsBasicConfiguration queueConfig, int attempt = 0, CancellationToken cancellationToken = default)
     {

--- a/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/AmazonQueueCreator.cs
@@ -38,7 +38,7 @@ public class AmazonQueueCreator(IAwsClientFactoryProxy awsClientFactory, ILogger
             else
             {
 #pragma warning disable 618
-                var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint, snsClient, loggerFactory);
+                var eventTopic = new SnsTopicByName(queueConfig.PublishEndpoint, queueConfig.IsFifoQueue, snsClient, loggerFactory);
 #pragma warning restore 618
                 await eventTopic.CreateAsync(cancellationToken).ConfigureAwait(false);
 
@@ -78,6 +78,7 @@ public class AmazonQueueCreator(IAwsClientFactoryProxy awsClientFactory, ILogger
 #pragma warning disable 618
         var queue = new SqsQueueByName(regionEndpoint,
             queueConfig.QueueName,
+            queueConfig.IsFifoQueue,
             sqsClient,
             queueConfig.RetryCountBeforeSendingToErrorQueue,
             loggerFactory);

--- a/src/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SnsWriteConfiguration.cs
@@ -11,4 +11,6 @@ public class SnsWriteConfiguration
     /// </summary>
     /// <returns>Boolean indicating whether the exception has been handled</returns>
     public Func<Exception, Message, bool> HandleException { get; set; }
+
+    public bool IsFifoTopic { get; set; }
 }

--- a/src/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -12,6 +12,7 @@ public class SqsBasicConfiguration
     public bool ErrorQueueOptOut { get; set; }
     public ServerSideEncryption ServerSideEncryption { get; set; }
     public string QueueName { get; set; }
+    public bool IsFifoQueue { get; set; }
 
     public void ApplyQueueNamingConvention<T>(IQueueNamingConvention namingConvention)
     {

--- a/src/JustSaying/Fluent/PublishConfig/StaticPublicationConfiguration.cs
+++ b/src/JustSaying/Fluent/PublishConfig/StaticPublicationConfiguration.cs
@@ -27,7 +27,8 @@ internal sealed class StaticPublicationConfiguration(
     {
         var readConfiguration = new SqsReadConfiguration(SubscriptionType.ToTopic)
         {
-            TopicName = topicName
+            TopicName = topicName,
+            IsFifoQueue = writeConfiguration.IsFifoTopic,
         };
 
         readConfiguration.ApplyTopicNamingConvention<T>(bus.Config.TopicNamingConvention);
@@ -44,6 +45,7 @@ internal sealed class StaticPublicationConfiguration(
 
         var snsTopic = new SnsTopicByName(
             readConfiguration.TopicName,
+            writeConfiguration.IsFifoTopic,
             snsClient,
             loggerFactory)
         {

--- a/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueuePublicationBuilder`1.cs
@@ -27,6 +27,8 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T>
     /// </summary>
     private Action<SqsWriteConfiguration> ConfigureWrites { get; set; }
 
+    private bool IsFifoQueue { get; set; }
+
     /// <summary>
     /// Configures the SQS write configuration.
     /// </summary>
@@ -81,6 +83,22 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T>
         return WithWriteConfiguration(r => r.WithQueueName(queueName));
     }
 
+    /// <summary>
+    /// Configures the SQS Queue as a FIFO Queue.
+    /// </summary>
+    /// <remarks>
+    /// Queue Name should have the ".fifo" suffix appended per SQS specification.
+    /// </remarks>
+    /// <returns>
+    /// The current <see cref="QueuePublicationBuilder{T}"/>.
+    /// </returns>
+    public QueuePublicationBuilder<T> WithFifo()
+    {
+        IsFifoQueue = true;
+
+        return this;
+    }
+
     /// <inheritdoc />
     void IPublicationBuilder<T>.Configure(
         JustSayingBus bus,
@@ -117,6 +135,7 @@ public sealed class QueuePublicationBuilder<T> : IPublicationBuilder<T>
         var sqsQueue = new SqsQueueByName(
             regionEndpoint,
             writeConfiguration.QueueName,
+            IsFifoQueue,
             sqsClient,
             writeConfiguration.RetryCountBeforeSendingToErrorQueue,
             loggerFactory);

--- a/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/QueueSubscriptionBuilder`1.cs
@@ -42,6 +42,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T>
     /// </summary>
     private Action<HandlerMiddlewareBuilder> MiddlewareConfiguration { get; set; }
 
+    private bool IsFifoQueue { get; set; }
 
     /// <summary>
     /// Configures that the <see cref="IQueueNamingConvention"/> will create the queue name that should be used.
@@ -147,6 +148,22 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T>
         return this;
     }
 
+    /// <summary>
+    /// Configures the SQS Queue as a FIFO Queue.
+    /// </summary>
+    /// <remarks>
+    /// Queue Name should have the ".fifo" suffix appended per SQS specification.
+    /// </remarks>
+    /// <returns>
+    /// The current <see cref="QueuePublicationBuilder{T}"/>.
+    /// </returns>
+    public QueueSubscriptionBuilder<T> WithFifo()
+    {
+        IsFifoQueue = true;
+
+        return this;
+    }
+
     /// <inheritdoc />
     public ISubscriptionBuilder<T> WithMiddlewareConfiguration(Action<HandlerMiddlewareBuilder> middlewareConfiguration)
     {
@@ -168,6 +185,7 @@ public sealed class QueueSubscriptionBuilder<T> : ISubscriptionBuilder<T>
         var subscriptionConfig = new SqsReadConfiguration(SubscriptionType.PointToPoint)
         {
             QueueName = QueueName,
+            IsFifoQueue = IsFifoQueue,
             Tags = Tags
         };
 

--- a/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
+++ b/src/JustSaying/Fluent/TopicSubscriptionBuilder`1.cs
@@ -41,6 +41,7 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
 
     private Action<HandlerMiddlewareBuilder> MiddlewareConfiguration { get; set; }
 
+    private bool IsFifoTopic { get; set; }
 
     /// <summary>
     /// Configures that the <see cref="ITopicNamingConvention"/> will create the topic name that should be used.
@@ -169,6 +170,22 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
         return this;
     }
 
+    /// <summary>
+    /// Configures the SNS Topic as a FIFO Topic.
+    /// </summary>
+    /// <remarks>
+    /// Topic Name should have the ".fifo" suffix appended per SQS specification.
+    /// </remarks>
+    /// <returns>
+    /// The current <see cref="TopicSubscriptionBuilder{T}"/>.
+    /// </returns>
+    public TopicSubscriptionBuilder<T> WithFifo()
+    {
+        IsFifoTopic = true;
+
+        return this;
+    }
+
     /// <inheritdoc />
     void ISubscriptionBuilder<T>.Configure(
         JustSayingBus bus,
@@ -183,6 +200,7 @@ public sealed class TopicSubscriptionBuilder<T> : ISubscriptionBuilder<T>
         var subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic)
         {
             QueueName = QueueName,
+            IsFifoQueue = IsFifoTopic,
             TopicName = TopicName,
             Tags = Tags
         };

--- a/src/JustSaying/Messaging/PublishBatchMetadata.cs
+++ b/src/JustSaying/Messaging/PublishBatchMetadata.cs
@@ -1,4 +1,5 @@
 using JustSaying.AwsTools;
+using JustSaying.Models;
 
 namespace JustSaying.Messaging;
 
@@ -14,4 +15,26 @@ public class PublishBatchMetadata : PublishMetadata
     /// The default value is the value of <see cref="JustSayingConstants.MaximumSnsBatchSize"/>.
     /// </remarks>
     public int BatchSize { get; set; } = JustSayingConstants.MaximumSnsBatchSize;
+
+    /// <summary>
+    /// Gets or sets the per-message MessageGroupIds.
+    /// </summary>
+    public Dictionary<Message, string> MessageGroupIds { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the per-message MessageDeduplicationIds.
+    /// </summary>
+    public Dictionary<Message, string> MessageDeduplicationIds { get; set; } = [];
+
+    public PublishMetadata AddMessageGroupId(Message message, string messageGroupId)
+    {
+        MessageGroupIds[message] = messageGroupId;
+        return this;
+    }
+
+    public PublishMetadata AddMessageDeduplicationId(Message message, string messageDeduplicationId)
+    {
+        MessageDeduplicationIds[message] = messageDeduplicationId;
+        return this;
+    }
 }

--- a/src/JustSaying/Messaging/PublishMetadata.cs
+++ b/src/JustSaying/Messaging/PublishMetadata.cs
@@ -8,6 +8,10 @@ public class PublishMetadata
 
     public IDictionary<string, MessageAttributeValue> MessageAttributes { get; private set; }
 
+    public string MessageGroupId { get; private set; }
+
+    public string MessageDeduplicationId { get; private set; }
+
     public PublishMetadata AddMessageAttribute(string key, IReadOnlyCollection<byte> data)
     {
         var mav = new MessageAttributeValue
@@ -48,4 +52,15 @@ public class PublishMetadata
         });
     }
 
+    public PublishMetadata AddMessageGroupId(string messageGroupId)
+    {
+        MessageGroupId = messageGroupId;
+        return this;
+    }
+
+    public PublishMetadata AddMessageDeduplicationId(string messageDeduplicationId)
+    {
+        MessageDeduplicationId = messageDeduplicationId;
+        return this;
+    }
 }

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedFifoQueueIsCreated.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedFifoQueueIsCreated.cs
@@ -1,0 +1,38 @@
+using JustSaying.AwsTools;
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.AwsTools.QueueCreation;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable 618
+
+namespace JustSaying.IntegrationTests.Fluent.AwsTools;
+
+public class WhenANamedFifoQueueIsCreated(ITestOutputHelper outputHelper) : IntegrationTestBase(outputHelper)
+{
+    [AwsFact]
+    public async Task Then_The_Error_Queue_Is_Created()
+    {
+        // Arrange
+        ILoggerFactory loggerFactory = OutputHelper.ToLoggerFactory();
+        IAwsClientFactory clientFactory = CreateClientFactory();
+
+        var client = clientFactory.GetSqsClient(Region);
+
+        var queue = new SqsQueueByName(
+            Region,
+            UniqueName + ".fifo",
+            true,
+            client,
+            1,
+            loggerFactory);
+
+        // Act
+        await queue.CreateAsync(new SqsBasicConfiguration());
+
+        // Assert
+        await Patiently.AssertThatAsync(OutputHelper,
+            async () => await queue.ErrorQueue.ExistsAsync(CancellationToken.None),
+            40.Seconds());
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedQueueIsCreated.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenANamedQueueIsCreated.cs
@@ -22,6 +22,7 @@ public class WhenANamedQueueIsCreated(ITestOutputHelper outputHelper) : Integrat
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingAQueueWithNoErrorQueue.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingAQueueWithNoErrorQueue.cs
@@ -22,6 +22,7 @@ public class WhenCreatingAQueueWithNoErrorQueue(ITestOutputHelper outputHelper) 
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingErrorQueue.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingErrorQueue.cs
@@ -21,6 +21,7 @@ public class WhenCreatingErrorQueue(ITestOutputHelper outputHelper) : Integratio
         var queue = new ErrorQueue(
             Region,
             UniqueName,
+            false,
             client,
             loggerFactory);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingQueueTwice.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingQueueTwice.cs
@@ -21,6 +21,7 @@ public class WhenCreatingQueueTwice(ITestOutputHelper outputHelper) : Integratio
 
         var topic = new SnsTopicByName(
             topicName,
+            false,
             client,
             loggerFactory);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingTopicWithServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingTopicWithServerSideEncryption.cs
@@ -20,6 +20,7 @@ public class WhenCreatingTopicWithServerSideEncryption(ITestOutputHelper outputH
 
         var topic = new SnsTopicByName(
             UniqueName,
+            false,
             client,
             loggerFactory);
 
@@ -41,6 +42,7 @@ public class WhenCreatingTopicWithServerSideEncryption(ITestOutputHelper outputH
 
         var topic = new SnsTopicByName(
             UniqueName,
+            false,
             client,
             loggerFactory);
 
@@ -64,6 +66,7 @@ public class WhenCreatingTopicWithServerSideEncryption(ITestOutputHelper outputH
 
         var topic = new SnsTopicByName(
             UniqueName,
+            false,
             client,
             loggerFactory);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenQueueIsDeleted.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenQueueIsDeleted.cs
@@ -22,6 +22,7 @@ public class WhenQueueIsDeleted(ITestOutputHelper outputHelper) : IntegrationTes
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingServerSideEncryption.cs
@@ -21,6 +21,7 @@ public class WhenRemovingServerSideEncryption(ITestOutputHelper outputHelper) : 
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingSnsServerSideEncryption.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenRemovingSnsServerSideEncryption.cs
@@ -20,6 +20,7 @@ public class WhenRemovingSnsServerSideEncryption(ITestOutputHelper outputHelper)
 
         var topic = new SnsTopicByName(
             UniqueName,
+            false,
             client,
             loggerFactory);
 

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingDeliveryDelay.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingDeliveryDelay.cs
@@ -25,6 +25,7 @@ public class WhenUpdatingDeliveryDelay(ITestOutputHelper outputHelper) : Integra
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRedrivePolicy.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRedrivePolicy.cs
@@ -24,6 +24,7 @@ public class WhenUpdatingRedrivePolicy(ITestOutputHelper outputHelper) : Integra
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRetentionPeriod.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUpdatingRetentionPeriod.cs
@@ -25,6 +25,7 @@ public class WhenUpdatingRetentionPeriod(ITestOutputHelper outputHelper) : Integ
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             1,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingABasicThrottle.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenUsingABasicThrottle.cs
@@ -32,6 +32,7 @@ public class WhenUsingABasicThrottle(ITestOutputHelper outputHelper) : Integrati
         var queue = new SqsQueueByName(
             Region,
             UniqueName,
+            false,
             client,
             retryCountBeforeSendingToErrorQueue,
             loggerFactory);

--- a/tests/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTestExtensions.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/MessagingBusBuilderTestExtensions.cs
@@ -5,7 +5,9 @@ namespace JustSaying.IntegrationTests.Fluent;
 
 internal static class MessagingBusBuilderTestExtensions
 {
-    public static MessagingBusBuilder WithLoopbackQueue<T>(this MessagingBusBuilder builder, string name,
+    public static MessagingBusBuilder WithLoopbackQueue<T>(
+        this MessagingBusBuilder builder,
+        string name,
         Action<QueueSubscriptionBuilder<T>> configure = null)
         where T : Message
     {
@@ -18,15 +20,51 @@ internal static class MessagingBusBuilderTestExtensions
             }));
     }
 
-    public static MessagingBusBuilder WithLoopbackTopic<T>(this MessagingBusBuilder builder, string name,
+    public static MessagingBusBuilder WithLoopbackFifoQueue<T>(
+        this MessagingBusBuilder builder,
+        string name,
+        Action<QueueSubscriptionBuilder<T>> configure = null)
+        where T : Message
+    {
+        return builder
+            .Publications((options) => options.WithQueue<T>(o => o.WithName(name).WithFifo()))
+            .Subscriptions((options) => options.ForQueue<T>(subscriptionBuilder =>
+            {
+                subscriptionBuilder.WithQueueName(name).WithFifo();
+                configure?.Invoke(subscriptionBuilder);
+            }));
+    }
+
+    public static MessagingBusBuilder WithLoopbackTopic<T>(
+        this MessagingBusBuilder builder,
+        string name,
         Action<TopicSubscriptionBuilder<T>> configure = null)
         where T : Message
     {
         return builder
-            .Publications((options) => options.WithTopic<T>())
+            .Publications((options) => options.WithTopic<T>(publicationBuilder =>
+                publicationBuilder.WithTopicName(name)
+            ))
             .Subscriptions((options) => options.ForTopic<T>(subscriptionBuilder =>
             {
-                subscriptionBuilder.WithQueueName(name);
+                subscriptionBuilder.WithQueueName(name).WithTopicName(name);
+                configure?.Invoke(subscriptionBuilder);
+            }));
+    }
+
+    public static MessagingBusBuilder WithLoopbackFifoTopic<T>(
+        this MessagingBusBuilder builder,
+        string name,
+        Action<TopicSubscriptionBuilder<T>> configure = null)
+        where T : Message
+    {
+        return builder
+            .Publications((options) => options.WithTopic<T>(publicationBuilder =>
+                publicationBuilder.WithTopicName(name).WithFifo()
+            ))
+            .Subscriptions((options) => options.ForTopic<T>(subscriptionBuilder =>
+            {
+                subscriptionBuilder.WithQueueName(name).WithTopicName(name).WithFifo();
                 configure?.Invoke(subscriptionBuilder);
             }));
     }

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToAQueueWithFifo.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToAQueueWithFifo.cs
@@ -1,0 +1,175 @@
+using JustSaying.Messaging;
+using JustSaying.Models;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing;
+
+public class WhenAMessageIsPublishedToAQueueWithFifo(ITestOutputHelper outputHelper) : IntegrationTestBase(outputHelper)
+{
+    [AwsFact]
+    public async Task Then_The_Message_Is_Handled()
+    {
+        // Arrange
+        var completionSource = new TaskCompletionSource<object>();
+        var handler = CreateHandler<SimpleMessage>(completionSource);
+        var uniqueFifoName = UniqueName + ".fifo";
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) => builder.WithLoopbackFifoQueue<SimpleMessage>(uniqueFifoName))
+            .AddSingleton(handler);
+
+        string content = Guid.NewGuid().ToString();
+        string messageGroupId = Guid.NewGuid().ToString();
+        string messageDeduplicationId = Guid.NewGuid().ToString();
+
+        var message = new SimpleMessage()
+        {
+            Content = content,
+        };
+
+        await WhenAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                // Act
+                await publisher.PublishAsync(message, new PublishMetadata().AddMessageGroupId(messageGroupId).AddMessageDeduplicationId(messageDeduplicationId), cancellationToken);
+
+                // Assert
+                completionSource.Task.Wait(cancellationToken);
+
+                await handler.Received().Handle(Arg.Is<SimpleMessage>((m) => m.Content == content));
+            });
+    }
+
+    [AwsTheory]
+    [InlineData(10, 10)]
+    [InlineData(10, 100)]
+    [InlineData(5, 100)]
+    public async Task Then_Multiple_Messages_Are_Handled(int maxBatchSize, int batchSize)
+    {
+        // Arrange
+        var completionSource = new TaskCompletionSource<object>();
+        var handler = CreateHandler<SimpleMessage>(completionSource, batchSize);
+        var uniqueFifoName = UniqueName + ".fifo";
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) => builder.WithLoopbackFifoQueue<SimpleMessage>(uniqueFifoName))
+            .AddSingleton(handler);
+
+        var messages = new List<Message>();
+        var messageGroupIds = new Dictionary<Message, string>();
+        var messageDeduplicationIds = new Dictionary<Message, string>();
+        for (int i = 0; i < batchSize; i++)
+        {
+            var message = new SimpleMessage
+            {
+                Content = $"Message {i} of {batchSize} with max batch size {maxBatchSize}"
+            };
+
+            messages.Add(message);
+            messageGroupIds.Add(message, Guid.NewGuid().ToString());
+            messageDeduplicationIds.Add(message, Guid.NewGuid().ToString());
+        }
+
+        await WhenBatchAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                // Act
+                await publisher.PublishAsync(messages, new PublishBatchMetadata
+                {
+                    BatchSize = maxBatchSize,
+                    MessageGroupIds = messageGroupIds,
+                    MessageDeduplicationIds = messageDeduplicationIds,
+                }, cancellationToken);
+
+                // Assert
+                completionSource.Task.Wait(cancellationToken);
+
+                await handler.Received(batchSize).Handle(Arg.Is<SimpleMessage>((m) => messages.Any(y => y.Id == m.Id)));
+            });
+    }
+
+    [AwsTheory]
+    [InlineData(10, 10)]
+    [InlineData(10, 100)]
+    [InlineData(5, 100)]
+    public async Task Then_Multiple_Message_Types_Are_Handled(int maxBatchSize, int batchSize)
+    {
+        // Arrange
+        var completionSource1 = new TaskCompletionSource<object>();
+        var handler1 = CreateHandler<SimpleMessage>(completionSource1, batchSize);
+        var uniqueFifoNam1 = UniqueName + ".fifo";
+
+        var completionSource2 = new TaskCompletionSource<object>();
+        var handler2 = CreateHandler<AnotherSimpleMessage>(completionSource2, batchSize);
+        var uniqueFifoName2 = UniqueName + "ish" + ".fifo";
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) =>
+            {
+                builder.WithLoopbackFifoQueue<SimpleMessage>(uniqueFifoNam1);
+                builder.WithLoopbackFifoQueue<AnotherSimpleMessage>(uniqueFifoName2);
+            })
+            .AddSingleton(handler1)
+            .AddSingleton(handler2);
+
+        var messages = new List<Message>();
+        var messageGroupIds = new Dictionary<Message, string>();
+        var messageDeduplicationIds = new Dictionary<Message, string>();
+        for (int i = 0; i < batchSize; i++)
+        {
+            var message = new SimpleMessage
+            {
+                Content = $"Message {i} of {batchSize} with max batch size {maxBatchSize}"
+            };
+
+            messages.Add(message);
+            messageGroupIds.Add(message, Guid.NewGuid().ToString());
+            messageDeduplicationIds.Add(message, Guid.NewGuid().ToString());
+        }
+
+        for (int i = 0; i < batchSize; i++)
+        {
+            var message = new AnotherSimpleMessage
+            {
+                Content = $"Message {i} of {batchSize} with max batch size {maxBatchSize}"
+            };
+
+            messages.Add(message);
+            messageGroupIds.Add(message, Guid.NewGuid().ToString());
+            messageDeduplicationIds.Add(message, Guid.NewGuid().ToString());
+        }
+
+        await WhenBatchAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                // Act
+                await publisher.PublishAsync(messages, new PublishBatchMetadata
+                {
+                    BatchSize = maxBatchSize,
+                    MessageGroupIds = messageGroupIds,
+                    MessageDeduplicationIds = messageDeduplicationIds,
+                }, cancellationToken);
+
+                // Assert
+                completionSource1.Task.Wait(cancellationToken);
+                await handler1.Received(batchSize).Handle(Arg.Is<SimpleMessage>((m) => messages.Any(y => y.Id == m.Id)));
+
+                completionSource2.Task.Wait(cancellationToken);
+                await handler2.Received(batchSize).Handle(Arg.Is<AnotherSimpleMessage>((m) => messages.Any(y => y.Id == m.Id)));
+            });
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToATopicWithFifo.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/WhenAMessageIsPublishedToATopicWithFifo.cs
@@ -1,0 +1,175 @@
+using JustSaying.Messaging;
+using JustSaying.Models;
+using JustSaying.TestingFramework;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace JustSaying.IntegrationTests.Fluent.Publishing;
+
+public class WhenAMessageIsPublishedToATopicWithFifo(ITestOutputHelper outputHelper) : IntegrationTestBase(outputHelper)
+{
+    [AwsFact]
+    public async Task Then_The_Message_Is_Handled()
+    {
+        // Arrange
+        var completionSource = new TaskCompletionSource<object>();
+        var handler = CreateHandler<SimpleMessage>(completionSource);
+        var uniqueFifoName = UniqueName + ".fifo";
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) => builder.WithLoopbackFifoTopic<SimpleMessage>(uniqueFifoName))
+            .AddSingleton(handler);
+
+        string content = Guid.NewGuid().ToString();
+        string messageGroupId = Guid.NewGuid().ToString();
+        string messageDeduplicationId = Guid.NewGuid().ToString();
+
+        var message = new SimpleMessage()
+        {
+            Content = content
+        };
+
+        await WhenAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                // Act
+                await publisher.PublishAsync(message, new PublishMetadata().AddMessageGroupId(messageGroupId).AddMessageDeduplicationId(messageDeduplicationId), cancellationToken);
+
+                // Assert
+                completionSource.Task.Wait(cancellationToken);
+
+                await handler.Received().Handle(Arg.Is<SimpleMessage>((m) => m.Content == content));
+            });
+    }
+
+    [AwsTheory]
+    [InlineData(10, 10)]
+    [InlineData(10, 20)]
+    [InlineData(5, 10)]
+    public async Task Then_Multiple_Messages_Are_Handled(int maxBatchSize, int batchSize)
+    {
+        // Arrange
+        var completionSource = new TaskCompletionSource<object>();
+        var handler = CreateHandler<SimpleMessage>(completionSource, batchSize);
+        var uniqueFifoName = UniqueName + ".fifo";
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) => builder.WithLoopbackFifoTopic<SimpleMessage>(uniqueFifoName))
+            .AddSingleton(handler);
+
+        var messages = new List<Message>();
+        var messageGroupIds = new Dictionary<Message, string>();
+        var messageDeduplicationIds = new Dictionary<Message, string>();
+        for (int i = 0; i < batchSize; i++)
+        {
+            var message = new SimpleMessage
+            {
+                Content = $"Message {i} of {batchSize} with max batch size {maxBatchSize}"
+            };
+
+            messages.Add(message);
+            messageGroupIds.Add(message, Guid.NewGuid().ToString());
+            messageDeduplicationIds.Add(message, Guid.NewGuid().ToString());
+        }
+
+        await WhenBatchAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                // Act
+                await publisher.PublishAsync(messages, new PublishBatchMetadata
+                {
+                    BatchSize = batchSize,
+                    MessageGroupIds = messageGroupIds,
+                    MessageDeduplicationIds = messageDeduplicationIds,
+                }, cancellationToken);
+
+                // Assert
+                completionSource.Task.Wait(cancellationToken);
+
+                await handler.Received(batchSize).Handle(Arg.Is<SimpleMessage>((m) => messages.Any(x => x.Id == m.Id)));
+            });
+    }
+
+    [AwsTheory]
+    [InlineData(10, 10)]
+    [InlineData(10, 20)]
+    [InlineData(5, 10)]
+    public async Task Then_Multiple_Message_Types_Are_Handled(int maxBatchSize, int batchSize)
+    {
+        // Arrange
+        var completionSource1 = new TaskCompletionSource<object>();
+        var handler1 = CreateHandler<SimpleMessage>(completionSource1, batchSize);
+        var uniqueFifoName1 = UniqueName + ".fifo";
+
+        var completionSource2 = new TaskCompletionSource<object>();
+        var handler2 = CreateHandler<AnotherSimpleMessage>(completionSource2, batchSize);
+        var uniqueFifoName2 = UniqueName + "ish" + ".fifo";
+
+        var services = GivenJustSaying()
+            .ConfigureJustSaying((builder) =>
+            {
+                builder.WithLoopbackFifoTopic<SimpleMessage>(uniqueFifoName1);
+                builder.WithLoopbackFifoTopic<AnotherSimpleMessage>(uniqueFifoName2);
+            })
+            .AddSingleton(handler1)
+            .AddSingleton(handler2);
+
+        var messages = new List<Message>();
+        var messageGroupIds = new Dictionary<Message, string>();
+        var messageDeduplicationIds = new Dictionary<Message, string>();
+        for (int i = 0; i < batchSize; i++)
+        {
+            var message = new SimpleMessage
+            {
+                Content = $"Message {i} of {batchSize} with max batch size {maxBatchSize}"
+            };
+
+            messages.Add(message);
+            messageGroupIds.Add(message, Guid.NewGuid().ToString());
+            messageDeduplicationIds.Add(message, Guid.NewGuid().ToString());
+        }
+
+        for (int i = 0; i < batchSize; i++)
+        {
+            var message = new AnotherSimpleMessage
+            {
+                Content = $"Message {i} of {batchSize} with max batch size {maxBatchSize}"
+            };
+
+            messages.Add(message);
+            messageGroupIds.Add(message, Guid.NewGuid().ToString());
+            messageDeduplicationIds.Add(message, Guid.NewGuid().ToString());
+        }
+
+        await WhenBatchAsync(
+            services,
+            async (publisher, listener, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                // Act
+                await publisher.PublishAsync(messages, new PublishBatchMetadata
+                {
+                    BatchSize = batchSize,
+                    MessageGroupIds = messageGroupIds,
+                    MessageDeduplicationIds = messageDeduplicationIds,
+                }, cancellationToken);
+
+                // Assert
+                completionSource1.Task.Wait(cancellationToken);
+                await handler1.Received(batchSize).Handle(Arg.Is<SimpleMessage>((m) => messages.Any(x => x.Id == m.Id)));
+
+                completionSource2.Task.Wait(cancellationToken);
+                await handler2.Received(batchSize).Handle(Arg.Is<AnotherSimpleMessage>((m) => messages.Any(x => x.Id == m.Id)));
+            });
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenHandlingMultipleTopics.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/Subscribing/WhenHandlingMultipleTopics.cs
@@ -32,7 +32,7 @@ public class WhenHandlingMultipleTopics(ITestOutputHelper outputHelper) : Integr
                 var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
                 var client = clientFactory.GetSqsClient(Region);
 
-                var queue = new SqsQueueByName(Region, UniqueName, client, 0, loggerFactory);
+                var queue = new SqsQueueByName(Region, UniqueName, false, client, 0, loggerFactory);
 
                 await Patiently.AssertThatAsync(OutputHelper, () => queue.ExistsAsync(CancellationToken.None), 60.Seconds());
 

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenApplyingTags.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenApplyingTags.cs
@@ -16,7 +16,7 @@ public class WhenApplyingTags : WhenSnsTopicTestBase
 
     private protected override Task<SnsTopicByName> CreateSystemUnderTestAsync()
     {
-        var topicByName = new SnsTopicByName("TopicName", Sns,  NullLoggerFactory.Instance)
+        var topicByName = new SnsTopicByName("TopicName", false, Sns,  NullLoggerFactory.Instance)
         {
             Tags = _tags
         };

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenFetchingFifoTopicByName.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenFetchingFifoTopicByName.cs
@@ -1,0 +1,63 @@
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using JustSaying.AwsTools.MessageHandling;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+#pragma warning disable 618
+
+namespace JustSaying.UnitTests.AwsTools.TopicCreation;
+
+public class WhenFetchingFifoTopicByName
+{
+    private readonly IAmazonSimpleNotificationService _client;
+    private readonly ILoggerFactory _log;
+
+    public WhenFetchingFifoTopicByName()
+    {
+        _client = Substitute.For<IAmazonSimpleNotificationService>();
+
+        _client.FindTopicAsync(Arg.Any<string>())
+            .Returns(x =>
+            {
+                if (x.Arg<string>() == "some-topic-name.fifo")
+                    return new Topic
+                    {
+                        TopicArn = "something:some-topic-name.fifo"
+                    };
+                return null;
+            });
+        _client.GetTopicAttributesAsync(Arg.Any<GetTopicAttributesRequest>())
+            .Returns(new GetTopicAttributesResponse()
+            {
+                Attributes = new Dictionary<string, string>
+                {
+                    { "TopicArn", "something:some-topic-name.fifo" },
+                    { "FifoTopic", "true" },
+                }
+            });
+        _log = Substitute.For<ILoggerFactory>();
+    }
+
+    [Fact]
+    public async Task IncorrectTopicNameDoNotMatch()
+    {
+        var snsTopicByName = new SnsTopicByName("some-topic-name1.fifo", true, _client, _log);
+        (await snsTopicByName.ExistsAsync(CancellationToken.None)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IncorrectPartialTopicNameDoNotMatch()
+    {
+        var snsTopicByName = new SnsTopicByName("some-topic.fifo", true, _client, _log);
+        (await snsTopicByName.ExistsAsync(CancellationToken.None)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CorrectQueueNameShouldMatch()
+    {
+        var snsTopicByName = new SnsTopicByName("some-topic-name.fifo", true, _client, _log);
+        (await snsTopicByName.ExistsAsync(CancellationToken.None)).ShouldBeTrue();
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenFetchingTopicByName.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sns/TopicByName/WhenFetchingTopicByName.cs
@@ -1,0 +1,63 @@
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using JustSaying.AwsTools.MessageHandling;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+#pragma warning disable 618
+
+namespace JustSaying.UnitTests.AwsTools.TopicCreation;
+
+public class WhenFetchingTopicByName
+{
+    private readonly IAmazonSimpleNotificationService _client;
+    private readonly ILoggerFactory _log;
+
+    public WhenFetchingTopicByName()
+    {
+        _client = Substitute.For<IAmazonSimpleNotificationService>();
+
+        _client.FindTopicAsync(Arg.Any<string>())
+            .Returns(x =>
+            {
+                if (x.Arg<string>() == "some-topic-name")
+                    return new Topic
+                    {
+                        TopicArn = "something:some-topic-name"
+                    };
+                return null;
+            });
+        _client.GetTopicAttributesAsync(Arg.Any<GetTopicAttributesRequest>())
+            .Returns(new GetTopicAttributesResponse()
+            {
+                Attributes = new Dictionary<string, string>
+                {
+                    { "TopicArn", "something:some-topic-name" },
+                    { "FifoTopic", "false" },
+                }
+            });
+        _log = Substitute.For<ILoggerFactory>();
+    }
+
+    [Fact]
+    public async Task IncorrectTopicNameDoNotMatch()
+    {
+        var snsTopicByName = new SnsTopicByName("some-topic-name1", false, _client, _log);
+        (await snsTopicByName.ExistsAsync(CancellationToken.None)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IncorrectPartialTopicNameDoNotMatch()
+    {
+        var snsTopicByName = new SnsTopicByName("some-topic", false, _client, _log);
+        (await snsTopicByName.ExistsAsync(CancellationToken.None)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CorrectQueueNameShouldMatch()
+    {
+        var snsTopicByName = new SnsTopicByName("some-topic-name", false, _client, _log);
+        (await snsTopicByName.ExistsAsync(CancellationToken.None)).ShouldBeTrue();
+    }
+}

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenApplyingQueueTags.cs
@@ -68,7 +68,7 @@ public class WhenApplyingQueueTags
     public async Task TagsAreAppliedToParentAndErrorQueues()
     {
         // Arrange
-        var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, _client, 3, NullLoggerFactory.Instance);
+        var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, false, _client, 3, NullLoggerFactory.Instance);
 
         var config = new SqsReadConfiguration(SubscriptionType.ToTopic)
         {
@@ -90,7 +90,7 @@ public class WhenApplyingQueueTags
     public async Task TagsAreNotAppliedIfNoneAreProvided()
     {
         // Arrange
-        var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, _client, 3, NullLoggerFactory.Instance);
+        var sut = new SqsQueueByName(RegionEndpoint.EUWest1, QueueName, false, _client, 3, NullLoggerFactory.Instance);
 
         // Act
         await sut.EnsureQueueAndErrorQueueExistAndAllAttributesAreUpdatedAsync(new SqsReadConfiguration(SubscriptionType.ToTopic), CancellationToken.None);

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingFifoQueueByName.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/Sqs/WhenFetchingFifoQueueByName.cs
@@ -9,30 +9,34 @@ using NSubstitute;
 
 namespace JustSaying.UnitTests.AwsTools.MessageHandling.Sqs;
 
-public class WhenFetchingQueueByName
+public class WhenFetchingFifoQueueByName
 {
     private readonly IAmazonSQS _client;
     private readonly ILoggerFactory _log;
     private const int RetryCount = 3;
 
-    public WhenFetchingQueueByName()
+    public WhenFetchingFifoQueueByName()
     {
         _client = Substitute.For<IAmazonSQS>();
 
         _client.GetQueueUrlAsync(Arg.Any<string>())
             .Returns(x =>
             {
-                if (x.Arg<string>() == "some-queue-name")
+                if (x.Arg<string>() == "some-queue-name.fifo")
                     return new GetQueueUrlResponse
                     {
-                        QueueUrl = "https://testqueues.com/some-queue-name"
+                        QueueUrl = "https://testqueues.com/some-queue-name.fifo"
                     };
-                throw new QueueDoesNotExistException("some-queue-name not found");
+                throw new QueueDoesNotExistException("some-queue-name.fifo not found");
             });
         _client.GetQueueAttributesAsync(Arg.Any<GetQueueAttributesRequest>())
             .Returns(new GetQueueAttributesResponse()
             {
-                Attributes = new Dictionary<string, string> { { "QueueArn", "something:some-queue-name" } }
+                Attributes = new Dictionary<string, string>
+                {
+                    { "QueueArn", "something:some-queue-name.fifo" },
+                    { "FifoQueue", "true" },
+                }
             });
         _log = Substitute.For<ILoggerFactory>();
     }
@@ -40,21 +44,21 @@ public class WhenFetchingQueueByName
     [Fact]
     public async Task IncorrectQueueNameDoNotMatch()
     {
-        var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name1", false, _client, RetryCount, _log);
+        var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name1.fifo", true, _client, RetryCount, _log);
         (await sqsQueueByName.ExistsAsync(CancellationToken.None)).ShouldBeFalse();
     }
 
     [Fact]
     public async Task IncorrectPartialQueueNameDoNotMatch()
     {
-        var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue", false, _client, RetryCount, _log);
+        var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue.fifo", true, _client, RetryCount, _log);
         (await sqsQueueByName.ExistsAsync(CancellationToken.None)).ShouldBeFalse();
     }
 
     [Fact]
     public async Task CorrectQueueNameShouldMatch()
     {
-        var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name", false, _client, RetryCount, _log);
+        var sqsQueueByName = new SqsQueueByName(RegionEndpoint.EUWest1, "some-queue-name.fifo", true, _client, RetryCount, _log);
         (await sqsQueueByName.ExistsAsync(CancellationToken.None)).ShouldBeTrue();
     }
 }

--- a/tests/JustSaying.UnitTests/AwsTools/TopicCreation/WhenCreatingTopicWithNoPermissions.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/TopicCreation/WhenCreatingTopicWithNoPermissions.cs
@@ -24,6 +24,7 @@ public class WhenCreatingTopicWithNoPermissions(ITestOutputHelper outputHelper)
 
         var topic = new SnsTopicByName(
             topicName,
+            false,
             client,
             loggerFactory);
 
@@ -45,6 +46,7 @@ public class WhenCreatingTopicWithNoPermissions(ITestOutputHelper outputHelper)
 
         var topic = new SnsTopicByName(
             topicName,
+            false,
             client,
             loggerFactory);
 

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/WhenUsingSqsQueueByName.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/WhenUsingSqsQueueByName.cs
@@ -26,6 +26,7 @@ public sealed class WhenUsingSqsQueueByName(ITestOutputHelper testOutputHelper) 
 
         var queue = new SqsQueueByName(RegionEndpoint.EUWest1,
             "some-queue-name",
+            false,
             _client,
             retryCount,
             LoggerFactory);


### PR DESCRIPTION
This PR makes the following changes:
- Supports the use of MessageGroupId & MessageDeduplicationId on message publishing (via PublishMetadata)
- Supports the use of FIFO Topics & Queues
  - Support added to the non-addressed subscription/publication builders (`WithFifo`)
- Additional Integration tests for FIFO Topics/Queues 

Per discussion in https://github.com/justeattakeaway/JustSaying/issues/911 there was openness to FIFO support being contributed

Notes/Questions : 
 - When using `WithFifo` there is an expectation on the configuration to use the ".fifo" suffix on Queue/Topic names - do we want to force the client knowledge of this, or hide it away and auto-add it?
   - Easy enough to do on the Queue/Topic creation, slightly more complexity to propagate it through to the queue -> handler mappings
- Does not support Content-based deduplication at this time, only based on `MessageDeduplicationId`
- Relies on the SNS/SQS Validation that publishing to a FIFO resource requires the `MessageGroupId`, better to validate pre-publish?
- The method of specifying the MessageGroupId/MessageDeduplicationId on the `PublishBatchMetadata` feels clunky, better alternatives?