### PR TITLE
Add extensibility support for custom message sources

### DIFF
--- a/src/JustSaying/Fluent/IPublicationBuilder`1.cs
+++ b/src/JustSaying/Fluent/IPublicationBuilder`1.cs
@@ -10,7 +10,7 @@ namespace JustSaying.Fluent;
 /// <typeparam name="T">
 /// The type of the messages to publish.
 /// </typeparam>
-internal interface IPublicationBuilder<out T>
+public interface IPublicationBuilder<out T>
     where T : Message
 {
     /// <summary>

--- a/src/JustSaying/Fluent/MessagingBusBuilderExtensions.cs
+++ b/src/JustSaying/Fluent/MessagingBusBuilderExtensions.cs
@@ -1,0 +1,95 @@
+namespace JustSaying.Fluent;
+
+/// <summary>
+/// Extension methods for <see cref="MessagingBusBuilder"/> to provide type-safe access to custom properties.
+/// </summary>
+public static class MessagingBusBuilderExtensions
+{
+    /// <summary>
+    /// Gets a property value from the builder's Properties dictionary with type-safe access.
+    /// </summary>
+    /// <typeparam name="T">The type of the property value.</typeparam>
+    /// <param name="builder">The messaging bus builder.</param>
+    /// <param name="key">The property key.</param>
+    /// <returns>The property value if found and of the correct type; otherwise, the default value for the type.</returns>
+    public static T GetProperty<T>(this MessagingBusBuilder builder, string key)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        if (builder.Properties.TryGetValue(key, out var value) && value is T typedValue)
+        {
+            return typedValue;
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Gets a property value from the builder's Properties dictionary with type-safe access.
+    /// </summary>
+    /// <typeparam name="T">The type of the property value.</typeparam>
+    /// <param name="builder">The messaging bus builder.</param>
+    /// <param name="key">The property key.</param>
+    /// <param name="value">When this method returns, contains the property value if found; otherwise, the default value for the type.</param>
+    /// <returns><see langword="true"/> if the property was found and is of the correct type; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetProperty<T>(this MessagingBusBuilder builder, string key, out T value)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        if (builder.Properties.TryGetValue(key, out var objValue) && objValue is T typedValue)
+        {
+            value = typedValue;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Sets a property value in the builder's Properties dictionary with type-safe access.
+    /// </summary>
+    /// <typeparam name="T">The type of the property value.</typeparam>
+    /// <param name="builder">The messaging bus builder.</param>
+    /// <param name="key">The property key.</param>
+    /// <param name="value">The property value to set.</param>
+    /// <returns>The messaging bus builder for method chaining.</returns>
+    public static MessagingBusBuilder SetProperty<T>(this MessagingBusBuilder builder, string key, T value)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        builder.Properties[key] = value;
+        return builder;
+    }
+
+    /// <summary>
+    /// Gets a required property value from the builder's Properties dictionary.
+    /// Throws if the property is not found or is not of the expected type.
+    /// </summary>
+    /// <typeparam name="T">The type of the property value.</typeparam>
+    /// <param name="builder">The messaging bus builder.</param>
+    /// <param name="key">The property key.</param>
+    /// <returns>The property value.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the property is not found or is not of the expected type.</exception>
+    public static T GetRequiredProperty<T>(this MessagingBusBuilder builder, string key)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        if (!builder.Properties.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Required property '{key}' was not found in MessagingBusBuilder.Properties.");
+        }
+
+        if (!(value is T typedValue))
+        {
+            throw new InvalidOperationException(
+                $"Property '{key}' is not of the expected type '{typeof(T).Name}'. Actual type: '{value?.GetType().Name ?? "null"}'.");
+        }
+
+        return typedValue;
+    }
+}

--- a/src/JustSaying/Fluent/PublicationsBuilder.cs
+++ b/src/JustSaying/Fluent/PublicationsBuilder.cs
@@ -25,11 +25,31 @@ public sealed class PublicationsBuilder
     internal MessagingBusBuilder Parent { get; }
 
     /// <summary>
+    /// Gets the parent bus builder for extension configuration.
+    /// </summary>
+    public MessagingBusBuilder BusBuilder => Parent;
+
+    /// <summary>
     /// Gets the configured publication builders.
     /// </summary>
     private List<IPublicationBuilder<Message>> Publications { get; } = [];
 
     private readonly List<Func<IServiceResolver, MiddlewareBase<PublishContext, bool>>> _publishMiddlewareFactories = [];
+
+    /// <summary>
+    /// Adds a custom publication builder to the list of publications.
+    /// This method is useful for extension libraries that want to add support for additional messaging systems.
+    /// </summary>
+    /// <param name="publicationBuilder">The publication builder to add.</param>
+    /// <returns>The current <see cref="PublicationsBuilder"/>.</returns>
+    public PublicationsBuilder WithCustomPublication(IPublicationBuilder<Message> publicationBuilder)
+    {
+        if (publicationBuilder == null) throw new ArgumentNullException(nameof(publicationBuilder));
+        
+        Publications.Add(publicationBuilder);
+        
+        return this;
+    }
 
     /// <summary>
     /// Configures a publisher for a queue.

--- a/src/JustSaying/Fluent/SubscriptionsBuilder.cs
+++ b/src/JustSaying/Fluent/SubscriptionsBuilder.cs
@@ -26,12 +26,32 @@ public sealed class SubscriptionsBuilder
     /// </summary>
     internal MessagingBusBuilder Parent { get; }
 
+    /// <summary>
+    /// Gets the parent bus builder for extension configuration.
+    /// </summary>
+    public MessagingBusBuilder BusBuilder => Parent;
+
     internal SubscriptionGroupSettingsBuilder Defaults = new();
 
     /// <summary>
     /// Gets the configured subscription builders.
     /// </summary>
     private List<ISubscriptionBuilder<Message>> Subscriptions { get; } = [];
+
+    /// <summary>
+    /// Adds a custom subscription builder to the list of subscriptions.
+    /// This method is useful for extension libraries that want to add support for additional messaging systems.
+    /// </summary>
+    /// <param name="subscriptionBuilder">The subscription builder to add.</param>
+    /// <returns>The current <see cref="SubscriptionsBuilder"/>.</returns>
+    public SubscriptionsBuilder WithCustomSubscription(ISubscriptionBuilder<Message> subscriptionBuilder)
+    {
+        if (subscriptionBuilder == null) throw new ArgumentNullException(nameof(subscriptionBuilder));
+        
+        Subscriptions.Add(subscriptionBuilder);
+        
+        return this;
+    }
 
     private Dictionary<string, SubscriptionGroupConfigBuilder> SubscriptionGroupSettings { get; } = new();
 

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -24,6 +24,7 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IMessageBa
     private readonly SemaphoreSlim _startLock = new(1, 1);
     private bool _busStarted;
     private readonly List<Func<CancellationToken, Task>> _startupTasks;
+    private readonly List<Func<CancellationToken, Task>> _customConsumers;
 
     private ConcurrentDictionary<string, SubscriptionGroupConfigBuilder> _subscriptionGroupSettings;
     private SubscriptionGroupSettingsBuilder _defaultSubscriptionGroupSettings;
@@ -43,7 +44,10 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IMessageBa
     internal MiddlewareMap MiddlewareMap { get; }
     internal PublishMessageMiddleware PublishMiddleware { get; set; }
     internal MessageCompressionRegistry CompressionRegistry { get; }
-    internal IMessageBodySerializationFactory MessageBodySerializerFactory { get; set; }
+    /// <summary>
+    /// Gets the message body serialization factory used by this bus.
+    /// </summary>
+    public IMessageBodySerializationFactory MessageBodySerializerFactory { get; set; }
 
     public Task Completion { get; private set; }
 
@@ -68,6 +72,7 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IMessageBa
         _monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
 
         _startupTasks = [];
+        _customConsumers = [];
         _log = _loggerFactory.CreateLogger("JustSaying");
         _messageReceivePauseSignal = messageReceivePauseSignal;
 
@@ -128,6 +133,25 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IMessageBa
     internal void AddStartupTask(Func<CancellationToken, Task> task)
     {
         _startupTasks.Add(task);
+    }
+
+    /// <summary>
+    /// Adds a custom consumer task that will run alongside the standard SQS subscription groups.
+    /// This allows extending JustSaying to support additional messaging transports.
+    /// </summary>
+    /// <param name="consumerTask">A function that starts the consumer and returns a task that completes when the consumer stops.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="consumerTask"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the bus has already been started.</exception>
+    public void AddCustomConsumer(Func<CancellationToken, Task> consumerTask)
+    {
+        if (consumerTask == null) throw new ArgumentNullException(nameof(consumerTask));
+
+        if (_busStarted)
+        {
+            throw new InvalidOperationException("Cannot add custom consumers after the bus has been started.");
+        }
+
+        _customConsumers.Add(consumerTask);
     }
 
     public void SetGroupSettings(
@@ -234,6 +258,23 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IMessageBa
 
         _log.LogInformation("Starting bus with settings: {@Response}", SubscriptionGroups.Interrogate());
 
+        var tasks = new List<Task>(_customConsumers.Count + 1);
+
+        // Add the standard SQS subscription groups task
+        tasks.Add(RunSubscriptionGroupsAsync(stoppingToken));
+
+        // Add custom consumer tasks
+        foreach (var customConsumer in _customConsumers)
+        {
+            tasks.Add(RunCustomConsumerAsync(customConsumer, stoppingToken));
+        }
+
+        // Wait for all tasks to complete
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private async Task RunSubscriptionGroupsAsync(CancellationToken stoppingToken)
+    {
         try
         {
             await SubscriptionGroups.RunAsync(stoppingToken).ConfigureAwait(false);
@@ -243,7 +284,26 @@ public sealed class JustSayingBus : IMessagingBus, IMessagePublisher, IMessageBa
             _log.LogDebug(
                 "Suppressed an exception of type {ExceptionType} which likely means the bus is shutting down.",
                 nameof(OperationCanceledException));
-            // Don't bubble cancellation up to Completion task
+        }
+    }
+
+    private async Task RunCustomConsumerAsync(Func<CancellationToken, Task> customConsumer, CancellationToken stoppingToken)
+    {
+        try
+        {
+            await customConsumer(stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _log.LogDebug(
+                "Suppressed an exception of type {ExceptionType} from custom consumer which likely means the bus is shutting down.",
+                nameof(OperationCanceledException));
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(
+                ex,
+                "Custom consumer threw an unhandled exception. The consumer has stopped.");
         }
     }
 

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/IMessageSource.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/IMessageSource.cs
@@ -1,0 +1,13 @@
+namespace JustSaying.Messaging.Channels.SubscriptionGroups;
+
+/// <summary>
+/// Represents a message source that can be consumed by a subscription group.
+/// This abstraction allows supporting multiple messaging transports.
+/// </summary>
+public interface IMessageSource
+{
+    /// <summary>
+    /// Gets the name/identifier of this message source (queue name, topic name, etc.)
+    /// </summary>
+    string Name { get; }
+}

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SqsSource.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SqsSource.cs
@@ -1,9 +1,12 @@
 using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging;
 
 namespace JustSaying.Messaging.Channels.SubscriptionGroups;
 
-public sealed class SqsSource
+public sealed class SqsSource : IMessageSource
 {
     public ISqsQueue SqsQueue { get; set; }
     public IInboundMessageConverter MessageConverter { get; set; }
+    
+    string IMessageSource.Name => SqsQueue?.QueueName ?? string.Empty;
 }

--- a/src/JustSaying/MessagingBusBuilder.cs
+++ b/src/JustSaying/MessagingBusBuilder.cs
@@ -34,7 +34,7 @@ public sealed class MessagingBusBuilder
     /// <summary>
     /// Gets or sets the builder to use to configure messaging.
     /// </summary>
-    internal MessagingConfigurationBuilder MessagingConfig { get; set; }
+    public MessagingConfigurationBuilder MessagingConfig { get; set; }
 
     /// <summary>
     /// Gets or sets the builder to use for publications.
@@ -51,6 +51,11 @@ public sealed class MessagingBusBuilder
     /// so that services can be obtained in a consistent way
     /// </summary>
     private ServiceBuilderServiceResolver ServiceBuilderServiceResolver { get; set; }
+
+    /// <summary>
+    /// Gets a dictionary for storing custom properties that can be used by extensions.
+    /// </summary>
+    public Dictionary<string, object> Properties { get; } = new Dictionary<string, object>();
 
     public MessagingBusBuilder()
     {

--- a/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
@@ -222,3 +222,22 @@ static JustSaying.Messaging.MessageSerialization.SystemTextJsonMessageBodySerial
 *REMOVED*JustSaying.Messaging.MessageSerialization.SystemTextJsonSerializationFactory.SystemTextJsonSerializationFactory() -> void
 *REMOVED*override JustSaying.AwsTools.QueueCreation.RedrivePolicy.ToString() -> string
 *REMOVED*static JustSaying.AwsTools.QueueCreation.RedrivePolicy.ConvertFromString(string policy) -> JustSaying.AwsTools.QueueCreation.RedrivePolicy
+JustSaying.Fluent.IPublicationBuilder<T>
+JustSaying.Fluent.IPublicationBuilder<T>.Configure(JustSaying.JustSayingBus bus, JustSaying.AwsTools.IAwsClientFactoryProxy proxy, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, JustSaying.Fluent.IServiceResolver serviceResolver) -> void
+JustSaying.Fluent.PublicationsBuilder.WithCustomPublication(JustSaying.Fluent.IPublicationBuilder<JustSaying.Models.Message> publicationBuilder) -> JustSaying.Fluent.PublicationsBuilder
+JustSaying.Fluent.SubscriptionsBuilder.WithCustomSubscription(JustSaying.Fluent.ISubscriptionBuilder<JustSaying.Models.Message> subscriptionBuilder) -> JustSaying.Fluent.SubscriptionsBuilder
+JustSaying.JustSayingBus.AddCustomConsumer(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> consumerTask) -> void
+JustSaying.Messaging.Channels.SubscriptionGroups.IMessageSource
+JustSaying.Messaging.Channels.SubscriptionGroups.IMessageSource.Name.get -> string
+JustSaying.JustSayingBus.MessageBodySerializerFactory.get -> JustSaying.Messaging.MessageSerialization.IMessageBodySerializationFactory
+JustSaying.JustSayingBus.MessageBodySerializerFactory.set -> void
+JustSaying.Fluent.PublicationsBuilder.BusBuilder.get -> JustSaying.MessagingBusBuilder
+JustSaying.Fluent.SubscriptionsBuilder.BusBuilder.get -> JustSaying.MessagingBusBuilder
+JustSaying.MessagingBusBuilder.MessagingConfig.get -> JustSaying.Fluent.MessagingConfigurationBuilder
+JustSaying.MessagingBusBuilder.MessagingConfig.set -> void
+JustSaying.MessagingBusBuilder.Properties.get -> System.Collections.Generic.Dictionary<string, object>
+JustSaying.Fluent.MessagingBusBuilderExtensions
+static JustSaying.Fluent.MessagingBusBuilderExtensions.GetProperty<T>(this JustSaying.MessagingBusBuilder builder, string key) -> T
+static JustSaying.Fluent.MessagingBusBuilderExtensions.TryGetProperty<T>(this JustSaying.MessagingBusBuilder builder, string key, out T value) -> bool
+static JustSaying.Fluent.MessagingBusBuilderExtensions.SetProperty<T>(this JustSaying.MessagingBusBuilder builder, string key, T value) -> JustSaying.MessagingBusBuilder
+static JustSaying.Fluent.MessagingBusBuilderExtensions.GetRequiredProperty<T>(this JustSaying.MessagingBusBuilder builder, string key) -> T

--- a/src/JustSaying/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/JustSaying/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,5 @@
+JustSaying.AwsTools.MessageHandling.PublishBatchException.PublishBatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.AwsTools.MessageHandling.PublishException.PublishException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.AwsTools.QueueCreation.ConfigurationErrorsException.ConfigurationErrorsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.HandlerNotRegisteredWithContainerException.HandlerNotRegisteredWithContainerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.Messaging.MessageSerialization.MessageFormatNotSupportedException.MessageFormatNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/JustSaying/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-JustSaying.AwsTools.MessageHandling.PublishException.PublishException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.AwsTools.QueueCreation.ConfigurationErrorsException.ConfigurationErrorsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.HandlerNotRegisteredWithContainerException.HandlerNotRegisteredWithContainerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.Messaging.MessageSerialization.MessageFormatNotSupportedException.MessageFormatNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.AwsTools.MessageHandling.PublishBatchException.PublishBatchException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/JustSaying/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/JustSaying/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,0 +1,4 @@
+JustSaying.AwsTools.MessageHandling.PublishException.PublishException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.AwsTools.QueueCreation.ConfigurationErrorsException.ConfigurationErrorsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.HandlerNotRegisteredWithContainerException.HandlerNotRegisteredWithContainerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+JustSaying.Messaging.MessageSerialization.MessageFormatNotSupportedException.MessageFormatNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/src/JustSaying/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-JustSaying.AwsTools.MessageHandling.PublishException.PublishException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.AwsTools.QueueCreation.ConfigurationErrorsException.ConfigurationErrorsException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.HandlerNotRegisteredWithContainerException.HandlerNotRegisteredWithContainerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-JustSaying.Messaging.MessageSerialization.MessageFormatNotSupportedException.MessageFormatNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/tests/JustSaying.UnitTests/Fluent/WhenUsingMessagingBusBuilder.cs
+++ b/tests/JustSaying.UnitTests/Fluent/WhenUsingMessagingBusBuilder.cs
@@ -1,0 +1,408 @@
+using JustSaying.Fluent;
+using JustSaying.TestingFramework;
+
+namespace JustSaying.UnitTests.Fluent;
+
+public class WhenUsingMessagingBusBuilder
+{
+    private readonly MessagingBusBuilder _sut;
+
+    public WhenUsingMessagingBusBuilder()
+    {
+        _sut = new MessagingBusBuilder();
+    }
+
+    [Test]
+    public void ThenPropertiesDictionaryIsInitialized()
+    {
+        // Assert
+        _sut.Properties.ShouldNotBeNull();
+        _sut.Properties.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void ThenPropertiesDictionaryCanStoreValues()
+    {
+        // Act
+        _sut.Properties["key1"] = "value1";
+        _sut.Properties["key2"] = 42;
+
+        // Assert
+        _sut.Properties.ShouldContainKey("key1");
+        _sut.Properties.ShouldContainKey("key2");
+        _sut.Properties["key1"].ShouldBe("value1");
+        _sut.Properties["key2"].ShouldBe(42);
+    }
+
+    [Test]
+    public void ThenMessagingConfigIsAccessible()
+    {
+        // Assert
+        _sut.MessagingConfig.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void ThenMessagingConfigCanBeSet()
+    {
+        // Arrange
+        var newConfig = new MessagingConfigurationBuilder(_sut);
+
+        // Act
+        _sut.MessagingConfig = newConfig;
+
+        // Assert
+        _sut.MessagingConfig.ShouldBe(newConfig);
+    }
+
+    [Test]
+    public void ThenClientConfigurationThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.Client(null));
+    }
+
+    [Test]
+    public void ThenClientConfigurationReturnsBuilder()
+    {
+        // Act
+        var result = _sut.Client(c => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenMessagingConfigurationThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.Messaging(null));
+    }
+
+    [Test]
+    public void ThenMessagingConfigurationReturnsBuilder()
+    {
+        // Act
+        var result = _sut.Messaging(m => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenPublicationsConfigurationThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.Publications(null));
+    }
+
+    [Test]
+    public void ThenPublicationsConfigurationReturnsBuilder()
+    {
+        // Act
+        var result = _sut.Publications(p => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenServicesConfigurationThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.Services(null));
+    }
+
+    [Test]
+    public void ThenServicesConfigurationReturnsBuilder()
+    {
+        // Act
+        var result = _sut.Services(s => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenSubscriptionsConfigurationThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.Subscriptions(null));
+    }
+
+    [Test]
+    public void ThenSubscriptionsConfigurationReturnsBuilder()
+    {
+        // Act
+        var result = _sut.Subscriptions(s => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithServiceResolverThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithServiceResolver(null));
+    }
+
+    [Test]
+    public void ThenWithServiceResolverReturnsBuilder()
+    {
+        // Arrange
+        var resolver = NSubstitute.Substitute.For<IServiceResolver>();
+
+        // Act
+        var result = _sut.WithServiceResolver(resolver);
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenMultipleConfigurationCallsCanBeChained()
+    {
+        // Act
+        var result = _sut
+            .Messaging(m => m.WithRegion("us-east-1"))
+            .Publications(p => { })
+            .Subscriptions(s => { })
+            .Services(s => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenPropertiesCanBeUsedForExtensions()
+    {
+        // Arrange
+        var customConfig = new { ConnectionString = "localhost:9092" };
+
+        // Act
+        _sut.Properties["CustomMessagingConfig"] = customConfig;
+
+        // Assert
+        _sut.Properties["CustomMessagingConfig"].ShouldBe(customConfig);
+    }
+
+    [Test]
+    public void ThenGetPropertyReturnsValueWhenExists()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = "TestValue";
+
+        // Act
+        var result = _sut.GetProperty<string>("TestKey");
+
+        // Assert
+        result.ShouldBe("TestValue");
+    }
+
+    [Test]
+    public void ThenGetPropertyReturnsDefaultWhenKeyNotFound()
+    {
+        // Act
+        var result = _sut.GetProperty<string>("NonExistentKey");
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public void ThenGetPropertyReturnsDefaultWhenTypeMismatch()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = 42;
+
+        // Act
+        var result = _sut.GetProperty<string>("TestKey");
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public void ThenTryGetPropertyReturnsTrueWhenExists()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = "TestValue";
+
+        // Act
+        var success = _sut.TryGetProperty<string>("TestKey", out var value);
+
+        // Assert
+        success.ShouldBeTrue();
+        value.ShouldBe("TestValue");
+    }
+
+    [Test]
+    public void ThenTryGetPropertyReturnsFalseWhenKeyNotFound()
+    {
+        // Act
+        var success = _sut.TryGetProperty<string>("NonExistentKey", out var value);
+
+        // Assert
+        success.ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    [Test]
+    public void ThenTryGetPropertyReturnsFalseWhenTypeMismatch()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = 42;
+
+        // Act
+        var success = _sut.TryGetProperty<string>("TestKey", out var value);
+
+        // Assert
+        success.ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    [Test]
+    public void ThenSetPropertySetsValueAndReturnsBuilder()
+    {
+        // Act
+        var result = _sut.SetProperty("TestKey", "TestValue");
+
+        // Assert
+        result.ShouldBe(_sut);
+        _sut.Properties["TestKey"].ShouldBe("TestValue");
+    }
+
+    [Test]
+    public void ThenSetPropertyOverwritesExistingValue()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = "OldValue";
+
+        // Act
+        _sut.SetProperty("TestKey", "NewValue");
+
+        // Assert
+        _sut.Properties["TestKey"].ShouldBe("NewValue");
+    }
+
+    [Test]
+    public void ThenGetRequiredPropertyReturnsValueWhenExists()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = "TestValue";
+
+        // Act
+        var result = _sut.GetRequiredProperty<string>("TestKey");
+
+        // Assert
+        result.ShouldBe("TestValue");
+    }
+
+    [Test]
+    public void ThenGetRequiredPropertyThrowsWhenKeyNotFound()
+    {
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() =>
+            _sut.GetRequiredProperty<string>("NonExistentKey"));
+
+        exception.Message.ShouldContain("NonExistentKey");
+        exception.Message.ShouldContain("was not found");
+    }
+
+    [Test]
+    public void ThenGetRequiredPropertyThrowsWhenTypeMismatch()
+    {
+        // Arrange
+        _sut.Properties["TestKey"] = 42;
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() =>
+            _sut.GetRequiredProperty<string>("TestKey"));
+
+        exception.Message.ShouldContain("TestKey");
+        exception.Message.ShouldContain("String");
+    }
+
+    [Test]
+    public void ThenExtensionMethodsCanBeChained()
+    {
+        // Act
+        var result = _sut
+            .SetProperty("Key1", "Value1")
+            .SetProperty("Key2", 42)
+            .Messaging(m => m.WithRegion("us-east-1"));
+
+        // Assert
+        result.ShouldBe(_sut);
+        _sut.GetProperty<string>("Key1").ShouldBe("Value1");
+        _sut.GetProperty<int>("Key2").ShouldBe(42);
+    }
+
+    [Test]
+    public void ThenGetPropertyThrowsWhenBuilderIsNull()
+    {
+        // Arrange
+        MessagingBusBuilder builder = null;
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => builder.GetProperty<string>("key"));
+    }
+
+    [Test]
+    public void ThenGetPropertyThrowsWhenKeyIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.GetProperty<string>(null));
+    }
+
+    [Test]
+    public void ThenTryGetPropertyThrowsWhenBuilderIsNull()
+    {
+        // Arrange
+        MessagingBusBuilder builder = null;
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => builder.TryGetProperty<string>("key", out _));
+    }
+
+    [Test]
+    public void ThenTryGetPropertyThrowsWhenKeyIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.TryGetProperty<string>(null, out _));
+    }
+
+    [Test]
+    public void ThenSetPropertyThrowsWhenBuilderIsNull()
+    {
+        // Arrange
+        MessagingBusBuilder builder = null;
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => builder.SetProperty("key", "value"));
+    }
+
+    [Test]
+    public void ThenSetPropertyThrowsWhenKeyIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.SetProperty<string>(null, "value"));
+    }
+
+    [Test]
+    public void ThenGetRequiredPropertyThrowsWhenBuilderIsNull()
+    {
+        // Arrange
+        MessagingBusBuilder builder = null;
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => builder.GetRequiredProperty<string>("key"));
+    }
+
+    [Test]
+    public void ThenGetRequiredPropertyThrowsWhenKeyIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.GetRequiredProperty<string>(null));
+    }
+}

