### PR TITLE
Minor - Fix broken link to subscription middleware docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,5 +41,3 @@ npm run deploy
 ```
 
 This will deploy the documentation to the `gh-pages` branch.
-
-

--- a/docs/docs/publishing/middleware.md
+++ b/docs/docs/publishing/middleware.md
@@ -3,7 +3,7 @@
 
 # Publish Middleware
 
-Publish middleware allows you to add cross-cutting concerns to your publish operations, such as tracing, logging, or metadata enrichment. It follows the same `MiddlewareBase<TContext, TOut>` pattern used for [handler middleware](/subscriptions/middleware/README), but wraps `PublishAsync` and `PublishBatchAsync` calls instead of message handling.
+Publish middleware allows you to add cross-cutting concerns to your publish operations, such as tracing, logging, or metadata enrichment. It follows the same `MiddlewareBase<TContext, TOut>` pattern used for [handler middleware](/subscriptions/middleware), but wraps `PublishAsync` and `PublishBatchAsync` calls instead of message handling.
 
 ## How It Works
 


### PR DESCRIPTION
Fixes a docs build error I noticed after the last 2 dependency pushes