### PR TITLE
Update LocalSqsSnsMessaging to 0.6.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
-    <PackageVersion Include="LocalSqsSnsMessaging" Version="0.6.1" />
+    <PackageVersion Include="LocalSqsSnsMessaging" Version="0.6.4" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
     <PackageVersion Include="MELT" Version="0.9.0" />
     <PackageVersion Include="MELT.Xunit" Version="0.9.0" />


### PR DESCRIPTION
This version uses the full AWSSDK client and intercepts at the `HttpMessageHandler` layer.