--- a/tests/JustSaying.UnitTests/Fluent/WhenUsingPublicationsBuilder.cs
+++ b/tests/JustSaying.UnitTests/Fluent/WhenUsingPublicationsBuilder.cs
@@ -1,0 +1,181 @@
+using JustSaying.Fluent;
+using JustSaying.Models;
+using JustSaying.TestingFramework;
+using NSubstitute;
+
+namespace JustSaying.UnitTests.Fluent;
+
+public class WhenUsingPublicationsBuilder
+{
+    private readonly MessagingBusBuilder _parentBuilder;
+    private readonly PublicationsBuilder _sut;
+
+    public WhenUsingPublicationsBuilder()
+    {
+        _parentBuilder = new MessagingBusBuilder();
+        _sut = new PublicationsBuilder(_parentBuilder);
+    }
+
+    [Test]
+    public void ThenBusBuilderPropertyReturnsParent()
+    {
+        // Assert
+        _sut.BusBuilder.ShouldBe(_parentBuilder);
+    }
+
+    [Test]
+    public void ThenWithCustomPublicationAddsPublisher()
+    {
+        // Arrange
+        var customPublisher = Substitute.For<IPublicationBuilder<Message>>();
+
+        // Act
+        var result = _sut.WithCustomPublication(customPublisher);
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithCustomPublicationThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithCustomPublication(null));
+    }
+
+    [Test]
+    public void ThenWithQueueReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithQueue<TestMessage>();
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithQueueWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithQueue<TestMessage>(q => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithQueueThrowsWhenConfigureIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithQueue<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenWithQueueArnReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithQueueArn<TestMessage>("arn:aws:sqs:us-east-1:123456789012:test-queue");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithQueueArnThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithQueueArn<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenWithQueueUrlReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithQueueUrl<TestMessage>("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithQueueUrlThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithQueueUrl<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenWithQueueUriReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithQueueUri<TestMessage>(new Uri("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"));
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithQueueUriThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithQueueUri<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenWithTopicReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithTopic<TestMessage>();
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithTopicWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithTopic<TestMessage>(t => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithTopicThrowsWhenConfigureIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithTopic<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenWithTopicArnReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithTopicArn<TestMessage>("arn:aws:sns:us-east-1:123456789012:test-topic");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithTopicArnThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithTopicArn<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenWithTopicArnWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.WithTopicArn<TestMessage>("arn:aws:sns:us-east-1:123456789012:test-topic", t => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    private class TestMessage : Message
+    {
+    }
+}

--- a/tests/JustSaying.UnitTests/Fluent/WhenUsingSubscriptionsBuilder.cs
+++ b/tests/JustSaying.UnitTests/Fluent/WhenUsingSubscriptionsBuilder.cs
@@ -1,0 +1,308 @@
+using JustSaying.Fluent;
+using JustSaying.Models;
+using JustSaying.TestingFramework;
+using NSubstitute;
+
+namespace JustSaying.UnitTests.Fluent;
+
+public class WhenUsingSubscriptionsBuilder
+{
+    private readonly MessagingBusBuilder _parentBuilder;
+    private readonly SubscriptionsBuilder _sut;
+
+    public WhenUsingSubscriptionsBuilder()
+    {
+        _parentBuilder = new MessagingBusBuilder();
+        _sut = new SubscriptionsBuilder(_parentBuilder);
+    }
+
+    [Test]
+    public void ThenBusBuilderPropertyReturnsParent()
+    {
+        // Assert
+        _sut.BusBuilder.ShouldBe(_parentBuilder);
+    }
+
+    [Test]
+    public void ThenWithCustomSubscriptionAddsSubscriber()
+    {
+        // Arrange
+        var customSubscriber = Substitute.For<ISubscriptionBuilder<Message>>();
+
+        // Act
+        var result = _sut.WithCustomSubscription(customSubscriber);
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenWithCustomSubscriptionThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithCustomSubscription(null));
+    }
+
+    [Test]
+    public void ThenWithDefaultsConfiguresDefaultSettings()
+    {
+        // Arrange
+        var configured = false;
+
+        // Act
+        var result = _sut.WithDefaults(d =>
+        {
+            configured = true;
+            d.WithDefaultConcurrencyLimit(10);
+        });
+
+        // Assert
+        result.ShouldBe(_sut);
+        configured.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ThenWithDefaultsThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithDefaults(null));
+    }
+
+    [Test]
+    public void ThenForQueueReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueue<TestMessage>();
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueue<TestMessage>(q => q.WithQueueName("test-queue"));
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueThrowsWhenConfigureIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForQueue<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenForQueueArnReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueArn<TestMessage>("arn:aws:sqs:us-east-1:123456789012:test-queue");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueArnThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForQueueArn<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenForQueueArnWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueArn<TestMessage>("arn:aws:sqs:us-east-1:123456789012:test-queue", q => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueUrlReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueUrl<TestMessage>("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueUrlThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForQueueUrl<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenForQueueUrlWithRegionReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueUrl<TestMessage>("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue", "us-east-1");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueUrlWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueUrl<TestMessage>("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue", null, q => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueUriReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueUri<TestMessage>(new Uri("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"));
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueUriThrowsWhenNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForQueueUri<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenForQueueUriWithRegionReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueUri<TestMessage>(new Uri("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"), "us-east-1");
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForQueueUriWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForQueueUri<TestMessage>(new Uri("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"), null, q => { });
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForTopicReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForTopic<TestMessage>();
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForTopicWithConfigureReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForTopic<TestMessage>(t => t.WithQueueName("test-queue"));
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForTopicThrowsWhenConfigureIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForTopic<TestMessage>(null));
+    }
+
+    [Test]
+    public void ThenForTopicWithNameReturnsBuilder()
+    {
+        // Act
+        var result = _sut.ForTopic<TestMessage>("custom-topic", t => t.WithQueueName("test-queue"));
+
+        // Assert
+        result.ShouldBe(_sut);
+    }
+
+    [Test]
+    public void ThenForTopicWithNameThrowsWhenConfigureIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForTopic<TestMessage>("custom-topic", null));
+    }
+
+    [Test]
+    public void ThenForTopicWithNameThrowsWhenTopicNameIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.ForTopic<TestMessage>(null, t => { }));
+    }
+
+    [Test]
+    public void ThenWithSubscriptionGroupAddsOrUpdatesGroup()
+    {
+        // Arrange
+        var configured = false;
+
+        // Act
+        var result = _sut.WithSubscriptionGroup("test-group", g =>
+        {
+            configured = true;
+            g.WithConcurrencyLimit(5);
+        });
+
+        // Assert
+        result.ShouldBe(_sut);
+        configured.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ThenWithSubscriptionGroupThrowsWhenGroupNameIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => _sut.WithSubscriptionGroup(null, g => { }));
+    }
+
+    [Test]
+    public void ThenWithSubscriptionGroupThrowsWhenGroupNameIsEmpty()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => _sut.WithSubscriptionGroup("", g => { }));
+    }
+
+    [Test]
+    public void ThenWithSubscriptionGroupThrowsWhenActionIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => _sut.WithSubscriptionGroup("test-group", null));
+    }
+
+    [Test]
+    public void ThenWithSubscriptionGroupCanUpdateExistingGroup()
+    {
+        // Arrange
+        var firstCallCount = 0;
+        var secondCallCount = 0;
+
+        // Act
+        _sut.WithSubscriptionGroup("test-group", g => { firstCallCount++; });
+        _sut.WithSubscriptionGroup("test-group", g => { secondCallCount++; });
+
+        // Assert
+        firstCallCount.ShouldBe(1);
+        secondCallCount.ShouldBe(1);
+    }
+
+    private class TestMessage : Message
+    {
+    }
+}

