### PR TITLE
v9 spike: CloudEvents attributes via MessageContext (alternative to the CloudEvent<T> wrapper)

### DIFF
--- a/src/JustSaying.CloudEvents/CloudEventMessageBodySerializer`1.cs
+++ b/src/JustSaying.CloudEvents/CloudEventMessageBodySerializer`1.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using JustSaying.Messaging;
+using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialization;
 
 namespace JustSaying.CloudEvents;
@@ -13,9 +14,14 @@ namespace JustSaying.CloudEvents;
 /// serialized by an inner <see cref="IMessageBodySerializer{TMessage}"/>.
 /// </summary>
 /// <typeparam name="TMessage">The type of message to be serialized or deserialized.</typeparam>
-public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySerializer<TMessage>, ISelfDescribingMessageBodySerializer where TMessage : class
+public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySerializer<TMessage>, IContextProvidingMessageBodySerializer<TMessage>, ISelfDescribingMessageBodySerializer where TMessage : class
 {
     private const string SpecVersion = "1.0";
+
+    private static readonly string[] ReservedAttributes =
+    [
+        "specversion", "id", "source", "type", "time", "datacontenttype", "dataschema", "subject", "data", "data_base64"
+    ];
 
     private readonly IMessageBodySerializer<TMessage> _dataSerializer;
     private readonly IMessageMetadataProvider _metadataProvider;
@@ -88,6 +94,91 @@ public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySeri
     public TMessage Deserialize(string message)
     {
         using var document = JsonDocument.Parse(message);
+        return DeserializeData(document);
+    }
+
+    /// <summary>
+    /// Deserializes the <c>data</c> payload of a structured-mode CloudEvents JSON envelope into a
+    /// message of type <typeparamref name="TMessage"/>, also capturing a factory for a
+    /// <see cref="CloudEventMessageContext"/> carrying the envelope's context attributes.
+    /// </summary>
+    /// <param name="message">The CloudEvents JSON.</param>
+    /// <param name="contextFactory">
+    /// When this method returns, a factory that creates the <see cref="CloudEventMessageContext"/>
+    /// for this message.
+    /// </param>
+    /// <returns>The deserialized message.</returns>
+    public TMessage Deserialize(string message, out MessageContextFactory contextFactory)
+    {
+        using var document = JsonDocument.Parse(message);
+        var data = DeserializeData(document);
+
+        var root = document.RootElement;
+        string specVersion = GetStringAttribute(root, "specversion") ?? SpecVersion;
+        string id = GetStringAttribute(root, "id");
+        string source = GetStringAttribute(root, "source");
+        string type = GetStringAttribute(root, "type");
+        string dataContentType = GetStringAttribute(root, "datacontenttype");
+        string dataSchema = GetStringAttribute(root, "dataschema");
+        string subject = GetStringAttribute(root, "subject");
+
+        if (id is null || source is null || type is null)
+        {
+            // Not a well-formed CloudEvent (id, source and type are required attributes);
+            // fall back to the default message context.
+            contextFactory = null;
+            return data;
+        }
+
+        DateTimeOffset? time = null;
+        if (root.TryGetProperty("time", out var timeElement) &&
+            timeElement.ValueKind == JsonValueKind.String &&
+            timeElement.TryGetDateTimeOffset(out var parsedTime))
+        {
+            time = parsedTime;
+        }
+
+        Dictionary<string, string> extensions = null;
+        foreach (var property in root.EnumerateObject())
+        {
+            if (Array.IndexOf(ReservedAttributes, property.Name) >= 0)
+            {
+                continue;
+            }
+
+            // CloudEvents extension attributes are simple (non-composite) values; ignore anything else.
+            string value = property.Value.ValueKind switch
+            {
+                JsonValueKind.String => property.Value.GetString(),
+                JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => property.Value.GetRawText(),
+                _ => null,
+            };
+
+            if (value is not null)
+            {
+                (extensions ??= new Dictionary<string, string>()).Add(property.Name, value);
+            }
+        }
+
+        contextFactory = (rawMessage, queueUri, messageAttributes) => new CloudEventMessageContext(
+            rawMessage,
+            queueUri,
+            messageAttributes,
+            specVersion,
+            id,
+            new Uri(source, UriKind.RelativeOrAbsolute),
+            type,
+            time,
+            dataContentType,
+            dataSchema is null ? null : new Uri(dataSchema, UriKind.RelativeOrAbsolute),
+            subject,
+            extensions);
+
+        return data;
+    }
+
+    private TMessage DeserializeData(JsonDocument document)
+    {
         if (!document.RootElement.TryGetProperty("data", out var data))
         {
             throw new InvalidOperationException("The CloudEvents payload does not contain a 'data' member.");
@@ -95,4 +186,9 @@ public sealed class CloudEventMessageBodySerializer<TMessage> : IMessageBodySeri
 
         return _dataSerializer.Deserialize(data.GetRawText());
     }
+
+    private static string GetStringAttribute(JsonElement root, string name)
+        => root.TryGetProperty(name, out var element) && element.ValueKind == JsonValueKind.String
+            ? element.GetString()
+            : null;
 }

--- a/src/JustSaying.CloudEvents/CloudEventMessageContext.cs
+++ b/src/JustSaying.CloudEvents/CloudEventMessageContext.cs
@@ -1,0 +1,104 @@
+using JustSaying.Messaging.MessageHandling;
+using SQSMessage = Amazon.SQS.Model.Message;
+
+namespace JustSaying.CloudEvents;
+
+/// <summary>
+/// A <see cref="MessageContext"/> for a message that arrived as a structured-mode
+/// <see href="https://github.com/cloudevents/spec">CloudEvents 1.0</see> envelope, exposing the
+/// envelope's context attributes. Handlers can observe it through
+/// <see cref="IMessageContextReader"/>, either by downcasting <see cref="IMessageContextReader.MessageContext"/>
+/// or via <see cref="MessageContextReaderExtensions.GetCloudEventContext"/>.
+/// </summary>
+public sealed class CloudEventMessageContext : MessageContext
+{
+    /// <summary>
+    /// Creates an instance of <see cref="CloudEventMessageContext"/>.
+    /// </summary>
+    /// <param name="message">The <see cref="Amazon.SQS.Model.Message"/> currently being processed.</param>
+    /// <param name="queueUri">The URI of the SQS queue the message is from.</param>
+    /// <param name="messageAttributes">The <see cref="MessageAttributes"/> from the message.</param>
+    /// <param name="specVersion">The CloudEvents <c>specversion</c> attribute.</param>
+    /// <param name="id">The CloudEvents <c>id</c> attribute.</param>
+    /// <param name="source">The CloudEvents <c>source</c> attribute.</param>
+    /// <param name="type">The CloudEvents <c>type</c> attribute.</param>
+    /// <param name="time">The CloudEvents <c>time</c> attribute, if present.</param>
+    /// <param name="dataContentType">The CloudEvents <c>datacontenttype</c> attribute, if present.</param>
+    /// <param name="dataSchema">The CloudEvents <c>dataschema</c> attribute, if present.</param>
+    /// <param name="subject">The CloudEvents <c>subject</c> attribute, if present.</param>
+    /// <param name="extensions">The envelope's extension attributes, keyed by attribute name.</param>
+    public CloudEventMessageContext(
+        SQSMessage message,
+        Uri queueUri,
+        MessageAttributes messageAttributes,
+        string specVersion,
+        string id,
+        Uri source,
+        string type,
+        DateTimeOffset? time = null,
+        string dataContentType = null,
+        Uri dataSchema = null,
+        string subject = null,
+        IReadOnlyDictionary<string, string> extensions = null)
+        : base(message, queueUri, messageAttributes)
+    {
+        SpecVersion = specVersion ?? throw new ArgumentNullException(nameof(specVersion));
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        Time = time;
+        DataContentType = dataContentType;
+        DataSchema = dataSchema;
+        Subject = subject;
+        Extensions = extensions ?? EmptyExtensions;
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyExtensions = new Dictionary<string, string>(0);
+
+    /// <summary>
+    /// Gets the CloudEvents <c>specversion</c> attribute.
+    /// </summary>
+    public string SpecVersion { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>id</c> attribute.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>source</c> attribute.
+    /// </summary>
+    public Uri Source { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>type</c> attribute.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>time</c> attribute, if present.
+    /// </summary>
+    public DateTimeOffset? Time { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>datacontenttype</c> attribute, if present.
+    /// </summary>
+    public string DataContentType { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>dataschema</c> attribute, if present.
+    /// </summary>
+    public Uri DataSchema { get; }
+
+    /// <summary>
+    /// Gets the CloudEvents <c>subject</c> attribute, if present.
+    /// </summary>
+    public string Subject { get; }
+
+    /// <summary>
+    /// Gets the envelope's extension attributes (top-level members other than the CloudEvents core
+    /// attributes and <c>data</c>), keyed by attribute name. Values are the attributes' string
+    /// representations.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Extensions { get; }
+}

--- a/src/JustSaying.CloudEvents/MessageContextReaderExtensions.cs
+++ b/src/JustSaying.CloudEvents/MessageContextReaderExtensions.cs
@@ -1,0 +1,22 @@
+using JustSaying.Messaging.MessageHandling;
+
+namespace JustSaying.CloudEvents;
+
+/// <summary>
+/// CloudEvents-related extensions for <see cref="IMessageContextReader"/>.
+/// </summary>
+public static class MessageContextReaderExtensions
+{
+    /// <summary>
+    /// Gets the <see cref="CloudEventMessageContext"/> for the message currently being processed, or
+    /// <see langword="null"/> if there is no current message or it did not arrive as a CloudEvents
+    /// envelope.
+    /// </summary>
+    /// <param name="reader">The <see cref="IMessageContextReader"/> to read the context from.</param>
+    /// <returns>The <see cref="CloudEventMessageContext"/>, or <see langword="null"/>.</returns>
+    public static CloudEventMessageContext GetCloudEventContext(this IMessageContextReader reader)
+    {
+        if (reader is null) throw new ArgumentNullException(nameof(reader));
+        return reader.MessageContext as CloudEventMessageContext;
+    }
+}

--- a/src/JustSaying.CloudEvents/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying.CloudEvents/PublicAPI/PublicAPI.Unshipped.txt
@@ -17,3 +17,17 @@ JustSaying.CloudEvents.CloudEventTypeDiscriminator.CloudEventTypeDiscriminator()
 JustSaying.CloudEvents.CloudEventTypeDiscriminator.TryGetMessageTypeName(JustSaying.Messaging.MessageDiscriminationContext context, out string typeName) -> bool
 Microsoft.Extensions.DependencyInjection.CloudEventsServiceCollectionExtensions
 static Microsoft.Extensions.DependencyInjection.CloudEventsServiceCollectionExtensions.AddJustSayingCloudEvents(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<JustSaying.CloudEvents.CloudEventOptions> configure, System.Text.Json.JsonSerializerOptions dataSerializerOptions = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+JustSaying.CloudEvents.CloudEventMessageBodySerializer<TMessage>.Deserialize(string message, out JustSaying.Messaging.MessageHandling.MessageContextFactory contextFactory) -> TMessage
+JustSaying.CloudEvents.CloudEventMessageContext
+JustSaying.CloudEvents.CloudEventMessageContext.CloudEventMessageContext(Amazon.SQS.Model.Message message, System.Uri queueUri, JustSaying.Messaging.MessageHandling.MessageAttributes messageAttributes, string specVersion, string id, System.Uri source, string type, System.DateTimeOffset? time = null, string dataContentType = null, System.Uri dataSchema = null, string subject = null, System.Collections.Generic.IReadOnlyDictionary<string, string> extensions = null) -> void
+JustSaying.CloudEvents.CloudEventMessageContext.DataContentType.get -> string
+JustSaying.CloudEvents.CloudEventMessageContext.DataSchema.get -> System.Uri
+JustSaying.CloudEvents.CloudEventMessageContext.Extensions.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+JustSaying.CloudEvents.CloudEventMessageContext.Id.get -> string
+JustSaying.CloudEvents.CloudEventMessageContext.Source.get -> System.Uri
+JustSaying.CloudEvents.CloudEventMessageContext.SpecVersion.get -> string
+JustSaying.CloudEvents.CloudEventMessageContext.Subject.get -> string
+JustSaying.CloudEvents.CloudEventMessageContext.Time.get -> System.DateTimeOffset?
+JustSaying.CloudEvents.CloudEventMessageContext.Type.get -> string
+JustSaying.CloudEvents.MessageContextReaderExtensions
+static JustSaying.CloudEvents.MessageContextReaderExtensions.GetCloudEventContext(this JustSaying.Messaging.MessageHandling.IMessageContextReader reader) -> JustSaying.CloudEvents.CloudEventMessageContext

--- a/src/JustSaying/AwsTools/MessageHandling/Dispatch/MessageDispatcher.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/Dispatch/MessageDispatcher.cs
@@ -34,7 +34,7 @@ internal sealed class MessageDispatcher : IMessageDispatcher
             return;
         }
 
-        (bool success, object typedMessage, MessageAttributes attributes) =
+        (bool success, InboundMessage inboundMessage) =
             await DeserializeMessage(messageContext, cancellationToken).ConfigureAwait(false);
 
         if (!success)
@@ -43,6 +43,8 @@ internal sealed class MessageDispatcher : IMessageDispatcher
             return;
         }
 
+        var typedMessage = inboundMessage.Message;
+        var attributes = inboundMessage.MessageAttributes;
         var messageType = typedMessage.GetType();
         var middleware = _middlewareMap.Get(messageContext.QueueName, messageType);
 
@@ -62,7 +64,8 @@ internal sealed class MessageDispatcher : IMessageDispatcher
             messageContext,
             messageContext,
             messageContext.QueueUri,
-            attributes);
+            attributes,
+            inboundMessage.MessageContextFactory?.Invoke(messageContext.Message, messageContext.QueueUri, attributes));
 
         using var activity = StartConsumerActivity(messageContext, typedMessage, messageType, attributes);
 
@@ -124,16 +127,16 @@ internal sealed class MessageDispatcher : IMessageDispatcher
         return activity;
     }
 
-    private async Task<(bool success, object typedMessage, MessageAttributes attributes)>
+    private async Task<(bool success, InboundMessage inboundMessage)>
         DeserializeMessage(IQueueMessageContext messageContext, CancellationToken cancellationToken)
     {
         try
         {
             _logger.LogDebug("Attempting to deserialize message.");
 
-            var (message, attributes) = await messageContext.MessageConverter.ConvertToInboundMessageAsync(messageContext.Message, cancellationToken);
+            var inboundMessage = await messageContext.MessageConverter.ConvertToInboundMessageAsync(messageContext.Message, cancellationToken);
 
-            return (true, message, attributes);
+            return (true, inboundMessage);
         }
         catch (MessageFormatNotSupportedException ex)
         {
@@ -145,12 +148,12 @@ internal sealed class MessageDispatcher : IMessageDispatcher
             await messageContext.DeleteMessage(cancellationToken).ConfigureAwait(false);
             _messagingMonitor.HandleError(ex, messageContext.Message);
 
-            return (false, null, null);
+            return (false, null);
         }
         catch (OperationCanceledException)
         {
             // Ignore cancellation
-            return (false, null, null);
+            return (false, null);
         }
         catch (Exception ex)
         {
@@ -162,7 +165,7 @@ internal sealed class MessageDispatcher : IMessageDispatcher
 
             _messagingMonitor.HandleError(ex, messageContext.Message);
 
-            return (false, null, null);
+            return (false, null);
         }
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/InboundMessageConverter.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/InboundMessageConverter.cs
@@ -50,8 +50,19 @@ internal sealed class InboundMessageConverter : IInboundMessageConverter
         }
         body = ApplyBodyDecompression(body, attributes);
         var serializer = _serializerResolver.Resolve(body, subject, attributes);
-        var result = serializer.Deserialize(body);
-        return new ValueTask<InboundMessage>(new InboundMessage(result, attributes));
+
+        object result;
+        MessageContextFactory contextFactory = null;
+        if (serializer is IContextProvidingMessageBodySerializer contextProviding)
+        {
+            result = contextProviding.Deserialize(body, out contextFactory);
+        }
+        else
+        {
+            result = serializer.Deserialize(body);
+        }
+
+        return new ValueTask<InboundMessage>(new InboundMessage(result, attributes, contextFactory));
     }
 
     private string ApplyBodyDecompression(string body, MessageAttributes attributes)

--- a/src/JustSaying/Messaging/MessageHandling/MessageContextFactory.cs
+++ b/src/JustSaying/Messaging/MessageHandling/MessageContextFactory.cs
@@ -1,0 +1,15 @@
+using SQSMessage = Amazon.SQS.Model.Message;
+
+namespace JustSaying.Messaging.MessageHandling;
+
+/// <summary>
+/// Creates the <see cref="MessageContext"/> for the message currently being processed, allowing a
+/// serializer whose wire format carries envelope metadata (such as a CloudEvents envelope) to
+/// substitute a derived context that exposes that metadata to handlers via
+/// <see cref="IMessageContextReader"/>.
+/// </summary>
+/// <param name="message">The <see cref="Amazon.SQS.Model.Message"/> currently being processed.</param>
+/// <param name="queueUri">The URI of the SQS queue the message is from.</param>
+/// <param name="messageAttributes">The <see cref="MessageAttributes"/> from the message.</param>
+/// <returns>The <see cref="MessageContext"/> (or derived type) for the current message.</returns>
+public delegate MessageContext MessageContextFactory(SQSMessage message, Uri queueUri, MessageAttributes messageAttributes);

--- a/src/JustSaying/Messaging/MessageSerialization/ErasedMessageBodySerializer`1.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/ErasedMessageBodySerializer`1.cs
@@ -7,10 +7,21 @@ namespace JustSaying.Messaging.MessageSerialization;
 /// inner serializer performs the actual (generic, trim/AOT-friendly) serialization.
 /// </summary>
 /// <typeparam name="TMessage">The concrete message type the inner serializer handles.</typeparam>
-internal sealed class ErasedMessageBodySerializer<TMessage>(IMessageBodySerializer<TMessage> inner) : IMessageBodySerializer
+internal sealed class ErasedMessageBodySerializer<TMessage>(IMessageBodySerializer<TMessage> inner) : IMessageBodySerializer, IContextProvidingMessageBodySerializer
     where TMessage : class
 {
     public string Serialize(object message) => inner.Serialize((TMessage)message);
 
     public object Deserialize(string message) => inner.Deserialize(message);
+
+    public object Deserialize(string message, out MessageHandling.MessageContextFactory contextFactory)
+    {
+        if (inner is IContextProvidingMessageBodySerializer<TMessage> contextProviding)
+        {
+            return contextProviding.Deserialize(message, out contextFactory);
+        }
+
+        contextFactory = null;
+        return inner.Deserialize(message);
+    }
 }

--- a/src/JustSaying/Messaging/MessageSerialization/IContextProvidingMessageBodySerializer.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/IContextProvidingMessageBodySerializer.cs
@@ -1,0 +1,15 @@
+namespace JustSaying.Messaging.MessageSerialization;
+
+/// <summary>
+/// The type-erased counterpart of <see cref="IContextProvidingMessageBodySerializer{TMessage}"/>,
+/// used internally at the dispatch boundary.
+/// </summary>
+internal interface IContextProvidingMessageBodySerializer
+{
+    /// <summary>
+    /// Deserializes a string representation back into a message object, also capturing a factory for
+    /// the <see cref="MessageHandling.MessageContext"/> describing the envelope the message arrived
+    /// in, or <see langword="null"/> to use the default context.
+    /// </summary>
+    object Deserialize(string message, out MessageHandling.MessageContextFactory contextFactory);
+}

--- a/src/JustSaying/Messaging/MessageSerialization/IContextProvidingMessageBodySerializer`1.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/IContextProvidingMessageBodySerializer`1.cs
@@ -1,0 +1,26 @@
+using JustSaying.Messaging.MessageHandling;
+
+namespace JustSaying.Messaging.MessageSerialization;
+
+/// <summary>
+/// An optional capability of an <see cref="IMessageBodySerializer{TMessage}"/> whose wire format is
+/// an envelope carrying metadata beyond the message payload itself. When a subscription's serializer
+/// implements this interface, the metadata extracted while deserializing the body is used to build a
+/// derived <see cref="MessageContext"/>, which handlers can observe through
+/// <see cref="IMessageContextReader"/>.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message to deserialize.</typeparam>
+public interface IContextProvidingMessageBodySerializer<TMessage> where TMessage : class
+{
+    /// <summary>
+    /// Deserializes a string representation back into a message object, also capturing a factory for
+    /// the <see cref="MessageContext"/> describing the envelope the message arrived in.
+    /// </summary>
+    /// <param name="message">The string representation of the message to deserialize.</param>
+    /// <param name="contextFactory">
+    /// When this method returns, a factory that creates the <see cref="MessageContext"/> for this
+    /// message, or <see langword="null"/> to use the default context.
+    /// </param>
+    /// <returns>The deserialized message object.</returns>
+    TMessage Deserialize(string message, out MessageContextFactory contextFactory);
+}

--- a/src/JustSaying/Messaging/MessageSerialization/InboundMessage.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/InboundMessage.cs
@@ -5,7 +5,7 @@ namespace JustSaying.Messaging.MessageSerialization;
 /// <summary>
 /// Represents a deserialized message with attributes.
 /// </summary>
-public sealed class InboundMessage(object message, MessageAttributes messageAttributes)
+public sealed class InboundMessage(object message, MessageAttributes messageAttributes, MessageContextFactory messageContextFactory = null)
 {
     /// <summary>
     /// Gets the message that was extracted from a message body.
@@ -16,6 +16,12 @@ public sealed class InboundMessage(object message, MessageAttributes messageAttr
     /// Gets the attributes that were extracted from a message body.
     /// </summary>
     public MessageAttributes MessageAttributes { get; } = messageAttributes;
+
+    /// <summary>
+    /// Gets the factory that creates the <see cref="MessageContext"/> for this message, or
+    /// <see langword="null"/> to use the default context.
+    /// </summary>
+    public MessageContextFactory MessageContextFactory { get; } = messageContextFactory;
 
     public void Deconstruct(out object message, out MessageAttributes attributes)
     {

--- a/src/JustSaying/Messaging/Middleware/Handle/HandleMessageContext.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandleMessageContext.cs
@@ -13,6 +13,7 @@ namespace JustSaying.Messaging.Middleware;
 /// <param name="queueName">The queue from which this message was received.</param>
 /// <param name="visibilityUpdater">The <see cref="IMessageVisibilityUpdater"/> to use to update message visibilities on failure.</param>
 /// <param name="messageDeleter">The <see cref="IMessageDeleter"/> to use to remove a message from the queue on success.</param>
+/// <param name="messageContext">An optional <see cref="MessageHandling.MessageContext"/> (or derived type) for this message; when omitted, the default context is created.</param>
 public sealed class HandleMessageContext(
     string queueName,
     Amazon.SQS.Model.Message rawMessage,
@@ -21,7 +22,8 @@ public sealed class HandleMessageContext(
     IMessageVisibilityUpdater visibilityUpdater,
     IMessageDeleter messageDeleter,
     Uri queueUri,
-    MessageAttributes messageAttributes)
+    MessageAttributes messageAttributes,
+    MessageHandling.MessageContext messageContext = null)
 {
 
     /// <summary>
@@ -53,6 +55,14 @@ public sealed class HandleMessageContext(
     /// The raw SQS message that was downloaded from the queue.
     /// </summary>
     public Amazon.SQS.Model.Message RawMessage { get; } = rawMessage;
+
+    /// <summary>
+    /// The <see cref="MessageHandling.MessageContext"/> for this message, made available to handlers
+    /// via <see cref="IMessageContextReader"/>. A serializer whose wire format is an envelope (such
+    /// as a CloudEvents envelope) may substitute a derived context carrying the envelope's metadata;
+    /// otherwise this is the default context.
+    /// </summary>
+    public MessageHandling.MessageContext MessageContext { get; } = messageContext ?? new MessageHandling.MessageContext(rawMessage, queueUri, messageAttributes);
 
     /// <summary>
     /// An <see cref="IMessageVisibilityUpdater"/> that can be used to update the visibility timeout for this message.

--- a/src/JustSaying/Messaging/Middleware/MessageContext/MessageContextAccessorMiddleware.cs
+++ b/src/JustSaying/Messaging/Middleware/MessageContext/MessageContextAccessorMiddleware.cs
@@ -15,7 +15,7 @@ public sealed class MessageContextAccessorMiddleware(IMessageContextAccessor mes
 
     protected override async Task<bool> RunInnerAsync(HandleMessageContext context, Func<CancellationToken, Task<bool>> func, CancellationToken stoppingToken)
     {
-        _messageContextAccessor.MessageContext = new MessageHandling.MessageContext(context.RawMessage, context.QueueUri, context.MessageAttributes);
+        _messageContextAccessor.MessageContext = context.MessageContext;
 
         try
         {

--- a/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/JustSaying/PublicAPI/PublicAPI.Unshipped.txt
@@ -236,7 +236,6 @@ JustSaying.Messaging.MessageSerialization.IMessageBodySerializer<TMessage>.Deser
 JustSaying.Messaging.MessageSerialization.IMessageBodySerializer<TMessage>.Serialize(TMessage message) -> string
 JustSaying.Messaging.MessageSerialization.ISelfDescribingMessageBodySerializer
 JustSaying.Messaging.MessageSerialization.InboundMessage.Deconstruct(out object message, out JustSaying.Messaging.MessageHandling.MessageAttributes attributes) -> void
-JustSaying.Messaging.MessageSerialization.InboundMessage.InboundMessage(object message, JustSaying.Messaging.MessageHandling.MessageAttributes messageAttributes) -> void
 JustSaying.Messaging.MessageSerialization.InboundMessage.Message.get -> object
 JustSaying.Messaging.MessageSerialization.NewtonsoftMessageBodySerializer<T>.Deserialize(string message) -> T
 JustSaying.Messaging.MessageSerialization.NewtonsoftMessageBodySerializer<T>.Serialize(T message) -> string
@@ -244,7 +243,6 @@ JustSaying.Messaging.MessageSerialization.NewtonsoftSerializationFactory.GetSeri
 JustSaying.Messaging.MessageSerialization.SystemTextJsonMessageBodySerializer<T>.Deserialize(string messageBody) -> T
 JustSaying.Messaging.MessageSerialization.SystemTextJsonMessageBodySerializer<T>.Serialize(T message) -> string
 JustSaying.Messaging.MessageSerialization.SystemTextJsonSerializationFactory.GetSerializer<T>() -> JustSaying.Messaging.MessageSerialization.IMessageBodySerializer<T>
-JustSaying.Messaging.Middleware.HandleMessageContext.HandleMessageContext(string queueName, Amazon.SQS.Model.Message rawMessage, object message, System.Type messageType, JustSaying.Messaging.Channels.Context.IMessageVisibilityUpdater visibilityUpdater, JustSaying.Messaging.Channels.Context.IMessageDeleter messageDeleter, System.Uri queueUri, JustSaying.Messaging.MessageHandling.MessageAttributes messageAttributes) -> void
 JustSaying.Messaging.Middleware.HandleMessageContext.Message.get -> object
 JustSaying.Messaging.Middleware.PublishContext.Message.get -> object
 JustSaying.Messaging.Middleware.PublishContext.Messages.get -> System.Collections.Generic.IReadOnlyCollection<object>
@@ -286,3 +284,10 @@ JustSaying.Messaging.SubjectMessageTypeDiscriminator.SubjectMessageTypeDiscrimin
 JustSaying.Messaging.SubjectMessageTypeDiscriminator.TryGetMessageTypeName(JustSaying.Messaging.MessageDiscriminationContext context, out string typeName) -> bool
 JustSaying.Fluent.MultiTypeQueueSubscriptionBuilder.Handling<TMessage>(string typeName = null, System.Action<JustSaying.Messaging.Middleware.HandlerMiddlewareBuilder> middlewareConfiguration = null) -> JustSaying.Fluent.MultiTypeQueueSubscriptionBuilder
 JustSaying.Fluent.MultiTypeQueueSubscriptionBuilder.WithDiscriminator(JustSaying.Messaging.IMessageTypeDiscriminator discriminator) -> JustSaying.Fluent.MultiTypeQueueSubscriptionBuilder
+JustSaying.Messaging.MessageHandling.MessageContextFactory
+JustSaying.Messaging.MessageSerialization.IContextProvidingMessageBodySerializer<TMessage>
+JustSaying.Messaging.MessageSerialization.IContextProvidingMessageBodySerializer<TMessage>.Deserialize(string message, out JustSaying.Messaging.MessageHandling.MessageContextFactory contextFactory) -> TMessage
+JustSaying.Messaging.MessageSerialization.InboundMessage.InboundMessage(object message, JustSaying.Messaging.MessageHandling.MessageAttributes messageAttributes, JustSaying.Messaging.MessageHandling.MessageContextFactory messageContextFactory = null) -> void
+JustSaying.Messaging.MessageSerialization.InboundMessage.MessageContextFactory.get -> JustSaying.Messaging.MessageHandling.MessageContextFactory
+JustSaying.Messaging.Middleware.HandleMessageContext.HandleMessageContext(string queueName, Amazon.SQS.Model.Message rawMessage, object message, System.Type messageType, JustSaying.Messaging.Channels.Context.IMessageVisibilityUpdater visibilityUpdater, JustSaying.Messaging.Channels.Context.IMessageDeleter messageDeleter, System.Uri queueUri, JustSaying.Messaging.MessageHandling.MessageAttributes messageAttributes, JustSaying.Messaging.MessageHandling.MessageContext messageContext = null) -> void
+JustSaying.Messaging.Middleware.HandleMessageContext.MessageContext.get -> JustSaying.Messaging.MessageHandling.MessageContext

--- a/tests/JustSaying.CloudEvents.Tests/WhenProvidingTheMessageContext.cs
+++ b/tests/JustSaying.CloudEvents.Tests/WhenProvidingTheMessageContext.cs
@@ -1,0 +1,108 @@
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageSerialization;
+using SQSMessage = Amazon.SQS.Model.Message;
+
+namespace JustSaying.CloudEvents.Tests;
+
+public class WhenProvidingTheMessageContext
+{
+    private sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    private static CloudEventMessageBodySerializer<OrderPlaced> CreateSerializer()
+    {
+        var data = new SystemTextJsonMessageBodySerializer<OrderPlaced>(SystemTextJsonMessageBodySerializer.DefaultJsonSerializerOptions);
+        var metadata = new MessagingConfig().MessageMetadataProvider;
+        return new CloudEventMessageBodySerializer<OrderPlaced>(data, metadata, new Uri("https://orders.justeattakeaway.com/"), "com.justeattakeaway.orders.orderplaced");
+    }
+
+    private static CloudEventMessageContext CreateContext(MessageContextFactory factory)
+        => (CloudEventMessageContext)factory(
+            new SQSMessage { MessageId = "sqs-1" },
+            new Uri("https://sqs.eu-west-1.amazonaws.com/123456789012/orders"),
+            new MessageAttributes());
+
+    [Test]
+    public async Task Captures_The_Envelope_Attributes()
+    {
+        const string envelope =
+            """
+            {
+              "specversion": "1.0",
+              "id": "event-42",
+              "source": "/demo/orders",
+              "type": "com.justeattakeaway.orders.orderplaced",
+              "time": "2026-07-12T09:30:00Z",
+              "datacontenttype": "application/json",
+              "subject": "order-123",
+              "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+              "sequence": 7,
+              "data": { "OrderId": "order-123" }
+            }
+            """;
+
+        var message = CreateSerializer().Deserialize(envelope, out var contextFactory);
+
+        await Assert.That(message.OrderId).IsEqualTo("order-123");
+        await Assert.That(contextFactory).IsNotNull();
+
+        var context = CreateContext(contextFactory);
+
+        await Assert.That(context.SpecVersion).IsEqualTo("1.0");
+        await Assert.That(context.Id).IsEqualTo("event-42");
+        await Assert.That(context.Source.ToString()).IsEqualTo("/demo/orders");
+        await Assert.That(context.Type).IsEqualTo("com.justeattakeaway.orders.orderplaced");
+        await Assert.That(context.Time).IsEqualTo(new DateTimeOffset(2026, 7, 12, 9, 30, 0, TimeSpan.Zero));
+        await Assert.That(context.DataContentType).IsEqualTo("application/json");
+        await Assert.That(context.Subject).IsEqualTo("order-123");
+        await Assert.That(context.Extensions["traceparent"]).IsEqualTo("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+        await Assert.That(context.Extensions["sequence"]).IsEqualTo("7");
+        await Assert.That(context.Extensions.ContainsKey("data")).IsFalse();
+        await Assert.That(context.Message.MessageId).IsEqualTo("sqs-1");
+    }
+
+    [Test]
+    public async Task Round_Trips_Its_Own_Envelope()
+    {
+        var serializer = CreateSerializer();
+
+        var message = serializer.Deserialize(serializer.Serialize(new OrderPlaced { OrderId = "order-9" }), out var contextFactory);
+        var context = CreateContext(contextFactory);
+
+        await Assert.That(message.OrderId).IsEqualTo("order-9");
+        await Assert.That(context.Source.ToString()).IsEqualTo("https://orders.justeattakeaway.com/");
+        await Assert.That(context.Type).IsEqualTo("com.justeattakeaway.orders.orderplaced");
+        await Assert.That(context.Extensions).IsEmpty();
+    }
+
+    [Test]
+    public async Task Falls_Back_To_The_Default_Context_When_Required_Attributes_Are_Missing()
+    {
+        var message = CreateSerializer().Deserialize("""{ "data": { "OrderId": "order-1" } }""", out var contextFactory);
+
+        await Assert.That(message.OrderId).IsEqualTo("order-1");
+        await Assert.That(contextFactory).IsNull();
+    }
+
+    [Test]
+    public async Task The_Context_Reader_Extension_Filters_By_Context_Type()
+    {
+        var accessor = new MessageContextAccessor();
+        var reader = (IMessageContextReader)accessor;
+
+        await Assert.That(reader.GetCloudEventContext()).IsNull();
+
+        var sqsMessage = new SQSMessage();
+        var queueUri = new Uri("https://sqs.eu-west-1.amazonaws.com/123456789012/orders");
+
+        accessor.MessageContext = new MessageContext(sqsMessage, queueUri, new MessageAttributes());
+        await Assert.That(reader.GetCloudEventContext()).IsNull();
+
+        accessor.MessageContext = new CloudEventMessageContext(
+            sqsMessage, queueUri, new MessageAttributes(),
+            "1.0", "event-1", new Uri("/demo/orders", UriKind.RelativeOrAbsolute), "com.justeattakeaway.orders.orderplaced");
+        await Assert.That(reader.GetCloudEventContext()).IsNotNull();
+    }
+}

--- a/tests/JustSaying.IntegrationTests/Fluent/CloudEvents/WhenReadingTheCloudEventMessageContext.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/CloudEvents/WhenReadingTheCloudEventMessageContext.cs
@@ -1,0 +1,84 @@
+using JustSaying.CloudEvents;
+using JustSaying.Messaging.MessageHandling;
+using JustSaying.Messaging.MessageSerialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace JustSaying.IntegrationTests.Fluent.CloudEvents;
+
+/// <summary>
+/// End-to-end coverage for the CloudEvents message context: when a message arrives as a structured
+/// CloudEvents envelope, a handler observes the envelope's context attributes through the injected
+/// <see cref="IMessageContextReader"/> — the handler's own contract stays a plain
+/// <see cref="IHandlerAsync{T}"/> of the data type.
+/// </summary>
+public class WhenReadingTheCloudEventMessageContext : IntegrationTestBase
+{
+    private const string OrderPlacedType = "com.example.orders.order.placed";
+
+    public sealed class OrderPlaced
+    {
+        public string OrderId { get; set; }
+    }
+
+    private sealed class CaptureContextHandler(IMessageContextReader contextReader) : IHandlerAsync<OrderPlaced>
+    {
+        private readonly TaskCompletionSource<CloudEventMessageContext> _completionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<CloudEventMessageContext> Context => _completionSource.Task;
+
+        public Task<bool> Handle(OrderPlaced message)
+        {
+            _completionSource.TrySetResult(contextReader.GetCloudEventContext());
+            return Task.FromResult(true);
+        }
+    }
+
+    [Test]
+    public async Task Then_The_Handler_Observes_The_Envelope_Attributes()
+    {
+        // Arrange
+        var services = GivenJustSaying()
+            .ConfigureJustSaying(builder => builder
+                .Publications(p => p.WithQueue<OrderPlaced>(o => o.WithQueueName(UniqueName)))
+                .Subscriptions(s => s.ForQueue<OrderPlaced>(sub => sub.WithQueueName(UniqueName))))
+            .AddSingleton<CaptureContextHandler>()
+            .AddSingleton<IHandlerAsync<OrderPlaced>>(p => p.GetRequiredService<CaptureContextHandler>());
+
+        services.RemoveAll<IMessageBodySerializationFactory>();
+        services.AddJustSayingCloudEvents(options =>
+        {
+            options.Source = new Uri("https://orders.example.com");
+            options.WithCloudEventType<OrderPlaced>(OrderPlacedType);
+        });
+
+        await WhenAsync(
+            services,
+            async (publisher, listener, serviceProvider, cancellationToken) =>
+            {
+                await listener.StartAsync(cancellationToken);
+                await publisher.StartAsync(cancellationToken);
+
+                var handler = serviceProvider.GetRequiredService<CaptureContextHandler>();
+
+                // Act
+                await publisher.PublishAsync(new OrderPlaced { OrderId = "order-42" }, cancellationToken);
+
+                // Assert
+                var context = await handler.Context.WaitAsync(cancellationToken);
+
+                context.ShouldNotBeNull();
+                context.SpecVersion.ShouldBe("1.0");
+                context.Type.ShouldBe(OrderPlacedType);
+                context.Source.ShouldBe(new Uri("https://orders.example.com/"));
+                context.Id.ShouldNotBeNullOrEmpty();
+                context.Time.ShouldNotBeNull();
+                context.DataContentType.ShouldBe("application/json");
+
+                // The base context members are populated too.
+                context.QueueUri.AbsolutePath.ShouldEndWith(UniqueName);
+                context.Message.ShouldNotBeNull();
+            });
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> **Design spike — alternative to the `CloudEvent<T>` wrapper approach (#2210).** This PR exists to be contrasted with the optional-wrapper design; only one of the two shapes (or a blend) should ship. Based on `slang25/v9-cloudevents` (#2184).

## The idea

Instead of introducing a `CloudEvent<T>` envelope type that handlers opt into, treat `MessageContext` as an **extensible base type**. When a message arrives as a structured CloudEvents envelope, the pipeline builds a `CloudEventMessageContext : MessageContext` carrying the envelope's context attributes, and handlers observe it through the existing injected `IMessageContextReader` — the same way you'd reach for message attributes today. Handlers keep their plain `IHandlerAsync<T>` contract:

```csharp
public class OrderPlacedHandler(IMessageContextReader contextReader) : IHandlerAsync<OrderPlaced>
{
    public Task<bool> Handle(OrderPlaced message)
    {
        var ce = contextReader.GetCloudEventContext(); // null if the message wasn't a CloudEvent
        if (ce is not null)
        {
            // ce.Id, ce.Source, ce.Type, ce.Time, ce.Subject, ce.DataContentType,
            // ce.Extensions["traceparent"], plus the base MessageContext members.
        }

        return Task.FromResult(true);
    }
}
```

No configuration changes: any subscription already using the CloudEvents serializer gets the derived context automatically.

## How it's plumbed

The envelope is parsed exactly once. The CloudEvents serializer already parses it to extract `data`; it now also captures the context attributes and hands them forward:

- **Core** gains an optional serializer capability, `IContextProvidingMessageBodySerializer<TMessage>`: `Deserialize(string, out MessageContextFactory)`. A serializer whose wire format is an envelope returns a factory (`(rawSqsMessage, queueUri, attributes) => MessageContext`) alongside the payload.
- The factory flows `InboundMessageConverter` → `InboundMessage` → `MessageDispatcher`, which materialises the context onto a new `HandleMessageContext.MessageContext` property (default context when no factory).
- `MessageContextAccessorMiddleware` now just publishes `context.MessageContext` instead of constructing one — so custom middleware can see the typed context too.
- The capability tunnels through `ErasedMessageBodySerializer<T>` like the rest of the generic serializer surface, and composes with multi-type-per-queue discrimination (the resolved per-type serializer is what's interrogated).
- **JustSaying.CloudEvents** adds `CloudEventMessageContext` (specversion, id, source, type, time, datacontenttype, dataschema, subject, extension attributes) + a `GetCloudEventContext()` convenience for `IMessageContextReader`. A malformed envelope (missing required attributes) falls back to the base context rather than failing dispatch.

### On "make `MessageContext` abstract"

The suggestion was to make `MessageContext` an abstract base. This spike keeps it a concrete, unsealed base instead: the default (non-envelope) case still needs a plain instance, and making it abstract would force inventing a `DefaultMessageContext`/`SqsMessageContext` and breaking every existing use for no behavioural gain — derivation gives us everything the abstract shape would. Easy to flip if we prefer the stricter shape.

## Contrast with the `CloudEvent<T>` wrapper

**Where this design wins:**
- Handler signatures stay pure domain (`IHandlerAsync<OrderPlaced>`), no JustSaying.CloudEvents type in the handler contract; consumers that don't care never see CE.
- Idiomatic .NET shape (`IHttpContextAccessor`-style) and reuses a seam JustSaying already has, rather than adding a parallel channel.
- One handler serves CE and non-CE traffic on the same queue (multi-type queues mixing native + CE messages): the context is CE-typed only when the message actually was one.
- Middleware gets the typed context for free (`HandleMessageContext.MessageContext`) — auditing/tracing middleware doesn't need handler cooperation.
- The core seam is CE-agnostic: any future envelope format (e.g. binary-mode CE, other standards) plugs in the same way.

**Where the wrapper wins:**
- **Explicitness**: the dependency on envelope data is visible in the handler signature; here it's ambient and discovered by downcast.
- **Testability**: handler tests construct a `CloudEvent<T>`; here they must arrange an `IMessageContextReader`.
- **Context flow**: the accessor is `AsyncLocal`-backed — hand the message off to a background queue/fire-and-forget and the context silently doesn't follow; wrapper data travels with the value.
- **Publish-side symmetry**: the wrapper gives per-message outbound `source`/`subject`/extensions via `PublishAsync(new CloudEvent<T> { ... })`. This design is **consume-side only** — an outbound equivalent would need a separate API, which is the wrapper again in all but name.

They aren't mutually exclusive: this could ship as the zero-ceremony read path, with the wrapper remaining the opt-in for explicit envelopes and outbound metadata.

## Testing

- 4 new unit tests (`WhenProvidingTheMessageContext`): envelope attribute capture incl. extensions, own-envelope round-trip, malformed-envelope fallback, reader extension filtering.
- 1 new end-to-end test (`WhenReadingTheCloudEventMessageContext`): DI-constructed handler observes the envelope attributes via `IMessageContextReader` over the in-memory bus.
- Full suites green: 296/296 unit, 12/12 CloudEvents, 110/120 integration (10 skipped, pre-existing), 23/23 OpenTelemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
