### PR TITLE
Fix default enum serialization to use strings instead of numbers

### DIFF
--- a/src/JustSaying/Messaging/MessageSerialization/NewtonsoftMessageBodySerializer`1.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/NewtonsoftMessageBodySerializer`1.cs
@@ -36,7 +36,11 @@ public sealed class NewtonsoftMessageBodySerializer<T> : IMessageBodySerializer 
     /// <param name="settings">The custom <see cref="JsonSerializerSettings"/> to use for serialization and deserialization.</param>
     public NewtonsoftMessageBodySerializer(JsonSerializerSettings settings)
     {
-        _settings = settings;
+        _settings = settings ?? new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            Converters = [new Newtonsoft.Json.Converters.StringEnumConverter()]
+        };
     }
 
     /// <summary>

--- a/tests/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenUsingDefaultSerializationFactory.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Serialization/Newtonsoft/WhenUsingDefaultSerializationFactory.cs
@@ -1,0 +1,40 @@
+using JustSaying.Messaging.MessageSerialization;
+using JustSaying.TestingFramework;
+
+namespace JustSaying.UnitTests.Messaging.Serialization.Newtonsoft;
+
+public class WhenUsingDefaultSerializationFactory : XBehaviourTest<NewtonsoftMessageBodySerializer<MessageWithEnum>>
+{
+    private MessageWithEnum _messageOut;
+    private string _jsonMessage;
+
+    protected override NewtonsoftMessageBodySerializer<MessageWithEnum> CreateSystemUnderTest()
+    {
+        // This is the path used when no custom settings are provided,
+        // which is the default for all DI registrations.
+        var factory = new NewtonsoftSerializationFactory();
+        return (NewtonsoftMessageBodySerializer<MessageWithEnum>)factory.GetSerializer<MessageWithEnum>();
+    }
+
+    protected override void Given()
+    {
+        _messageOut = new MessageWithEnum { EnumVal = Value.Two };
+    }
+
+    protected override void WhenAction()
+    {
+        _jsonMessage = SystemUnderTest.Serialize(_messageOut);
+    }
+
+    [Test]
+    public void MessageHasBeenCreated()
+    {
+        _messageOut.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void EnumsAreRepresentedAsStrings()
+    {
+        _jsonMessage.ShouldContain("\"EnumVal\":\"Two\"");
+    }
+}


### PR DESCRIPTION
## Problem

When upgrading from JustSaying v7 to v8, enum values in messages are serialized as numbers instead of strings (the previous default behaviour).

## Root Cause

`NewtonsoftSerializationFactory` is created with `settings = null` by default. It passes this null to `NewtonsoftMessageBodySerializer<T>(JsonSerializerSettings settings)`, which directly assigned it to `_settings`. With null settings, `JsonConvert` uses Newtonsoft's global defaults which serialize enums as integers.

The parameterless constructor correctly configured `StringEnumConverter`, but it was never called in the default registration path.

## Fix

The `JsonSerializerSettings` constructor now falls back to the same default settings (with `NullValueHandling.Ignore` and `StringEnumConverter`) when `null` is passed, preserving the expected enum-as-string serialization behaviour.