--- a/tests/JustSaying.UnitTests/JustSayingBus/WhenAddingCustomConsumers.cs
+++ b/tests/JustSaying.UnitTests/JustSayingBus/WhenAddingCustomConsumers.cs
@@ -1,0 +1,215 @@
+using JustSaying.Messaging.Channels.Receive;
+using JustSaying.Messaging.Channels.SubscriptionGroups;
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+
+namespace JustSaying.UnitTests.JustSayingBus;
+
+public class WhenAddingCustomConsumers : GivenAServiceBus
+{
+    private bool _customConsumerCalled;
+    private int _customConsumerCallCount;
+
+    protected override Task WhenAsync()
+    {
+        // Arrange
+        _customConsumerCalled = false;
+        _customConsumerCallCount = 0;
+
+        // Act
+        SystemUnderTest.AddCustomConsumer(async (cancellationToken) =>
+        {
+            _customConsumerCalled = true;
+            _customConsumerCallCount++;
+            await Task.CompletedTask;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ThenCustomConsumerRunsWhenBusStarts()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        // Act
+        await SystemUnderTest.StartAsync(cts.Token);
+        await Task.Delay(100, cts.Token); // Give custom consumer time to execute
+
+        // Assert
+        _customConsumerCalled.ShouldBeTrue();
+        _customConsumerCallCount.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public void ThenThrowsArgumentNullExceptionWhenConsumerTaskIsNull()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => SystemUnderTest.AddCustomConsumer(null));
+    }
+}
+
+public class WhenAddingMultipleCustomConsumers : GivenAServiceBus
+{
+    private int _consumer1CallCount;
+    private int _consumer2CallCount;
+
+    protected override Task WhenAsync()
+    {
+        _consumer1CallCount = 0;
+        _consumer2CallCount = 0;
+
+        SystemUnderTest.AddCustomConsumer(async (cancellationToken) =>
+        {
+            _consumer1CallCount++;
+            await Task.CompletedTask;
+        });
+
+        SystemUnderTest.AddCustomConsumer(async (cancellationToken) =>
+        {
+            _consumer2CallCount++;
+            await Task.CompletedTask;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ThenAllCustomConsumersRun()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        // Act
+        await SystemUnderTest.StartAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        // Assert
+        _consumer1CallCount.ShouldBeGreaterThanOrEqualTo(1);
+        _consumer2CallCount.ShouldBeGreaterThanOrEqualTo(1);
+    }
+}
+
+public class WhenAccessingMessageBodySerializerFactory : GivenAServiceBus
+{
+    protected override Task WhenAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public void ThenMessageBodySerializerFactoryIsAccessible()
+    {
+        // Assert
+        SystemUnderTest.MessageBodySerializerFactory.ShouldNotBeNull();
+        SystemUnderTest.MessageBodySerializerFactory.ShouldBeOfType<NewtonsoftSerializationFactory>();
+    }
+
+    [Test]
+    public void ThenMessageBodySerializerFactoryCanBeSet()
+    {
+        // Arrange
+        var newFactory = new NewtonsoftSerializationFactory();
+
+        // Act
+        SystemUnderTest.MessageBodySerializerFactory = newFactory;
+
+        // Assert
+        SystemUnderTest.MessageBodySerializerFactory.ShouldBe(newFactory);
+    }
+}
+
+public class WhenCustomConsumerThrowsOperationCanceledException : GivenAServiceBus
+{
+    private bool _consumerStarted;
+
+    protected override Task WhenAsync()
+    {
+        _consumerStarted = false;
+
+        SystemUnderTest.AddCustomConsumer((cancellationToken) =>
+        {
+            _consumerStarted = true;
+            throw new OperationCanceledException();
+        });
+
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ThenExceptionIsSuppressed()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        // Act & Assert - Should not throw
+        await SystemUnderTest.StartAsync(cts.Token);
+        await Task.Delay(100, cts.Token);
+
+        _consumerStarted.ShouldBeTrue();
+    }
+}
+
+public class WhenCustomConsumerThrowsGeneralException : GivenAServiceBus
+{
+    private bool _consumerStarted;
+    private bool _otherConsumerCompleted;
+
+    protected override Task WhenAsync()
+    {
+        _consumerStarted = false;
+        _otherConsumerCompleted = false;
+
+        // Add a consumer that throws a general exception
+        SystemUnderTest.AddCustomConsumer((cancellationToken) =>
+        {
+            _consumerStarted = true;
+            throw new InvalidOperationException("Test exception from custom consumer");
+        });
+
+        // Add another consumer to verify the bus continues running
+        SystemUnderTest.AddCustomConsumer(async (cancellationToken) =>
+        {
+            await Task.Delay(50, cancellationToken);
+            _otherConsumerCompleted = true;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ThenExceptionIsSuppressedAndOtherConsumersContinue()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+
+        // Act & Assert - Should not throw
+        await SystemUnderTest.StartAsync(cts.Token);
+        await Task.Delay(200, cts.Token);
+
+        _consumerStarted.ShouldBeTrue();
+        _otherConsumerCompleted.ShouldBeTrue();
+    }
+}
+
+public class WhenAddingCustomConsumerAfterBusStarted : GivenAServiceBus
+{
+    protected override Task WhenAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ThenThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        await SystemUnderTest.StartAsync(cts.Token);
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() =>
+            SystemUnderTest.AddCustomConsumer(async (ct) => await Task.CompletedTask))
+            .Message.ShouldContain("Cannot add custom consumers after the bus has been started");
+    }
+}

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroups/WhenUsingSqsSource.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroups/WhenUsingSqsSource.cs
@@ -1,0 +1,94 @@
+using JustSaying.AwsTools.MessageHandling;
+using JustSaying.Messaging;
+using JustSaying.Messaging.Channels.SubscriptionGroups;
+using JustSaying.TestingFramework;
+using NSubstitute;
+
+namespace JustSaying.UnitTests.Messaging.Channels.SubscriptionGroups;
+
+public class WhenUsingSqsSource
+{
+    [Test]
+    public void ThenSqsQueueCanBeSet()
+    {
+        // Arrange
+        var sut = new SqsSource();
+        var queue = Substitute.For<ISqsQueue>();
+        queue.QueueName.Returns("test-queue");
+
+        // Act
+        sut.SqsQueue = queue;
+
+        // Assert
+        sut.SqsQueue.ShouldBe(queue);
+    }
+
+    [Test]
+    public void ThenMessageConverterCanBeSet()
+    {
+        // Arrange
+        var sut = new SqsSource();
+        var converter = Substitute.For<IInboundMessageConverter>();
+
+        // Act
+        sut.MessageConverter = converter;
+
+        // Assert
+        sut.MessageConverter.ShouldBe(converter);
+    }
+
+    [Test]
+    public void ThenNameReturnsQueueName()
+    {
+        // Arrange
+        var sut = new SqsSource();
+        var queue = Substitute.For<ISqsQueue>();
+        queue.QueueName.Returns("my-test-queue");
+        sut.SqsQueue = queue;
+
+        // Act
+        var name = ((IMessageSource)sut).Name;
+
+        // Assert
+        name.ShouldBe("my-test-queue");
+    }
+
+    [Test]
+    public void ThenNameReturnsEmptyStringWhenQueueIsNull()
+    {
+        // Arrange
+        var sut = new SqsSource();
+
+        // Act
+        var name = ((IMessageSource)sut).Name;
+
+        // Assert
+        name.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public void ThenNameReturnsEmptyStringWhenQueueNameIsNull()
+    {
+        // Arrange
+        var sut = new SqsSource();
+        var queue = Substitute.For<ISqsQueue>();
+        queue.QueueName.Returns((string)null);
+        sut.SqsQueue = queue;
+
+        // Act
+        var name = ((IMessageSource)sut).Name;
+
+        // Assert
+        name.ShouldBe(string.Empty);
+    }
+
+    [Test]
+    public void ThenImplementsIMessageSource()
+    {
+        // Arrange
+        var sut = new SqsSource();
+
+        // Assert
+        sut.ShouldBeAssignableTo<IMessageSource>();
+    }
+}


### PR DESCRIPTION
This adds infrastructure changes to JustSaying core to support pluggable message sources beyond SQS:

Core changes:
- Add IMessageSource interface for custom source implementations
- Refactor SqsSource to implement IMessageSource
- Add AddCustomConsumer() method to JustSayingBus for custom transports
- Add extension points in fluent builders (WithCustomPublication/WithCustomSubscription)
- Expose MessagingBusBuilder.Properties dictionary for extension configuration
- Add type-safe extension methods (GetProperty, SetProperty, GetRequiredProperty)

Safety improvements:
- Add exception handling for general exceptions in custom consumers
- Add thread-safety guard preventing consumer registration after bus start
- Refactor RunImplAsync to use dedicated async methods instead of Task.Run

Tests:
- Add comprehensive unit tests for new extensibility features
- Add tests for custom consumer exception handling and lifecycle

These changes enable extensions to be added as separate packages while maintaining backward compatibility with existing SQS/SNS functionality.